### PR TITLE
fix: retire the DCR post-render patch, bump apsRef to the muster-5.7.2 curation

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -115,20 +115,17 @@ failed with "inconsistent vendoring".
 
 ## Blocked upstream (documented, not fixable in this repo)
 
-### U1. `muster-post-render.sh` patch: `allowPublicClientRegistration` edited into the rendered ConfigMap
-The muster chart exposes the key in values.yaml, values.schema.json, README
-and unit tests, but `templates/configmap.yaml` never renders it, so the value
-is silently dropped and Claude Code's DCR registration dies with
-"Registration requires authentication". **Verified still broken in muster
-chart 5.7.1** (the BOM pin of the 3.2.2 curation, checked 2026-08-30: the
-oauth server block in `templates/configmap.yaml` renders every neighbouring
-key but not this one). Neither alternative gate can work for a
-public loopback client (no token, random port, http/https stripped from
-allowed schemes by mcp-oauth validation).
-**Unblocks:** giantswarm/muster — render the key in
-`helm/muster/templates/configmap.yaml` (`aggregator.oauth.server.allowPublicClientRegistration`).
-The values entry in `manifests/agent-platform/values.yaml` is kept so the
-values file tells the truth; delete the yq patch once the chart renders it.
+### U1. `muster-post-render.sh` patch: `allowPublicClientRegistration` edited into the rendered ConfigMap — FIXED upstream
+The muster chart exposed the key in values.yaml, values.schema.json, README
+and unit tests, but `templates/configmap.yaml` never rendered it, so the value
+was silently dropped and Claude Code's DCR registration died with
+"Registration requires authentication". Neither alternative gate can work for
+a public loopback client (no token, random port, http/https stripped from
+allowed schemes by mcp-oauth validation), so the key was edited into the
+rendered ConfigMap by the post-renderer.
+**Fixed:** muster 5.7.2 (giantswarm/muster#1118) renders the key; the chart
+BOM carries it since the curation that pinned muster 5.7.2. The post-render
+ConfigMap edit is deleted — the values entry alone is effective now.
 
 ### U2. `muster-post-render.sh` patch: hostNetwork + dnsPolicy + maxSurge 0 on the muster Deployment
 muster must resolve `https://localhost:32000/dex` to the Dex NodePort from

--- a/README.md
+++ b/README.md
@@ -211,18 +211,15 @@ same one-URL trick, just spelled with a name.
   `agentlab platform` refuses if it finds the old HelmReleases; run
   `agentlab platform-down` first (an old cluster keeps its now-idle `flux-system`,
   which is harmless).
-- **`allowPublicClientRegistration` is a no-op in the muster chart (still
-  unrendered at 5.7.1).** It exists in `values.yaml`, `values.schema.json`, the README table
-  and the chart's unit tests, but `templates/configmap.yaml` never renders it —
-  so DCR stays gated and Claude Code's login dies at `/oauth/register` with
-  *"Registration requires authentication"*. Neither of the other gates can help:
-  Claude Code cannot send a registration token, its loopback port is random (so
-  `trustedPublicRegistrationRedirectURIs` cannot match), and `http`/`https` are
-  deliberately stripped from `trustedPublicRegistrationSchemes` by mcp-oauth's
-  config validation. `agentlab post-render` works around it by editing the key
-  into the rendered config — surgically, so everything else in the ConfigMap
-  stays chart-rendered and muster bumps via the chart need no hand-copying (the
-  old meta-package setup froze the whole ConfigMap and had to pin muster for it).
+- **`allowPublicClientRegistration` must be on for Claude Code's login.**
+  Claude Code registers over DCR as a public client on a random loopback port,
+  so none of the other registration gates can be opened for it: it cannot send
+  a registration token, `trustedPublicRegistrationRedirectURIs` cannot match a
+  random port, and `http`/`https` are deliberately stripped from
+  `trustedPublicRegistrationSchemes` by mcp-oauth's config validation. The
+  muster chart renders the key since 5.7.2 (muster#1118); before that,
+  `agentlab post-render` had to edit it into the rendered ConfigMap
+  (HACKS.md U1, now fixed upstream).
 - **A `Recreate` strategy cannot be patched onto an existing Deployment.** The API
   server has already defaulted `spec.strategy.rollingUpdate`, and a patch that
   flips the type without also deleting that field fails with
@@ -612,7 +609,7 @@ internal/lab/                  everything operational:
   login.go browser.go            password grant / authorization-code flow
   platform.go platformtest.go    agent platform install + MCP smoke test
   backstage.go backstagetest.go  Backstage deploy + headless sign-in proof
-  postrender.go                  helm post-renderer (hostNetwork, DCR fix, route strip)
+  postrender.go                  helm post-renderer (hostNetwork, route strip, nodePort pin)
   helmplugin.go                  generates the Helm 4 postrenderer plugin wrapping it
   templates/                     every manifest, rendered from agentlab.yaml
 agentlab.yaml                    your configuration (gitignored; `agentlab configure`)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,7 +154,7 @@ func Default() *Config {
 			MusterPort:           8090,
 			MCPKubernetesVersion: "1.0.9",
 			APSRepo:              "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:               "4976adeecd118e27c52fc4402cd047f73616c657", // feat/curate-generator head: curated against agent-platform 3.2.2 (PR #24), Helm-4-installable
+			APSRef:               "07019de9707ebe098def6700fa4a916ce5e08728", // feat/curate-generator head: 3.2.2 curation, muster 5.7.2 (native DCR toggle), Renovate-owned pins
 		},
 		Backstage: Backstage{
 			Enabled: false,

--- a/internal/lab/postrender.go
+++ b/internal/lab/postrender.go
@@ -1,7 +1,6 @@
 package lab
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -12,13 +11,17 @@ import (
 )
 
 // PostRender is the Helm post-renderer for the agent-platform-standalone
-// install (stdin: the full rendered release, stdout: the same with three
-// muster patches). Plain Helm has no values hook for any of these, so they
-// live here — the replacement for the Flux postRenderers the old
+// install (stdin: the full rendered release, stdout: the same with the muster
+// and kagent-ui patches). Plain Helm has no values hook for any of these, so
+// they live here — the replacement for the Flux postRenderers the old
 // agent-platform meta-package forwarded to helm-controller. Wired up through
 // a generated postrenderer/v1 plugin whose command is this very binary with
 // the `post-render` arg (Helm 4 accepts only plugin-type post-renderers; see
 // helmplugin.go).
+//
+// (The allowPublicClientRegistration ConfigMap edit that used to live here is
+// gone: the muster chart renders the key itself since 5.7.2, muster#1118 —
+// the value in agent-platform-values.yaml.tmpl is enough now.)
 //
 //  1. hostNetwork + dnsPolicy on the muster Deployment: muster must resolve
 //     the issuer URL to the Dex NodePort from inside the pod so it can share
@@ -29,27 +32,13 @@ import (
 //     new pod cannot start until the old one releases the port. Old pod goes
 //     down first.
 //
-//  3. allowPublicClientRegistration: WORKAROUND (muster chart <= 5.7.1, still
-//     unrendered as of the 3.2.2 curation). The chart exposes the key in
-//     values.yaml, values.schema.json and its README,
-//     but templates/configmap.yaml never renders it, so the value is silently
-//     dropped and Dynamic Client Registration stays gated. Claude Code
-//     registers as a PUBLIC client on a random loopback port, so neither
-//     `registrationToken` (it cannot send one),
-//     `trustedPublicRegistrationRedirectURIs` (the port is random) nor
-//     `trustedPublicRegistrationSchemes` (http/https are stripped by
-//     mcp-oauth's config validation on purpose) can gate it open. The key is
-//     edited into the rendered config surgically — everything else in the
-//     ConfigMap stays chart-rendered, so muster bumps via the chart need no
-//     hand-copying here. Delete this patch once the chart renders the key.
-//
-//  4. Drop the muster HTTPRoute. The chart hard-fails on empty
+//  3. Drop the muster HTTPRoute. The chart hard-fails on empty
 //     ingress.parentRefs in ALL modes (it assumes a public Gateway even for
 //     muster-direct), so the values carry a placeholder parentRef and the
 //     rendered route is stripped here: this lab has no Gateway, no Gateway API
 //     CRDs, and reaches muster through hostNetwork + the kind port mapping.
 //
-//  5. A fixed nodePort on the kagent-ui Service: the values set
+//  4. A fixed nodePort on the kagent-ui Service: the values set
 //     `ui.service.type: NodePort` (a chart value), but the chart's ui-service
 //     template renders no `nodePort` field, so Kubernetes would pick a random
 //     one — useless to kind's fixed extraPortMappings. Pinned to
@@ -81,11 +70,6 @@ func PostRender(in io.Reader, out io.Writer) error {
 		}
 		if kind == "Deployment" && name == componentMuster {
 			patchMusterDeployment(root)
-		}
-		if kind == "ConfigMap" && name == "muster-config" {
-			if err := patchMusterConfig(root); err != nil {
-				return err
-			}
 		}
 		if kind == "Service" && name == "kagent-ui" {
 			patchKagentUIService(root)
@@ -123,41 +107,6 @@ func patchKagentUIService(root *yaml.Node) {
 			setKey(p, "nodePort", intNode(config.KagentUINodePort))
 		}
 	}
-}
-
-func patchMusterConfig(root *yaml.Node) error {
-	data := mapValue(root, "data")
-	if data == nil {
-		return fmt.Errorf("muster-config ConfigMap has no data")
-	}
-	cfgNode := mapValue(data, "config.yaml")
-	if cfgNode == nil {
-		return fmt.Errorf("muster-config ConfigMap has no config.yaml")
-	}
-	// Decode the nested config as a node tree too, so key order and the rest
-	// of the chart-rendered content survive byte-for-byte in structure.
-	var inner yaml.Node
-	if err := yaml.Unmarshal([]byte(cfgNode.Value), &inner); err != nil {
-		return fmt.Errorf("parsing muster config.yaml: %w", err)
-	}
-	innerRoot := docRoot(&inner)
-	if innerRoot == nil {
-		return fmt.Errorf("muster config.yaml is empty")
-	}
-	server := ensureMap(ensureMap(ensureMap(innerRoot, "aggregator"), "oauth"), "server")
-	setKey(server, "allowPublicClientRegistration", boolNode(true))
-
-	var buf bytes.Buffer
-	ienc := yaml.NewEncoder(&buf)
-	ienc.SetIndent(2)
-	if err := ienc.Encode(&inner); err != nil {
-		return err
-	}
-	_ = ienc.Close()
-
-	cfgNode.SetString(buf.String())
-	cfgNode.Style = yaml.LiteralStyle
-	return nil
 }
 
 // --- yaml.Node plumbing -----------------------------------------------------

--- a/internal/lab/postrender_test.go
+++ b/internal/lab/postrender_test.go
@@ -92,8 +92,9 @@ func TestPostRender(t *testing.T) {
 		t.Errorf("unrelated document dropped")
 	}
 
-	// The ConfigMap's nested config must gain exactly the DCR key and keep
-	// everything else.
+	// The muster ConfigMap passes through UNTOUCHED: the chart renders
+	// allowPublicClientRegistration itself since muster 5.7.2 (muster#1118),
+	// so the retired DCR edit must not sneak back in.
 	var docs []map[string]any
 	dec := yaml.NewDecoder(strings.NewReader(rendered))
 	for {
@@ -132,11 +133,11 @@ func TestPostRender(t *testing.T) {
 			t.Fatalf("inner config unparsable: %v", err)
 		}
 		server := cfg["aggregator"].(map[string]any)["oauth"].(map[string]any)["server"].(map[string]any)
-		if server["allowPublicClientRegistration"] != true {
-			t.Errorf("allowPublicClientRegistration not set: %v", server)
+		if _, edited := server["allowPublicClientRegistration"]; edited {
+			t.Errorf("retired DCR edit resurfaced in the rendered config: %v", server)
 		}
 		if server["enabled"] != true {
-			t.Errorf("existing server keys lost: %v", server)
+			t.Errorf("chart-rendered server keys lost: %v", server)
 		}
 		if cfg["other"].(map[string]any)["keep"] != "value" {
 			t.Errorf("unrelated config lost: %v", cfg["other"])

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -116,13 +116,10 @@ muster:
           allowPrivateIPOIDC: true
         existingSecret: agent-platform-secrets
         # Lab only: lets Claude Code register itself over DCR without a
-        # pre-shared registration token. WORKAROUND (muster chart <= 5.7.1,
-        # still unrendered): the chart exposes this key in values.yaml,
-        # values.schema.json and its README, but templates/configmap.yaml never
-        # renders it — so the value set here is silently dropped. `agentlab
-        # post-render` re-adds it to the rendered config; this entry stays so
-        # the values file tells the truth and the workaround can be deleted
-        # once the chart renders it.
+        # pre-shared registration token (its loopback port is random, so no
+        # other registration gate can be opened for it). Rendered by the
+        # muster chart since 5.7.2 (muster#1118) — the post-render edit that
+        # used to force this key into the ConfigMap is retired.
         allowPublicClientRegistration: true
         # Lab only: accept a Dex id_token with aud=muster as a bearer token, so
         # the stack can be smoke-tested headlessly with the password grant.


### PR DESCRIPTION
The muster chart renders `allowPublicClientRegistration` itself since 5.7.2 ([muster#1118](https://github.com/giantswarm/muster/pull/1118)), so the post-renderer's surgical ConfigMap edit — the workaround for the value being silently dropped — is deleted; the entry in `agent-platform-values.yaml.tmpl` alone is effective now. The post-render test asserts the muster ConfigMap passes through untouched, so the retired edit cannot sneak back.

`platform.apsRef` moves to `07019de9707e` — the `feat/curate-generator` head whose BOM pins muster 5.7.2 (agent-platform-standalone#25), and where [Renovate owns the pins](https://github.com/giantswarm/agent-platform-standalone/pull/26) going forward. HACKS.md U1 flips to FIXED upstream; README follows.

## Verification (fresh kind v0.32.0 cluster, Helm v4.2.2, vendored at exactly this pin)

- `agentlab up` and `agentlab platform` green (vendor log shows `@ 07019de9707e`).
- `agentlab platform-test`: PASS (Dex → muster → mcp-kubernetes → apiserver).
- `agentlab test`: 10/10 RBAC assertions.
- The deployed `muster-config` ConfigMap carries the **chart-rendered** `allowPublicClientRegistration: true` (no post-render involved any more).
- Unauthenticated `POST /oauth/register` → **HTTP 201** with a public client registration — Claude Code's DCR path, now native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)