### PR TITLE
fix: bump apsRef — backstage 0.200.14, kube:apply honors the cluster caFile

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,7 +195,7 @@ func Default() *Config {
 			GatewayPort:          443,
 			MCPKubernetesVersion: "1.0.9",
 			APSRepo:              "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:               "07019de9707ebe098def6700fa4a916ce5e08728", // feat/curate-generator head: 3.2.2 curation, muster 5.7.2 (native DCR toggle), Renovate-owned pins
+			APSRef:               "8026394c4ff6f1aa315e4670095efc83e0690a72", // main: backstage 0.200.14 — kube:apply honors the cluster caFile (agent create flow TLS)
 		},
 		Backstage: Backstage{
 			Enabled: true,


### PR DESCRIPTION
Points \`apsRef\` at agent-platform-standalone main (\`8026394c\`), which pins backstage **0.200.14**.

That release carries giantswarm/backstage#2154: the scaffolder's \`kube:apply\` action now honors \`caFile\` on clusters declared under \`kubernetes.clusterLocatorMethods\`. Without it the agent create flow's "Apply to installation" step built a Kubernetes client with no CA and failed against the kind API server with:

```
Failed to fetch resource metadata for source.toolkit.fluxcd.io/v1/OCIRepository:
unable to verify the first certificate
```

Also picks up agent-platform-standalone#30 (the pin bump + chart regen). The ref moves from the pre-squash \`feat/curate-generator\` head onto \`main\` proper, where #11 landed squashed.

Verification: fresh \`agentlab up\` with this ref, then the agent create flow applies OCIRepository + HelmRelease successfully (to be confirmed in the lab after merge/release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)