### PR TITLE
fix: print one summary at the end of the boot, not two

### DIFF
--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -52,7 +52,7 @@ func PlatformUp(cfg *config.Config) error {
 	// no-op, and after a half-failed boot it heals the missing side-loads
 	// before the installs start their rollout waits.
 	reportPreload(loadLabImages(cfg, pullLabImages(cfg)))
-	return platformUp(cfg, nil)
+	return platformUp(cfg, nil, "Platform is up.")
 }
 
 // vendorPlatformChart runs ensurePlatformChart in the background so the git
@@ -127,7 +127,11 @@ func ensurePlatformChart(cfg *config.Config) error {
 	return nil
 }
 
-func platformUp(cfg *config.Config, chartReady <-chan error) error {
+// platformUp installs and verifies the platform, then prints the boot's one
+// and only summary under the given header: `up` passes "Lab is up." so the
+// user reads a single "what to do next" block once everything is verified,
+// the standalone `agentlab platform` entry point passes "Platform is up.".
+func platformUp(cfg *config.Config, chartReady <-chan error, header string) error {
 	chartDir := filepath.Join(apsDir, "helm", "agent-platform-standalone")
 
 	// Also checked at the very top of `agentlab up`; repeated here for the
@@ -424,18 +428,15 @@ func platformUp(cfg *config.Config, chartReady <-chan error) error {
 		}
 	}
 	fmt.Printf(`
-Platform is up.
+%s
   %s
-
+%s
 %s
 
 %s
 
 %s
-
-  Smoke-test it headlessly instead:
-    agentlab platform-test
-`, reach, backstageHint, claudeCodeHint(cfg), agentsHint)
+%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, tryItBlock(cfg))
 	// Everything the platform runs is in the node now — record it so the next
 	// boot side-loads instead of pulling.
 	snapshotPreloadImages(cfg)

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -123,37 +123,64 @@ func Up(cfg *config.Config) error {
 	}
 	note("apiserver accepts Dex tokens")
 
-	fmt.Println()
-	fmt.Println("Lab is up.")
-	fmt.Println()
-	fmt.Println("  Users:")
-	for _, u := range cfg.Users {
-		fmt.Printf("    %-22s password: %-12s groups: %s\n",
-			u.Email, u.Password, strings.Join(u.Groups, ", "))
-	}
-	fmt.Println()
-	fmt.Println("  Try it:")
-	fmt.Printf("    agentlab login %s     # headless, prints the token claims\n", admin.Email)
-	fmt.Println("    agentlab browser      # real browser login screen")
-	fmt.Println("    agentlab test         # full RBAC assertion run")
-	// The platform path prints its own, more complete trust hint.
-	if !cfg.Platform.Enabled && !SystemTrusted() {
-		fmt.Println()
-		fmt.Println("  The browser will warn on the Dex login page (lab-CA certificate). One-time")
-		fmt.Println("  fix, reverted by `agentlab untrust`:  agentlab trust")
-	}
-
 	reportPreload(loaded)
 	if cfg.Platform.Enabled {
-		fmt.Println()
 		// Backstage deploys as part of the platform (the umbrella chart's
-		// backstage component), through the same agentgateway edge.
-		if err := platformUp(cfg, chartReady); err != nil {
+		// backstage component), through the same agentgateway edge. One
+		// summary per boot: the platform path prints it — users, URLs and
+		// try-it commands together — once everything is actually up.
+		if err := platformUp(cfg, chartReady, "Lab is up."); err != nil {
 			return err
+		}
+	} else {
+		fmt.Println()
+		fmt.Println("Lab is up.")
+		fmt.Print(usersBlock(cfg))
+		fmt.Print(tryItBlock(cfg))
+		// The platform summary carries its own, more complete trust hint.
+		if !SystemTrusted() {
+			fmt.Println()
+			fmt.Println("  The browser will warn on the Dex login page (lab-CA certificate). One-time")
+			fmt.Println("  fix, reverted by `agentlab untrust`:  agentlab trust")
 		}
 	}
 	snapshotPreloadImages(cfg)
 	return nil
+}
+
+// usersBlock and tryItBlock are the "what to do next" tail of every boot
+// summary — the configured identities and the commands that exercise them.
+// Both start with a blank separator line and end with a newline so callers
+// can concatenate them between other summary sections.
+func usersBlock(cfg *config.Config) string {
+	var b strings.Builder
+	b.WriteString("\n  Users:\n")
+	for _, u := range cfg.Users {
+		fmt.Fprintf(&b, "    %-22s password: %-12s groups: %s\n",
+			u.Email, u.Password, strings.Join(u.Groups, ", "))
+	}
+	return b.String()
+}
+
+func tryItBlock(cfg *config.Config) string {
+	cmds := [][2]string{
+		{"agentlab login " + cfg.AdminUser().Email, "headless, prints the token claims"},
+		{"agentlab browser", "real browser login screen"},
+		{"agentlab test", "full RBAC assertion run"},
+	}
+	if cfg.Platform.Enabled {
+		cmds = append(cmds, [2]string{"agentlab platform-test", "headless smoke test of the whole platform"})
+	}
+	width := 0
+	for _, c := range cmds {
+		width = max(width, len(c[0]))
+	}
+	var b strings.Builder
+	b.WriteString("\n  Try it:\n")
+	for _, c := range cmds {
+		fmt.Fprintf(&b, "    %-*s   # %s\n", width, c[0], c[1])
+	}
+	return b.String()
 }
 
 // ApplyDex renders manifests with the input checksum stamped into the pod


### PR DESCRIPTION
## What

`agentlab up` used to print a "Lab is up." block (users + try-it commands) right after the OIDC verification — minutes before the platform install finished. That read as "done" while the boot was visibly still running, and async preload notes could land in the middle of it.

Now the boot prints **one** summary, at the very end, once everything is verified:

- users and passwords
- muster / Backstage / kagent URLs
- the "point Claude Code at it" hint
- an aligned `Try it:` block, with `agentlab platform-test` folded in (replacing the separate "Smoke-test it headlessly instead" section)

When the platform is disabled, the lab-only block already was the final output and stays as it was (including the trust hint). Standalone `agentlab platform` keeps its "Platform is up." header but gains the same combined body.

## Verified

Re-ran `./agentlab up` against a live lab: no mid-boot summary, single combined block at the end, all waits and probes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)