### PR TITLE
fix: give the Dex rollout wait room for a cold image pull

### DIFF
--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -176,7 +176,10 @@ func ApplyDex(cfg *config.Config) error {
 		return err
 	}
 	step("Waiting for Dex to become ready")
-	return run("kubectl", "-n", componentDex, "rollout", "status", "deployment/dex", "--timeout=120s")
+	// 420s, not 120s: on a fresh kind node the Dex image is a cold pull from
+	// ghcr.io and regularly outlasts two minutes; the rollout itself is
+	// seconds once the image is local.
+	return run("kubectl", "-n", componentDex, "rollout", "status", "deployment/dex", "--timeout=420s")
 }
 
 func kindClusterExists(name string) bool {


### PR DESCRIPTION
Three consecutive fresh `agentlab up` runs on a machine with ordinary bandwidth died at *Waiting for Dex to become ready* — the pod was still `ContainerCreating`, mid-pull of `ghcr.io/dexidp/dex:v2.45.1`, when the 120s `rollout status` wait expired. Each time a plain re-run succeeded once the pull had finished in the background.

Bump the wait to 420s. Once the image is local the rollout takes seconds, so the longer ceiling costs nothing on the happy path; on a cold node it turns a guaranteed first-run failure into a one-time slower boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)