### PR TITLE
fix(lab): unbreak the Backstage agent create flow end to end

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -262,6 +262,25 @@ the kind config maps 30443 onto `platform.gatewayPort` (default 443).
 Service's nodePort; then this Service is deleted and the kind mapping targets
 the controller's own Service.
 
+### U11. Agent CRD patched with `spec.iconUrl` — BLOCKED UPSTREAM
+The kagent package (giantswarm/kagent, ex-kagent-app) pins the upstream 0.9.x
+CRDs, whose v1alpha2 Agent spec predates the A2A-card metadata fields added on
+upstream main for 0.10 (kagent-dev/kagent#2188). The Backstage create flow
+composes `agent.iconUrl` (the deterministic `avatars.<baseDomain>` URL)
+whenever the installation has a `baseDomain` — this lab always sets one — the
+`agent` chart renders it into `Agent.spec.iconUrl`, and server-side apply
+rejects the whole HelmRelease: `.spec.iconUrl: field not declared in schema`.
+The agents list then stays empty with no visible error, because the scaffolder
+task only kube-applies the HelmRelease and reports success. Not lab-specific:
+any installation with a configured `baseDomain` fails the same way.
+**Workaround (automated):** `patchAgentCRDIconURL` (`internal/lab/kagentcrd.go`,
+run by `agentlab up`/`platform` when agents are enabled) adds upstream main's
+`iconUrl` property (optional string, stored and ignored by the 0.9.x
+controller) to the installed CRD's v1alpha2 schema. Idempotent, and a no-op
+once the CRD already carries the field — a kagent bump retires it silently.
+**Unblocks:** giantswarm/kagent#55 — ship CRDs that declare the A2A-card
+metadata fields (backport or the 0.10 bump); then delete `kagentcrd.go`.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,7 +195,7 @@ func Default() *Config {
 			GatewayPort:          443,
 			MCPKubernetesVersion: "1.0.9",
 			APSRepo:              "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:               "197e82270bb39eed8105760144d07b941bd3b945", // main: backstage 0.200.16 — global-agent no longer strips the kube client CA (backstage#2157); agent create flow verified e2e
+			APSRef:               "d2dc19f9a705b7b297c2fafcd685675683a4631c", // main: components.backstage.enabledExtensions (#39) + backstage 0.200.19
 		},
 		Backstage: Backstage{
 			Enabled: true,

--- a/internal/lab/kagentcrd.go
+++ b/internal/lab/kagentcrd.go
@@ -1,0 +1,55 @@
+package lab
+
+import (
+	"fmt"
+	"strings"
+)
+
+// patchAgentCRDIconURL works around HACKS.md U11: the kagent package pins the
+// upstream 0.9.x CRDs, whose v1alpha2 Agent spec predates the A2A-card
+// metadata fields. The Backstage create flow composes agent.iconUrl whenever
+// the installation has a baseDomain (this lab always sets one), the agent
+// chart renders it into Agent.spec.iconUrl, and server-side apply then
+// rejects the whole HelmRelease with ".spec.iconUrl: field not declared in
+// schema" — the portal's agents list stays empty with no visible error, since
+// the scaffolder task only kube-applies the HelmRelease and reports success.
+//
+// Until giantswarm/kagent#55 ships CRDs that carry the field, add upstream
+// main's definition (optional string; the 0.9.x controller stores and ignores
+// it) to the installed CRD. Idempotent: a no-op once the field is present, so
+// a kagent bump that carries it retires this silently.
+func patchAgentCRDIconURL() error {
+	const crd = "agents.kagent.dev"
+	present, err := outputQuiet("kubectl", "get", "crd", crd, "-o",
+		`jsonpath={.spec.versions[?(@.name=="v1alpha2")].schema.openAPIV3Schema.properties.spec.properties.iconUrl}`)
+	if err != nil {
+		return fmt.Errorf("reading the %s CRD: %w", crd, err)
+	}
+	if strings.TrimSpace(present) != "" {
+		note("Agent CRD already declares spec.iconUrl; the patch retired (HACKS.md U11)")
+		return nil
+	}
+	names, err := outputQuiet("kubectl", "get", "crd", crd, "-o",
+		`jsonpath={range .spec.versions[*]}{.name}{"\n"}{end}`)
+	if err != nil {
+		return fmt.Errorf("listing the %s CRD versions: %w", crd, err)
+	}
+	idx := -1
+	for i, name := range strings.Split(strings.TrimSpace(names), "\n") {
+		if name == "v1alpha2" {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return fmt.Errorf("the %s CRD serves no v1alpha2 (versions: %q)", crd, strings.TrimSpace(names))
+	}
+	patch := fmt.Sprintf(`[{"op":"add","path":"/spec/versions/%d/schema/openAPIV3Schema/properties/spec/properties/iconUrl",`+
+		`"value":{"description":"IconURL is a URL to an icon representing the agent. It is surfaced on the agent's A2A AgentCard.",`+
+		`"format":"uri","type":"string"}}]`, idx)
+	if err := runQuiet("kubectl", "patch", "crd", crd, "--type=json", "-p", patch); err != nil {
+		return fmt.Errorf("patching %s with spec.iconUrl: %w", crd, err)
+	}
+	note("Agent CRD patched with spec.iconUrl (until giantswarm/kagent#55)")
+	return nil
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -358,6 +358,12 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		// which upstream has been observed not to publish (HACKS.md U8).
 		step("Ensuring the agents' ADK runtime images are on the node")
 		healADKImages(cfg)
+		// The 0.9.x Agent CRD rejects the spec.iconUrl the create flow always
+		// composes, failing every created agent's HelmRelease (HACKS.md U11).
+		step("Ensuring the Agent CRD accepts spec.iconUrl")
+		if err := patchAgentCRDIconURL(); err != nil {
+			return err
+		}
 	}
 
 	// The public URL runs client -> agentgateway edge -> muster: reaching it

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -86,6 +86,18 @@ components:
       - federated:id
       - audience:server:client_id:dex-k8s-authenticator
       - audience:server:client_id:kubernetes
+    # The vanilla UI hides the portal's HelmRelease pages, but the create
+    # flow's scaffolder result links straight to
+    # /deployments/<installation>/helmrelease/<ns>/<name> — without these the
+    # link 404s AND a failed agent install is invisible (the agents list only
+    # shows Agent CRs that exist). Clusters rides along because the
+    # deployments table links cluster details unconditionally and crashes
+    # without its routes (giantswarm/backstage#2161).
+    enabledExtensions:
+      - page:gs/deployments
+      - nav-item:gs/deployments
+      - page:gs/clusters
+      - nav-item:gs/clusters
 {{- end }}
 
 muster:


### PR DESCRIPTION
## What broke

Creating an agent through the portal reported success ("Apply to installation ✓") but the agent never appeared in the agents list, and the result's "Go to the deployment" link 404'd.

Two independent causes:

1. **Agent CRD schema skew (HACKS.md U11, new).** The kagent package pins the upstream 0.9.x CRDs; the Backstage create flow composes `agent.iconUrl` whenever the installation has a `baseDomain` (the lab always does), the `agent` chart renders it into `Agent.spec.iconUrl`, and server-side apply rejects the created HelmRelease with `.spec.iconUrl: field not declared in schema`. No Agent CR → empty agents list, no visible error. Blocked upstream on giantswarm/kagent#55; until then `patchAgentCRDIconURL` (new `internal/lab/kagentcrd.go`, run when agents are enabled) adds upstream main's optional field to the installed CRD. Idempotent and self-retiring once a kagent bump ships the field.

2. **Portal pages disabled (404).** The vanilla standalone UI hides the Deployments page — which is also `disabled: true` in the Backstage app itself, so it needs an explicit enable entry. The apsRef bump picks up agent-platform-standalone#39 (`components.backstage.enabledExtensions`) and the lab values now enable Deployments + Clusters (Clusters because the deployments table links cluster details unconditionally and crashes without its routes — giantswarm/backstage#2161).

## Verified on the live lab

The same changes were applied by hand to the running agentlab cluster first:

- CRD patch + `flux reconcile hr test -n kagent --reset` → HelmRelease Ready, Agent CR created with `spec.iconUrl` stored, agent pod Running, agents list shows the agent **Ready**.
- Extensions enabled + Backstage restart → `/deployments/agent-platform/helmrelease/kagent/test` renders the HelmRelease detail (Ready/Released, chart `agent` 0.5.1).

`go build ./...` and `go test -count=1 ./internal/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)