### PR TITLE
fix: install the platform under Helm 4 via a generated postrenderer plugin, bump apsRef to the 3.2.2 curation

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -120,8 +120,9 @@ The muster chart exposes the key in values.yaml, values.schema.json, README
 and unit tests, but `templates/configmap.yaml` never renders it, so the value
 is silently dropped and Claude Code's DCR registration dies with
 "Registration requires authentication". **Verified still broken in muster
-chart 5.6.2** (latest stable as of 2026-08-27; templates are byte-identical to
-5.5.6 — only Chart.yaml differs). Neither alternative gate can work for a
+chart 5.7.1** (the BOM pin of the 3.2.2 curation, checked 2026-08-30: the
+oauth server block in `templates/configmap.yaml` renders every neighbouring
+key but not this one). Neither alternative gate can work for a
 public loopback client (no token, random port, http/https stripped from
 allowed schemes by mcp-oauth validation).
 **Unblocks:** giantswarm/muster — render the key in

--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ YAML to hand-edit and no shell to source.
 
 ## Requirements
 
-`go` (>= 1.25), `docker`, `kind` (>= 0.31), `kubectl`, `helm` (**3.x** — Helm 4
-accepts only plugin-type post-renderers, which breaks the `agentlab
-post-render` mechanism the platform install depends on; see
-[#3](https://github.com/giantswarm/agentplatform-kind/issues/3)), `git`.
+`go` (>= 1.25), `docker`, `kind` (>= 0.31), `kubectl`, `helm` (**>= 4** — Helm 3
+cannot store the umbrella chart's release any more: the dependency archives put
+the release Secret over etcd's 1 MiB cap, see
+[agent-platform-standalone#21](https://github.com/giantswarm/agent-platform-standalone/issues/21);
+Helm 4's plugin-only post-renderer contract is handled by a generated plugin,
+see below), `git`.
 
 (The old script stack also needed openssl, curl, jq and python3; the binary
 does all of that itself.)
@@ -195,7 +197,7 @@ same one-URL trick, just spelled with a name.
 | `networkPolicy.enabled: false`, `kyvernoPolicies.enabled: false` | The umbrella's own policy objects. No Cilium and no Kyverno in kind, so both would render CRs whose API groups the cluster does not serve. |
 | `valkey.valkey.metrics.podMonitor.enabled: false`, `muster…serviceMonitor.enabled: false`, `muster…prometheusRule.enabled: false` | No Prometheus Operator, so `PodMonitor` / `ServiceMonitor` / `PrometheusRule` have no CRD. |
 | `muster.rbac.{mcpServerEditor,workflowEditor}.subjects` → `oidc:platform-admins` | The umbrella binds muster's editor Roles to Giant Swarm's admin groups, which do not exist here. Rebound to the lab's own admin group (`--oidc-groups-prefix=oidc:`, same spelling as the lab RBAC). Lists replace, so the GS groups are dropped. |
-| muster patched to `hostNetwork` + `maxSurge: 0` | Same issuer trick as the apiserver and Backstage. `maxSurge: 0` because two hostNetwork pods cannot both bind `:8090` on a one-node cluster. Applied by `agentlab post-render` (`helm --post-renderer`, the binary invoking itself) — the plain-Helm replacement for the Flux `postRenderers` the meta-package forwarded to helm-controller. |
+| muster patched to `hostNetwork` + `maxSurge: 0` | Same issuer trick as the apiserver and Backstage. `maxSurge: 0` because two hostNetwork pods cannot both bind `:8090` on a one-node cluster. Applied by `agentlab post-render` — Helm 4 accepts only plugin-type post-renderers, so the install generates a `postrenderer/v1` plugin in `state/helm-plugins/` whose command is the agentlab binary itself, and passes it via `HELM_PLUGINS` + `--post-renderer agentlab-postrender`. The plain-Helm replacement for the Flux `postRenderers` the meta-package forwarded to helm-controller. |
 | `components.kagent.enabled` from `platform.agents`, `controller.auth.mode: unsecure`, kagent ServiceMonitor + OTel off | Agents are part of what the lab tests, so kagent is on by default (the umbrella defaults it off) but optional — `platform.agents: false` skips the runtime. `unsecure` because the GS `trusted-proxy` mode assumes a JWT-validating agentgateway in front; no Prometheus Operator / OTLP gateway in kind. See [Agents (kagent)](#agents-kagent). |
 | `kagent.ui.service.type: NodePort`, nodePort 30880 pinned by `agentlab post-render` | On a real MC the UI sits behind the agentgateway edge; this lab publishes it through the kind port mapping instead (host side `platform.agentsPort`, default 8081). The chart's Service template renders no `nodePort` field, so the fixed node port is a post-render patch (HACKS.md U9). |
 | The chart vendored at a pinned git SHA | Component versions are the chart's own tested BOM (`Chart.lock`); the lab no longer pins its own. The only lab-side pin is `platform.apsRef` — the chart repo commit — so two runs still install the same thing. |
@@ -209,8 +211,8 @@ same one-URL trick, just spelled with a name.
   `agentlab platform` refuses if it finds the old HelmReleases; run
   `agentlab platform-down` first (an old cluster keeps its now-idle `flux-system`,
   which is harmless).
-- **`allowPublicClientRegistration` is a no-op in the muster chart (still at
-  5.5.6).** It exists in `values.yaml`, `values.schema.json`, the README table
+- **`allowPublicClientRegistration` is a no-op in the muster chart (still
+  unrendered at 5.7.1).** It exists in `values.yaml`, `values.schema.json`, the README table
   and the chart's unit tests, but `templates/configmap.yaml` never renders it —
   so DCR stays gated and Claude Code's login dies at `/oauth/register` with
   *"Registration requires authentication"*. Neither of the other gates can help:
@@ -611,6 +613,7 @@ internal/lab/                  everything operational:
   platform.go platformtest.go    agent platform install + MCP smoke test
   backstage.go backstagetest.go  Backstage deploy + headless sign-in proof
   postrender.go                  helm post-renderer (hostNetwork, DCR fix, route strip)
+  helmplugin.go                  generates the Helm 4 postrenderer plugin wrapping it
   templates/                     every manifest, rendered from agentlab.yaml
 agentlab.yaml                    your configuration (gitignored; `agentlab configure`)
 state/                         rendered manifests, for inspection (gitignored)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,7 +154,7 @@ func Default() *Config {
 			MusterPort:           8090,
 			MCPKubernetesVersion: "1.0.9",
 			APSRepo:              "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:               "672e08cb67cb210cdcc3bb9c5d11f78a42e92003", // PR #11 head (feat/curate-generator)
+			APSRef:               "4976adeecd118e27c52fc4402cd047f73616c657", // feat/curate-generator head: curated against agent-platform 3.2.2 (PR #24), Helm-4-installable
 		},
 		Backstage: Backstage{
 			Enabled: false,

--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -38,6 +38,21 @@ func runQuiet(name string, args ...string) error {
 	return pipeInto(nil, name, args...)
 }
 
+// runQuietEnv is runQuiet with extra environment entries ("KEY=value")
+// appended to the inherited environment.
+func runQuietEnv(extraEnv []string, name string, args ...string) error {
+	var buf bytes.Buffer
+	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	if err := cmd.Run(); err != nil {
+		_, _ = os.Stderr.Write(buf.Bytes())
+		return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
 // output captures a command's stdout (stderr goes to the terminal).
 func output(name string, args ...string) (string, error) {
 	var buf bytes.Buffer

--- a/internal/lab/helmplugin.go
+++ b/internal/lab/helmplugin.go
@@ -1,0 +1,104 @@
+package lab
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// The platform install needs a Helm post-renderer (see PostRender), and Helm 4
+// changed the contract: --post-renderer no longer takes an executable path but
+// the NAME of an installed plugin of type postrenderer/v1. So agentlab
+// generates that plugin on the fly — a plugin.yaml whose command points back
+// at this very binary — into a lab-owned plugin dir, and passes it to Helm via
+// the HELM_PLUGINS environment variable. The user's real plugin dir is never
+// touched (and never consulted: HELM_PLUGINS replaces it for that one
+// invocation, which is fine — the install needs no other plugin).
+//
+// Helm 3 is not supported for the platform install at all, plugin mechanics
+// aside: Helm 3 stores the whole chart in one release Secret, and the umbrella
+// chart's dependency archives (~1.3 MiB of already-gzipped .tgz files) blow
+// etcd's 1 MiB cap — giantswarm/agent-platform-standalone#21 concluded plain
+// Helm 3 cannot install the chart, and its README documents Helm 4 as the CLI
+// install path. ensureHelmSupportsPlatform turns that into a fail-fast.
+
+// postRenderPluginName is the generated plugin's name — what plugin.yaml
+// declares and what `helm --post-renderer` is passed.
+const postRenderPluginName = "agentlab-postrender"
+
+// helmPluginsDir is the lab-owned HELM_PLUGINS directory the generated plugin
+// lands in. Under StateDir like every other generated artifact, so `helm
+// template <chart> --post-renderer agentlab-postrender` can be replayed by
+// hand with HELM_PLUGINS pointed here.
+const helmPluginsDir = StateDir + "/helm-plugins"
+
+// ensureHelmSupportsPlatform fails fast when the installed Helm cannot
+// install the platform chart (see the package comment above). Called before
+// any cluster work so a Helm 3 user is not told after a five-minute boot.
+func ensureHelmSupportsPlatform() error {
+	raw, err := outputQuiet("helm", "version", "--template", "{{.Version}}")
+	if err != nil {
+		return fmt.Errorf("probing the helm version (`helm version`): %w", err)
+	}
+	version := strings.TrimSpace(raw)
+	major, err := helmMajor(version)
+	if err != nil {
+		return err
+	}
+	if major < 4 {
+		return fmt.Errorf("helm %s cannot install the agent platform — Helm >= 4 is required:\n"+
+			"Helm 3 stores the whole chart in one release Secret, and the umbrella chart's\n"+
+			"dependency archives put that Secret over etcd's 1 MiB cap\n"+
+			"(giantswarm/agent-platform-standalone#21)", version)
+	}
+	return nil
+}
+
+// helmMajor extracts the major version from `helm version --template
+// {{.Version}}` output ("v4.2.2").
+func helmMajor(version string) (int, error) {
+	majorStr, _, _ := strings.Cut(strings.TrimPrefix(version, "v"), ".")
+	major, err := strconv.Atoi(majorStr)
+	if err != nil {
+		return 0, fmt.Errorf("unparseable helm version %q", version)
+	}
+	return major, nil
+}
+
+// ensurePostRenderPlugin (re)writes the generated postrenderer plugin and
+// returns the absolute HELM_PLUGINS path to run Helm with. Rewritten on every
+// install: the binary's own path is baked in, and a rebuilt or moved agentlab
+// must not leave the plugin pointing at a stale executable.
+func ensurePostRenderPlugin() (string, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	pluginDir := filepath.Join(helmPluginsDir, postRenderPluginName)
+	if err := os.MkdirAll(pluginDir, 0o750); err != nil {
+		return "", err
+	}
+	// %q on the command path: YAML's double-quoted style shares Go's \\ and \"
+	// escapes, so Windows paths survive. Helm splits the command on SPACES
+	// before quoting is even considered (its documented plugin contract), so a
+	// binary living under a path with spaces cannot work here — Helm's
+	// limitation, not this file's.
+	manifest := fmt.Sprintf(`apiVersion: v1
+name: %s
+type: postrenderer/v1
+runtime: subprocess
+version: 0.1.0
+runtimeConfig:
+  platformCommand:
+    - command: %q
+      args: ["post-render"]
+`, postRenderPluginName, self)
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.yaml"), []byte(manifest), 0o600); err != nil {
+		return "", err
+	}
+	// Absolute: Helm resolves HELM_PLUGINS itself, from its own idea of the
+	// working directory.
+	return filepath.Abs(helmPluginsDir)
+}

--- a/internal/lab/helmplugin_test.go
+++ b/internal/lab/helmplugin_test.go
@@ -1,0 +1,110 @@
+package lab
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestHelmMajor(t *testing.T) {
+	cases := []struct {
+		version string
+		want    int
+		wantErr bool
+	}{
+		{"v4.2.2", 4, false},
+		{"v3.19.0", 3, false},
+		{"v4.0.0-rc.1", 4, false},
+		{"4.2.2", 4, false}, // defensive: no leading v
+		{"", 0, true},
+		{"garbage", 0, true},
+	}
+	for _, c := range cases {
+		got, err := helmMajor(c.version)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("helmMajor(%q): expected error, got %d", c.version, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("helmMajor(%q): %v", c.version, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("helmMajor(%q) = %d, want %d", c.version, got, c.want)
+		}
+	}
+}
+
+// TestEnsurePostRenderPlugin proves the generated plugin.yaml is what Helm 4's
+// v1 plugin loader requires: apiVersion v1, a semver version, subprocess
+// runtime, postrenderer/v1 type, and a platformCommand pointing at this
+// process's own executable with the post-render arg baked in (extra
+// --post-renderer-args would be env-expanded by Helm, so nothing may rely on
+// them).
+func TestEnsurePostRenderPlugin(t *testing.T) {
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	pluginsDir, err := ensurePostRenderPlugin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(pluginsDir) {
+		t.Errorf("HELM_PLUGINS path must be absolute, got %q", pluginsDir)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(pluginsDir, postRenderPluginName, "plugin.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest struct {
+		APIVersion    string `yaml:"apiVersion"`
+		Name          string `yaml:"name"`
+		Type          string `yaml:"type"`
+		Runtime       string `yaml:"runtime"`
+		Version       string `yaml:"version"`
+		RuntimeConfig struct {
+			PlatformCommand []struct {
+				Command string   `yaml:"command"`
+				Args    []string `yaml:"args"`
+			} `yaml:"platformCommand"`
+		} `yaml:"runtimeConfig"`
+	}
+	if err := yaml.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("generated plugin.yaml does not parse: %v\n%s", err, raw)
+	}
+	if manifest.APIVersion != "v1" || manifest.Type != "postrenderer/v1" || manifest.Runtime != "subprocess" {
+		t.Errorf("wrong plugin envelope: %+v", manifest)
+	}
+	if manifest.Name != postRenderPluginName {
+		t.Errorf("plugin name %q does not match the --post-renderer argument %q", manifest.Name, postRenderPluginName)
+	}
+	if manifest.Version == "" {
+		t.Error("plugin version is required (Helm validates semver)")
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(manifest.RuntimeConfig.PlatformCommand) != 1 {
+		t.Fatalf("expected exactly one platformCommand, got %+v", manifest.RuntimeConfig.PlatformCommand)
+	}
+	cmd := manifest.RuntimeConfig.PlatformCommand[0]
+	if cmd.Command != self {
+		t.Errorf("plugin command %q is not this executable %q", cmd.Command, self)
+	}
+	if len(cmd.Args) != 1 || cmd.Args[0] != "post-render" {
+		t.Errorf("plugin args %v, want [post-render]", cmd.Args)
+	}
+}

--- a/internal/lab/helmplugin_test.go
+++ b/internal/lab/helmplugin_test.go
@@ -64,7 +64,7 @@ func TestEnsurePostRenderPlugin(t *testing.T) {
 		t.Errorf("HELM_PLUGINS path must be absolute, got %q", pluginsDir)
 	}
 
-	raw, err := os.ReadFile(filepath.Join(pluginsDir, postRenderPluginName, "plugin.yaml"))
+	raw, err := os.ReadFile(filepath.Join(pluginsDir, postRenderPluginName, "plugin.yaml")) // #nosec G304 -- reads back the file this test just generated under t.TempDir
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -77,6 +77,23 @@ func ensurePlatformChart(cfg *config.Config) error {
 		return err
 	}
 
+	// A `helm dependency build` killed mid-flight (this very function runs in
+	// a goroutine that dies with a failed boot) leaves a tmpcharts-<pid>/ dir
+	// inside the chart. Helm's directory loader embeds every file .helmignore
+	// does not exclude into the release record, so that corpse of raw .tgz
+	// archives silently doubles the payload and the install dies with
+	// `Secret "sh.helm.release.v1...." is invalid: data: Too long`. Sweep
+	// unconditionally: the corpse can outlive the digest-match fast path below.
+	stale, err := filepath.Glob(filepath.Join(chartDir, "tmpcharts-*"))
+	if err != nil {
+		return err
+	}
+	for _, dir := range stale {
+		if err := os.RemoveAll(dir); err != nil {
+			return err
+		}
+	}
+
 	// Subchart .tgz pulls from gsoci/ghcr (anonymous). Skipped when charts/
 	// was last built from exactly this Chart.lock — compared by content digest,
 	// not mtime: mtimes change on checkout and prove nothing about the last

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -101,6 +101,12 @@ func ensurePlatformChart(cfg *config.Config) error {
 func platformUp(cfg *config.Config, chartReady <-chan error) error {
 	chartDir := filepath.Join(apsDir, "helm", "agent-platform-standalone")
 
+	// Also checked at the very top of `agentlab up`; repeated here for the
+	// standalone `agentlab platform` entry point.
+	if err := ensureHelmSupportsPlatform(); err != nil {
+		return err
+	}
+
 	// A cluster still running the old meta-package has Flux HelmReleases under
 	// the same Helm release name; upgrading across that boundary races
 	// helm-controller uninstalls against this install. Start clean instead.
@@ -172,15 +178,18 @@ func platformUp(cfg *config.Config, chartReady <-chan error) error {
 	// workloads now. The MCPServer/Workflow CRDs ship in the muster subchart's
 	// crds/ dir, which Helm applies before the manifests on first install.
 	// The post-renderer is this very binary (see PostRender): hostNetwork,
-	// the DCR chart-bug workaround, HTTPRoute strip.
-	self, err := os.Executable()
+	// the DCR chart-bug workaround, HTTPRoute strip, kagent-ui nodePort pin.
+	// Helm 4 accepts only plugin-type post-renderers, so the binary is wrapped
+	// in a generated plugin (see helmplugin.go) that HELM_PLUGINS points at.
+	pluginsDir, err := ensurePostRenderPlugin()
 	if err != nil {
 		return err
 	}
-	if err := runQuiet("helm", "upgrade", "--install", "agent-platform", chartDir,
+	if err := runQuietEnv([]string{"HELM_PLUGINS=" + pluginsDir},
+		"helm", "upgrade", "--install", "agent-platform", chartDir,
 		"-n", platformNamespace,
 		"-f", StateDir+"/agent-platform-values.yaml",
-		"--post-renderer", self, "--post-renderer-args", "post-render",
+		"--post-renderer", postRenderPluginName,
 		"--wait", "--timeout", "10m"); err != nil {
 		return err
 	}

--- a/internal/lab/postrender.go
+++ b/internal/lab/postrender.go
@@ -15,8 +15,10 @@ import (
 // install (stdin: the full rendered release, stdout: the same with three
 // muster patches). Plain Helm has no values hook for any of these, so they
 // live here — the replacement for the Flux postRenderers the old
-// agent-platform meta-package forwarded to helm-controller. Wired up as
-// `helm --post-renderer <agentlab> --post-renderer-args post-render`.
+// agent-platform meta-package forwarded to helm-controller. Wired up through
+// a generated postrenderer/v1 plugin whose command is this very binary with
+// the `post-render` arg (Helm 4 accepts only plugin-type post-renderers; see
+// helmplugin.go).
 //
 //  1. hostNetwork + dnsPolicy on the muster Deployment: muster must resolve
 //     the issuer URL to the Dex NodePort from inside the pod so it can share
@@ -27,8 +29,9 @@ import (
 //     new pod cannot start until the old one releases the port. Old pod goes
 //     down first.
 //
-//  3. allowPublicClientRegistration: WORKAROUND (muster chart <= 5.5.6). The
-//     chart exposes the key in values.yaml, values.schema.json and its README,
+//  3. allowPublicClientRegistration: WORKAROUND (muster chart <= 5.7.1, still
+//     unrendered as of the 3.2.2 curation). The chart exposes the key in
+//     values.yaml, values.schema.json and its README,
 //     but templates/configmap.yaml never renders it, so the value is silently
 //     dropped and Dynamic Client Registration stays gated. Claude Code
 //     registers as a PUBLIC client on a random loopback port, so neither

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -15,9 +15,10 @@
 #     the Dex NodePort from inside the pod, exactly the trick the
 #     kube-apiserver static pod and the Backstage deployment already use. This
 #     is what lets muster share ONE issuer URL with the browser on the host.
-#     Not a chart value; patched in by `agentlab post-render` (helm
-#     --post-renderer), the plain-Helm replacement for the Flux postRenderers
-#     the old agent-platform meta-package forwarded to helm-controller.
+#     Not a chart value; patched in by `agentlab post-render` (a generated
+#     Helm 4 postrenderer plugin backed by the agentlab binary itself), the
+#     plain-Helm replacement for the Flux postRenderers the old agent-platform
+#     meta-package forwarded to helm-controller.
 # ---------------------------------------------------------------------------
 
 components:
@@ -50,12 +51,10 @@ ingress:
     - name: no-gateway-in-this-lab
       namespace: agent-platform
 
-# The umbrella's own policy objects. No Cilium and no Kyverno in kind, so both
-# would render CRs whose API groups the cluster does not serve.
-networkPolicy:
-  enabled: false
-kyvernoPolicies:
-  enabled: false
+# The umbrella's own policy objects (network policy lives under
+# global.networkPolicy since the vanilla-defaults rework; a top-level
+# networkPolicy key now fails the strict schema). Both are off in the chart's
+# vanilla defaults — nothing to override.
 
 muster:
   networkPolicy:
@@ -117,12 +116,13 @@ muster:
           allowPrivateIPOIDC: true
         existingSecret: agent-platform-secrets
         # Lab only: lets Claude Code register itself over DCR without a
-        # pre-shared registration token. WORKAROUND (muster chart <= 5.5.6):
-        # the chart exposes this key in values.yaml, values.schema.json and its
-        # README, but templates/configmap.yaml never renders it — so the value
-        # set here is silently dropped. `agentlab post-render` re-adds it to the
-        # rendered config; this entry stays so the values file tells the truth
-        # and the workaround can be deleted once the chart renders it.
+        # pre-shared registration token. WORKAROUND (muster chart <= 5.7.1,
+        # still unrendered): the chart exposes this key in values.yaml,
+        # values.schema.json and its README, but templates/configmap.yaml never
+        # renders it — so the value set here is silently dropped. `agentlab
+        # post-render` re-adds it to the rendered config; this entry stays so
+        # the values file tells the truth and the workaround can be deleted
+        # once the chart renders it.
         allowPublicClientRegistration: true
         # Lab only: accept a Dex id_token with aud=muster as a bearer token, so
         # the stack can be smoke-tested headlessly with the password grant.

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -14,6 +14,15 @@ import (
 // OIDC verification, and then the components the configuration enables — the
 // agent platform (the default; it is what the lab tests) and Backstage.
 func Up(cfg *config.Config) error {
+	// Fail on Helm 3 before any real work: the platform install at the end of
+	// this boot needs Helm 4 (see ensureHelmSupportsPlatform), and finding
+	// that out after a five-minute cluster boot is the wrong moment.
+	if cfg.Platform.Enabled {
+		if err := ensureHelmSupportsPlatform(); err != nil {
+			return err
+		}
+	}
+
 	if err := GenCerts(false); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #3.

## What

- **Helm 4 post-renderer.** Helm 4 removed exec-path post-renderers: `--post-renderer` now names an installed plugin of type `postrenderer/v1`. `agentlab platform` generates that plugin on the fly — `state/helm-plugins/agentlab-postrender/plugin.yaml`, whose `platformCommand` is the agentlab binary itself with the `post-render` arg baked in — and runs the install with `HELM_PLUGINS` pointed at it. The user's real plugin dir is never touched. The arg lives in plugin.yaml rather than `--post-renderer-args` because Helm env-expands extra args (a literal `$` would be eaten).
- **Helm >= 4 preflight, deviating from the issue's keep-both proposal on purpose.** The issue suggested keeping the exec flag for Helm 3, but giantswarm/agent-platform-standalone#21 has since settled that Helm 3 cannot store the chart's release at all (dependency archives > etcd's 1 MiB Secret cap), so a Helm 3 branch would be dead code that fails after minutes with a cryptic storage error. `agentlab up` and `agentlab platform` now say so up front instead.
- **apsRef 672e08cb → 4976adee** — the `feat/curate-generator` head curated against agent-platform 3.2.2, carrying the AgentgatewayParameters SSA fix (giantswarm/agent-platform#250) Helm 4 hard-failed on. The values template drops the top-level `networkPolicy`/`kyvernoPolicies` block the vanilla-defaults rework made schema-illegal (both off in the chart's vanilla defaults anyway).
- **Stale `tmpcharts-*` sweep.** A `helm dependency build` killed mid-flight (the vendor step runs in a goroutine that dies with a failed boot) leaves a `tmpcharts-<pid>/` corpse inside the chart; Helm's dir loader embeds it into the release record, doubling the payload and reproducing the 1 MiB Secret error *on Helm 4*. Found the hard way during verification; swept unconditionally now.
- **DCR workaround checked, kept.** Per the issue's follow-up note: muster 5.7.1 (the new BOM pin) still does not render `allowPublicClientRegistration` (`templates/configmap.yaml` renders every neighbouring key but not this one), so the post-render edit stays; comments and HACKS.md U1 now say 5.7.1.

## Verification (kind v0.32.0, Helm v4.2.2, the exact pair the issue reports broken)

- `go build`, `go test ./...`, `golangci-lint run` (0 issues) — plus new unit tests for the plugin manifest and version parse.
- `agentlab up` green end to end on a fresh cluster: chart vendored @ 4976adee, schema passes, Helm 4 installs through the generated plugin, all four post-render patches verified in the rendered release (hostNetwork+maxSurge, DCR key, HTTPRoute stripped, kagent-ui nodePort pinned), MCPServer `Connected`, muster serves and validates a fresh Dex token, kagent UI up.
- `agentlab platform-test`: PASS (Dex password grant → muster `/mcp` → `x_kubernetes_list` → apiserver).
- `agentlab test`: 10/10 RBAC assertions.

Note for first boots on a cold image cache: the new BOM's kagent (with its postgresql) can crashloop past the install's 10m `--wait` while images pull; a second `agentlab up` completes. Pre-existing behavior (the preload cache prevents it on every later boot), left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)