### PR TITLE
fix: always pull images on the host and side-load them into the node

### DIFF
--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -40,6 +40,11 @@ const apsDir = ".vendor/agent-platform-standalone"
 // it is vendored from git at a pinned SHA and installed from the local path.
 // Once released: swap the vendor step for the OCI ref.
 func PlatformUp(cfg *config.Config) error {
+	// The standalone entry point skips Up's overlapped preload, so join a
+	// synchronous one here: on a live cluster the node filter makes it a
+	// no-op, and after a half-failed boot it heals the missing side-loads
+	// before the installs start their rollout waits.
+	reportPreload(loadLabImages(cfg, pullLabImages(cfg)))
 	return platformUp(cfg, nil)
 }
 
@@ -176,6 +181,26 @@ func platformUp(cfg *config.Config, chartReady <-chan error) error {
 	}
 	if _, _, err := renderManifest(cfg, "demo-workflow.yaml.tmpl"); err != nil {
 		return err
+	}
+
+	// Every platform image goes host cache -> node, never kubelet -> network:
+	// the host cache survives `agentlab down`, so even when this very boot
+	// fails later, the next one starts from warm images. Derived from the
+	// charts (not the snapshot manifest) so a first boot and version bumps
+	// are covered too. Best-effort: anything this misses is pulled in-node
+	// under the helm --wait timeouts, exactly as before.
+	step("Side-loading the platform images (the host cache survives `agentlab down`)")
+	if imgs, err := platformImages(cfg, chartDir); err != nil {
+		note("cannot derive the platform images from the charts (%v); the node pulls anything missing", err)
+	} else {
+		switch res := sideloadImages(cfg, hostPullImages(imgs)); {
+		case res.err != nil:
+			note("side-loading failed (%v); the node pulls anything missing", res.err)
+		case res.n > 0:
+			note("side-loaded %d of %d platform images (%s)", res.n, len(imgs), res.d)
+		default:
+			note("all %d platform images are already on the node", len(imgs))
+		}
 	}
 
 	step("Deploying mcp-kubernetes (%s)", cfg.Platform.MCPKubernetesVersion)
@@ -322,6 +347,32 @@ Platform is up.
 	// boot side-loads instead of pulling.
 	snapshotPreloadImages(cfg)
 	return nil
+}
+
+// platformImages derives the platform's image refs from the charts exactly
+// as they are about to be installed: helm-template the vendored umbrella
+// chart and the mcp-kubernetes chart with the rendered lab values, then
+// scrape the image fields. The runtime-composed images this cannot see (the
+// ADK runtime tags kagent builds from its ConfigMap) are covered by
+// healADKImages and the snapshot manifest.
+func platformImages(cfg *config.Config, chartDir string) ([]string, error) {
+	umbrella, err := outputQuiet("helm", "template", "agent-platform", chartDir,
+		"-n", platformNamespace, "-f", StateDir+"/agent-platform-values.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("templating agent-platform-standalone: %w", err)
+	}
+	mcp, err := outputQuiet("helm", "template", "mcp-kubernetes",
+		"oci://gsoci.azurecr.io/charts/giantswarm/mcp-kubernetes",
+		"--version", cfg.Platform.MCPKubernetesVersion,
+		"-n", platformNamespace, "-f", StateDir+"/mcp-kubernetes-values.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("templating mcp-kubernetes: %w", err)
+	}
+	imgs := scrapeImages(umbrella + "\n" + mcp)
+	if len(imgs) == 0 {
+		return nil, fmt.Errorf("no image fields found in the rendered charts")
+	}
+	return imgs, nil
 }
 
 // ensureMusterValidatesTokens proves the auth path end to end (Dex password

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -13,93 +14,159 @@ import (
 	"agentlab/internal/config"
 )
 
+// The lab's image rule: images are ALWAYS pulled on the HOST and side-loaded
+// into the node, never pulled by the kubelet. The host docker cache survives
+// `agentlab down`; the node's containerd dies with it. An in-node pull is
+// therefore paid again on every boot — and worse, a pull the kubelet started
+// never adopts a concurrently side-loaded image, so in-node pulls also race
+// every rollout timeout on a slow network. Three lanes feed the node:
+//
+//   - the Dex image (pullDexImage/sideloadDexImage): known from config,
+//     side-loaded synchronously before the Dex Deployment lands;
+//   - the snapshot manifest (pullLabImages/loadLabImages): everything the
+//     last successful boot ran, loaded in the background while Dex and the
+//     OIDC verification run, joined before the platform install;
+//   - the chart-derived set (platformImages in platform.go): what the charts
+//     about to be installed actually reference, so even a FIRST boot (no
+//     manifest yet) pulls on the host.
+//
+// A failed host pull or side-load is never fatal: the affected image just
+// degrades to the in-node pull it would have been anyway.
+
 // preloadImagesFile is the self-maintaining image cache manifest: after a
