### PR TITLE
fix: bump apsRef — backstage 0.200.16, global-agent keeps kube client CAs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,7 +195,7 @@ func Default() *Config {
 			GatewayPort:          443,
 			MCPKubernetesVersion: "1.0.9",
 			APSRepo:              "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:               "d8dc380c70df4fe0cf9cfd7b8a1e0974b72a4386", // main: backstage 0.200.15 — actually ships the kube:apply caFile fix (0.200.14 image was cache-poisoned, backstage#2156)
+			APSRef:               "197e82270bb39eed8105760144d07b941bd3b945", // main: backstage 0.200.16 — global-agent no longer strips the kube client CA (backstage#2157); agent create flow verified e2e
 		},
 		Backstage: Backstage{
 			Enabled: true,


### PR DESCRIPTION
Points \`apsRef\` at agent-platform-standalone \`197e8227\` (backstage **0.200.16**, agent-platform-standalone#33).

Completes the agent-create-flow TLS fix: the \`caFile\` pass-through (#25 / backstage#2154) was necessary but not sufficient — the backend's \`global-agent\` bootstrap force-replaced every request's agent, discarding the cluster CA the kube client carries (giantswarm/backstage#2157). Verified end to end in the lab: scaffolder task completes, OCIRepository + HelmRelease apply with the user's OIDC token, Flux pulls the agent chart, the Agent CR is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)