-// successful boot the node's workload images are snapshotted here, and the
-// next boot pulls them on the HOST (whose docker cache survives `agentlab
-// down`) and side-loads them into the fresh node. `down` deletes the node and
-// with it every image, so without this every boot re-pulls the whole platform
-// from the network.
+// successful boot the node's workload images are snapshotted here. It backs
+// the manifest lane and catches images the chart render cannot see (e.g. the
+// ADK runtime images kagent composes at run time).
 const preloadImagesFile = StateDir + "/preload-images.txt"
 
 // infraImagePrefixes are baked into the kindest/node image already — nothing
 // to preload, so the snapshot skips them.
 var infraImagePrefixes = []string{"registry.k8s.io/", "docker.io/kindest/"}
 
-// preloadResult is what the load stage reports back to Up.
+// preloadResult is what a side-load reports back.
 type preloadResult struct {
 	n   int // images actually side-loaded into the node
 	d   time.Duration
 	err error
 }
 
-// pullLabImages starts pulling the cached image list into the host docker
-// cache in the background and yields the refs that are available on the host
-// (freshly pulled or already cached). Independent of the cluster, so it
-// overlaps with cluster creation. A missing manifest (first boot) or a failed
-// pull is not an error — those images just fall back to in-node pulls.
-func pullLabImages() <-chan []string {
+// hostPullImages ensures every ref is in the host docker cache, pulling the
+// missing ones concurrently, and returns the refs that are available there
+// (already cached or freshly pulled), sorted. Failed pulls are dropped:
+// callers side-load what exists and the node pulls the rest itself.
+func hostPullImages(images []string) []string {
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var have []string
+	for _, img := range images {
+		wg.Go(func() {
+			if _, err := outputQuiet("docker", "image", "inspect", img); err != nil {
+				if err := runQuiet("docker", "pull", "-q", img); err != nil {
+					return
+				}
+			}
+			mu.Lock()
+			have = append(have, img)
+			mu.Unlock()
+		})
+	}
+	wg.Wait()
+	slices.Sort(have)
+	return have
+}
+
+// sideloadImages side-loads the given host-cached refs into the node in one
+// `kind load`, skipping what the node already has — on a re-run over a live
+// cluster that skip usually covers everything.
+func sideloadImages(cfg *config.Config, images []string) preloadResult {
+	start := time.Now()
+	if have, err := nodeImageTags(cfg.ControlPlaneNode()); err == nil {
+		images = slices.DeleteFunc(images, func(img string) bool {
+			return slices.Contains(have, img)
+		})
+	}
+	if len(images) == 0 {
+		return preloadResult{}
+	}
+	args := append([]string{"load", "docker-image", "--name", cfg.ClusterName}, images...)
+	if err := runQuiet("kind", args...); err != nil {
+		return preloadResult{err: err}
+	}
+	return preloadResult{n: len(images), d: time.Since(start).Round(time.Second)}
+}
+
+// pullLabImages starts pulling the snapshot manifest's images into the host
+// docker cache in the background and yields the refs available on the host.
+// Independent of the cluster, so it overlaps with cluster creation. A missing
+// manifest (first boot) is not an error — the chart-derived lane covers the
+// platform images and the node pulls any leftovers.
+func pullLabImages(cfg *config.Config) <-chan []string {
 	done := make(chan []string, 1)
 	images := readPreloadManifest()
+	// The Dex image rides its own lane (pullDexImage/sideloadDexImage): it
+	// must be in the node before the Dex Deployment lands, not whenever the
+	// bulk load finishes. Dropped here so the lanes never double-pull or
+	// double-load it.
+	images = slices.DeleteFunc(images, func(img string) bool { return img == cfg.DexImage })
 	if len(images) == 0 {
 		done <- nil
 		return done
 	}
-	go func() {
-		var mu sync.Mutex
-		var wg sync.WaitGroup
-		var have []string
-		for _, img := range images {
-			wg.Go(func() {
-				if _, err := outputQuiet("docker", "image", "inspect", img); err != nil {
-					if err := runQuiet("docker", "pull", "-q", img); err != nil {
-						return
-					}
-				}
-				mu.Lock()
-				have = append(have, img)
-				mu.Unlock()
-			})
-		}
-		wg.Wait()
-		slices.Sort(have)
-		done <- have
-	}()
+	go func() { done <- hostPullImages(images) }()
 	return done
 }
 
 // loadLabImages waits for the host pulls and side-loads the images into the
-// kind node, so the pods find every layer already present instead of pulling
-// over the network. Quiet: it runs concurrently with the Dex/OIDC phase and
-// Up reports the result when it joins the channel.
+// node. Quiet: it runs concurrently with the Dex/OIDC phase and Up reports
+// the result when it joins the channel.
 func loadLabImages(cfg *config.Config, pulled <-chan []string) <-chan preloadResult {
 	done := make(chan preloadResult, 1)
-	go func() {
-		start := time.Now()
-		images := <-pulled
-		// Skip what the node already has: on a fresh node this filters
-		// nothing, on a re-run over a live cluster it skips the whole load.
-		if have, err := nodeImageTags(cfg.ControlPlaneNode()); err == nil {
-			images = slices.DeleteFunc(images, func(img string) bool {
-				return slices.Contains(have, img)
-			})
-		}
-		if len(images) == 0 {
-			done <- preloadResult{}
-			return
-		}
-		args := append([]string{"load", "docker-image", "--name", cfg.ClusterName}, images...)
-		if err := runQuiet("kind", args...); err != nil {
-			done <- preloadResult{err: err}
-			return
-		}
-		done <- preloadResult{n: len(images), d: time.Since(start).Round(time.Second)}
-	}()
+	go func() { done <- sideloadImages(cfg, <-pulled) }()
 	return done
 }
 
-// reportPreload joins the load stage and notes the outcome; failures are
-// informational — the pods pull from the network exactly as they would have
-// without the cache.
+// pullDexImage ensures the Dex image is in the host docker cache in the
+// background, independent of the snapshot manifest: the ref is known from
+// config, so even a first boot (no manifest yet) caches it for every boot
+// after this one. The buffered channel yields availability.
+func pullDexImage(cfg *config.Config) <-chan bool {
+	done := make(chan bool, 1)
+	img := cfg.DexImage
+	go func() { done <- len(hostPullImages([]string{img})) == 1 }()
+	return done
+}
+
+// sideloadDexImage joins the host-side Dex pull and side-loads the image into
+// the node BEFORE the Deployment lands. This one image cannot ride the bulk
+// side-load: that runs concurrently with the Dex deploy, and the kubelet
+// starts its own network pull the moment the pod exists — on a slow network
+// that pull alone has outlasted ApplyDex's rollout timeout with the image
+// sitting in the host cache the whole time.
+func sideloadDexImage(cfg *config.Config, ready <-chan bool) {
+	var ok bool
+	select {
+	case ok = <-ready:
+	default:
+		note("waiting for the host pull of %s", cfg.DexImage)
+		ok = <-ready
+	}
+	if !ok {
+		note("%s is neither cached on the host nor pullable; the node pulls it instead", cfg.DexImage)
+		return
+	}
+	res := sideloadImages(cfg, []string{cfg.DexImage})
+	if res.err != nil {
+		note("side-loading %s failed (%v); the node pulls it instead", cfg.DexImage, res.err)
+		return
+	}
+	if res.n > 0 {
+		note("side-loaded %s from the host cache (%s)", cfg.DexImage, res.d)
+	}
+}
+
+// reportPreload joins the manifest lane's load stage and notes the outcome;
+// failures are informational — the pods pull from the network exactly as they
+// would have without the cache.
 func reportPreload(loaded <-chan preloadResult) {
 	res := <-loaded
 	switch {
@@ -108,6 +175,23 @@ func reportPreload(loaded <-chan preloadResult) {
 	case res.n > 0:
 		note("preloaded %d cached images into the node (%s)", res.n, res.d)
 	}
+}
+
+// imageLineRe matches the image fields of rendered Kubernetes manifests.
+var imageLineRe = regexp.MustCompile(`(?m)^\s*(?:-\s*)?image:\s*["']?([^\s"']+)["']?\s*$`)
+
+// scrapeImages extracts the image refs from rendered manifests. Only refs
+// carrying a tag or digest count: a bare word under some config blob's
+// `image:` key is not pullable and would poison the pull set.
+func scrapeImages(rendered string) []string {
+	var imgs []string
+	for _, m := range imageLineRe.FindAllStringSubmatch(rendered, -1) {
+		if ref := m[1]; strings.ContainsAny(ref, ":@") {
+			imgs = append(imgs, ref)
+		}
+	}
+	slices.Sort(imgs)
+	return slices.Compact(imgs)
 }
 
 // snapshotPreloadImages records the node's current workload images into the

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -61,7 +61,12 @@ func hostPullImages(images []string) []string {
 	for _, img := range images {
 		wg.Go(func() {
 			if _, err := outputQuiet("docker", "image", "inspect", img); err != nil {
-				if err := runQuiet("docker", "pull", "-q", img); err != nil {
+				// Pull with stderr swallowed: the chart-derived lane scrapes
+				// the odd unpullable ref out of config blobs (e.g. a bare
+				// `giantswarm/valkey`, which docker reads as a Docker Hub
+				// repo), and dropping it here IS the filter — not an error
+				// worth showing.
+				if _, err := outputQuiet("docker", "pull", "-q", img); err != nil {
 					return
 				}
 			}

--- a/internal/lab/preload_test.go
+++ b/internal/lab/preload_test.go
@@ -1,0 +1,45 @@
+package lab
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestScrapeImages(t *testing.T) {
+	rendered := `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - image: gsoci.azurecr.io/giantswarm/muster:5.7.2
+        - image: "gsoci.azurecr.io/giantswarm/mcp-kubernetes:1.0.9"
+      initContainers:
+        - image: 'docker.io/library/postgres:18.3-alpine'
+---
+kind: ConfigMap
+data:
+  # a bare word under an image key is config, not a pullable ref
+  image: muster
+  settings: |
+    image: not-yaml-context:but-tagged
+---
+kind: Pod
+spec:
+  containers:
+    - image: gsoci.azurecr.io/giantswarm/muster:5.7.2
+    - image: gsoci.azurecr.io/giantswarm/valkey@sha256:abcdef0123456789
+`
+	got := scrapeImages(rendered)
+	want := []string{
+		"docker.io/library/postgres:18.3-alpine",
+		"gsoci.azurecr.io/giantswarm/mcp-kubernetes:1.0.9",
+		"gsoci.azurecr.io/giantswarm/muster:5.7.2",
+		"gsoci.azurecr.io/giantswarm/valkey@sha256:abcdef0123456789",
+		"not-yaml-context:but-tagged",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("scrapeImages:\n got  %v\n want %v", got, want)
+	}
+}

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -29,12 +29,14 @@ func Up(cfg *config.Config) error {
 
 	// Pure network work that needs no cluster starts first, so it overlaps
 	// with cluster creation: vendoring the platform chart, and pulling the
-	// last boot's images into the host docker cache (which survives `down`).
+	// Dex image plus the last boot's images into the host docker cache
+	// (which survives `down`).
 	var chartReady <-chan error
 	if cfg.Platform.Enabled {
 		chartReady = vendorPlatformChart(cfg)
 	}
-	pulled := pullLabImages()
+	pulled := pullLabImages(cfg)
+	dexReady := pullDexImage(cfg)
 
 	_, kindCfgPath, err := renderManifest(cfg, "kind-config.yaml.tmpl")
 	if err != nil {
@@ -73,6 +75,7 @@ func Up(cfg *config.Config) error {
 	}); err != nil {
 		return err
 	}
+	sideloadDexImage(cfg, dexReady)
 	if err := ApplyDex(cfg); err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

Every image the lab needs now travels **host docker cache → node side-load**, never kubelet → network. The host cache survives `agentlab down`, so a second `agentlab up` always benefits from the previous run — including a previous run that failed.

Three lanes feed the node:

- **Dex** (`pullDexImage`/`sideloadDexImage`): the ref is known from config, so the host pull starts before cluster creation and the image is side-loaded **synchronously before the Deployment lands**. The rollout wait never covers a network pull again.
- **Snapshot manifest** (`pullLabImages`/`loadLabImages`): unchanged behavior — overlaps the Dex/OIDC phase, joined before the platform install. Now built on shared `hostPullImages`/`sideloadImages` helpers.
- **Chart-derived** (`platformImages`): `helm template` the vendored umbrella chart and the mcp-kubernetes chart with the rendered lab values, scrape the `image:` fields, host-pull what's missing and side-load before the installs. Covers **first boots** (no manifest yet) and **version bumps** (stale manifest), which the snapshot lane cannot.

`agentlab platform` (standalone) now also joins the manifest preload, healing missing side-loads after a half-failed boot. Every lane is best-effort: any failure degrades to exactly the in-node pull it replaced.

## Why

Observed on a slow uplink (~400 KB/s): a fresh boot pulled `ghcr.io/dexidp/dex:v2.45.1` in-node for **2m08s** and the 120s `rollout status` wait timed out 8 seconds before the pod went Ready — while the image sat in the host cache and in `state/preload-images.txt` the whole time. The background bulk side-load races the Dex deploy: the kubelet starts its own network pull the moment the pod exists, and an in-flight pull never adopts a concurrently imported image. When the boot then failed, the orphaned `kind load` died with the process, so the node ended up with zero preloaded images.

## Verification

- `go test ./...`, `go vet`, gofmt clean; new unit test for the image scraper.
- Full `agentlab down && agentlab up` on the same slow uplink with a warm host cache: Dex side-loads and its phase passes in seconds (previously a 2-minute in-node pull → timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)