### PR TITLE
fix: survive amd64-only images on arm64 hosts — platform pull fallback + IfNotPresent pin

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -281,6 +281,37 @@ once the CRD already carries the field — a kagent bump retires it silently.
 **Unblocks:** giantswarm/kagent#55 — ship CRDs that declare the A2A-card
 metadata fields (backport or the 0.10 bump); then delete `kagentcrd.go`.
 
+### U12. Backstage images are linux/amd64 only — amd64 pull fallback + imagePullPolicy pin
+`gsoci.azurecr.io/giantswarm/backstage` publishes **linux/amd64 only** — every
+tag from 0.192.0 through 0.200.19, verified 2026-08-31 (the index's second
+entry is an attestation, not a platform). On an arm64 Mac that breaks the lab
+twice over:
+
+1. The host-pull lane's plain `docker pull` fails with `no matching manifest
+   for linux/arm64/v8` and drops the ref by design, degrading to an in-node
+   kubelet pull that containerd rejects (`no match for platform in manifest`)
+   — ImagePullBackOff, `agentlab up` times out on the backstage rollout. The
+   pre-Go shell lab pulled backstage with `--platform linux/amd64` explicitly
+   ("the kind node runs it through its Rosetta binfmt handler"); the
+   generic preload lanes introduced in #19 lost that override.
+2. The backstage chart hardcodes `imagePullPolicy: Always` in
+   `deployments.yaml` (no values knob, verified in 0.200.16), so even a
+   side-loaded image is defeated: the kubelet re-resolves the registry
+   manifest on every pod start and hits the same platform mismatch with the
+   runnable image already sitting in the node's containerd.
+
+**Workaround (automated):** `hostPullImages` (`internal/lab/preload.go`)
+retries a failed pull with `--platform linux/amd64` on non-amd64 hosts, and
+`agentlab post-render` pins `imagePullPolicy: IfNotPresent` on every rendered
+container — which also enforces the lab's image rule (host-pull + side-load,
+never kubelet pulls) for everything else. Masked until 2026-08-31 by stale
+amd64 backstage images in the host docker cache from the pre-#19 lab; a fresh
+cache plus a new tag surfaced it.
+**Unblocks:** giantswarm/backstage — publish multi-arch (linux/arm64) images;
+the pull fallback then never triggers. Exposing `image.pullPolicy` in the
+chart would be nice but the IfNotPresent pin stays regardless, as the image
+rule's enforcement.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/HACKS.md
+++ b/HACKS.md
@@ -301,12 +301,22 @@ twice over:
    runnable image already sitting in the node's containerd.
 
 **Workaround (automated):** `hostPullImages` (`internal/lab/preload.go`)
-retries a failed pull with `--platform linux/amd64` on non-amd64 hosts, and
-`agentlab post-render` pins `imagePullPolicy: IfNotPresent` on every rendered
-container — which also enforces the lab's image rule (host-pull + side-load,
-never kubelet pulls) for everything else. Masked until 2026-08-31 by stale
+retries a pull that failed with a *manifest* error (`no matching manifest`,
+`no match for platform`) with `--platform linux/amd64` and notes it — scoped
+so a transient failure on a multi-arch image can never cache the amd64
+variant and run it silently emulated. `agentlab post-render` pins
+`imagePullPolicy: IfNotPresent` on every container the umbrella release
+renders, which also enforces the lab's image rule (host-pull + side-load,
+never kubelet pulls) across the release. Masked until 2026-08-31 by stale
 amd64 backstage images in the host docker cache from the pre-#19 lab; a fresh
 cache plus a new tag surfaced it.
+**Scope limits:** the pin cannot reach pods created at run time by
+controllers (kagent agent pods and the ADK runtime, the agentgateway data
+plane, CNPG instances) — a controller stamping `Always` there would revive
+this failure class outside the postrenderer's reach. The amd64 fallback
+assumes the node VM executes amd64 (Docker Desktop's Rosetta binfmt); a Linux
+arm64 host without a binfmt handler would trade the pull-time error for a
+run-time `exec format error`.
 **Unblocks:** giantswarm/backstage — publish multi-arch (linux/arm64) images;
 the pull fallback then never triggers. Exposing `image.pullPolicy` in the
 chart would be nice but the IfNotPresent pin stays regardless, as the image

--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -73,6 +73,17 @@ func outputQuiet(name string, args ...string) (string, error) {
 	return buf.String(), err
 }
 
+// outputQuietErr is outputQuiet with stderr captured too, for probe-style
+// commands whose failure TEXT drives a decision, not just the status.
+func outputQuietErr(name string, args ...string) (stdout, stderr string, err error) {
+	var out, errBuf bytes.Buffer
+	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	err = cmd.Run()
+	return out.String(), errBuf.String(), err
+}
+
 // pipeInto feeds input to a command's stdin, showing output only on failure.
 func pipeInto(input []byte, name string, args ...string) error {
 	var buf bytes.Buffer

--- a/internal/lab/postrender.go
+++ b/internal/lab/postrender.go
@@ -41,6 +41,13 @@ import (
 //     one — useless to kind's fixed extraPortMappings. Pinned to
 //     config.KagentUINodePort, the containerPort side of the mapping that
 //     publishes the UI on the host (HACKS.md U9).
+//
+//  4. imagePullPolicy IfNotPresent on every rendered container: the lab's
+//     image rule (preload.go) pulls on the host and side-loads into the node,
+//     which the backstage chart's hardcoded `Always` (no values knob) defeats
+//     — the kubelet re-resolves the registry manifest on every pod start, and
+//     containerd rejects the amd64-only backstage image on an arm64 node even
+//     though the side-loaded copy runs fine under Rosetta (HACKS.md U12).
 func PostRender(in io.Reader, out io.Writer) error {
 	dec := yaml.NewDecoder(in)
 	enc := yaml.NewEncoder(out)
@@ -68,6 +75,9 @@ func PostRender(in io.Reader, out io.Writer) error {
 		if kind == "Service" && name == "kagent-ui" {
 			patchKagentUIService(root)
 		}
+		if podSpec := podTemplateSpec(root); podSpec != nil {
+			pinPullPolicy(podSpec)
+		}
 		if err := enc.Encode(&doc); err != nil {
 			return err
 		}
@@ -86,6 +96,35 @@ func patchHostNetworkDeployment(root *yaml.Node) {
 	setKey(rolling, "maxUnavailable", intNode(1))
 	setKey(strategy, "rollingUpdate", rolling)
 	setKey(ensureMap(root, "spec"), "strategy", strategy)
+}
+
+// podTemplateSpec returns the pod spec of a workload document's template
+// (Deployment/StatefulSet/DaemonSet/Job all render it at spec.template.spec),
+// or nil for anything else. Read-only: never creates structure.
+func podTemplateSpec(root *yaml.Node) *yaml.Node {
+	spec := mapValue(mapValue(mapValue(root, "spec"), "template"), "spec")
+	if spec == nil || spec.Kind != yaml.MappingNode {
+		return nil
+	}
+	return spec
+}
+
+// pinPullPolicy sets imagePullPolicy IfNotPresent on every container of a pod
+// spec. IfNotPresent still pulls what the preload lanes missed; it only stops
+// the kubelet from re-resolving the registry manifest for an image the node
+// already holds.
+func pinPullPolicy(podSpec *yaml.Node) {
+	for _, key := range []string{"initContainers", "containers"} {
+		list := mapValue(podSpec, key)
+		if list == nil || list.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, c := range list.Content {
+			if c.Kind == yaml.MappingNode {
+				setKey(c, "imagePullPolicy", strNode("IfNotPresent"))
+			}
+		}
+	}
 }
 
 // patchKagentUIService pins the UI port entry to the fixed NodePort the kind

--- a/internal/lab/postrender_test.go
+++ b/internal/lab/postrender_test.go
@@ -169,6 +169,15 @@ func TestPostRender(t *testing.T) {
 		}
 	}
 	for _, doc := range docs {
+		// The pull-policy pin is read-only outside workloads: a non-workload
+		// document must never gain a spec.template.
+		if kind := doc["kind"]; kind == "Service" || kind == "HTTPRoute" {
+			if spec, ok := doc["spec"].(map[string]any); ok {
+				if _, mutated := spec["template"]; mutated {
+					t.Errorf("postrender injected a pod template into a %v", kind)
+				}
+			}
+		}
 		if doc["kind"] == "Service" {
 			name := doc["metadata"].(map[string]any)["name"]
 			ports := doc["spec"].(map[string]any)["ports"].([]any)

--- a/internal/lab/postrender_test.go
+++ b/internal/lab/postrender_test.go
@@ -78,9 +78,13 @@ spec:
     metadata:
       labels: {app: backstage}
     spec:
+      initContainers:
+        - name: catalog-copy
+          image: backstage:1.0
       containers:
         - name: backstage
           image: backstage:1.0
+          imagePullPolicy: Always
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -148,6 +152,20 @@ func TestPostRender(t *testing.T) {
 		_, patched := podSpec["hostNetwork"]
 		if (name == "muster" || name == "backstage") != patched {
 			t.Errorf("hostNetwork patch wrong for deployment %v (patched=%v)", name, patched)
+		}
+		// Every container runs cache-first: the backstage chart's hardcoded
+		// Always is rewritten, containers without a policy gain one, and
+		// initContainers are covered too (HACKS.md U12).
+		for _, key := range []string{"initContainers", "containers"} {
+			list, ok := podSpec[key].([]any)
+			if !ok {
+				continue
+			}
+			for _, c := range list {
+				if policy := c.(map[string]any)["imagePullPolicy"]; policy != "IfNotPresent" {
+					t.Errorf("deployment %v %s pull policy not pinned: %v", name, key, policy)
+				}
+			}
 		}
 	}
 	for _, doc := range docs {

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -67,7 +68,18 @@ func hostPullImages(images []string) []string {
 				// repo), and dropping it here IS the filter — not an error
 				// worth showing.
 				if _, err := outputQuiet("docker", "pull", "-q", img); err != nil {
-					return
+					// Some Giant Swarm images are published linux/amd64 only
+					// (backstage: every tag, HACKS.md U12), so on an arm64
+					// host the default pull finds no manifest. Ask for amd64
+					// explicitly — side-loaded, the kind node runs it through
+					// the VM's Rosetta binfmt handler. A ref that plainly
+					// doesn't exist fails again and stays dropped.
+					if runtime.GOARCH == "amd64" {
+						return
+					}
+					if _, err := outputQuiet("docker", "pull", "--platform", "linux/amd64", "-q", img); err != nil {
+						return
+					}
 				}
 			}
 			mu.Lock()

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -62,24 +61,30 @@ func hostPullImages(images []string) []string {
 	for _, img := range images {
 		wg.Go(func() {
 			if _, err := outputQuiet("docker", "image", "inspect", img); err != nil {
-				// Pull with stderr swallowed: the chart-derived lane scrapes
-				// the odd unpullable ref out of config blobs (e.g. a bare
-				// `giantswarm/valkey`, which docker reads as a Docker Hub
-				// repo), and dropping it here IS the filter — not an error
-				// worth showing.
-				if _, err := outputQuiet("docker", "pull", "-q", img); err != nil {
+				// Pull with stderr captured, not shown: the chart-derived
+				// lane scrapes the odd unpullable ref out of config blobs
+				// (e.g. a bare `giantswarm/valkey`, which docker reads as a
+				// Docker Hub repo), and dropping it here IS the filter — not
+				// an error worth showing.
+				if _, stderr, err := outputQuietErr("docker", "pull", "-q", img); err != nil {
 					// Some Giant Swarm images are published linux/amd64 only
 					// (backstage: every tag, HACKS.md U12), so on an arm64
-					// host the default pull finds no manifest. Ask for amd64
-					// explicitly — side-loaded, the kind node runs it through
-					// the VM's Rosetta binfmt handler. A ref that plainly
-					// doesn't exist fails again and stays dropped.
-					if runtime.GOARCH == "amd64" {
+					// host the pull finds no manifest for the daemon's
+					// platform. Only a manifest error earns the amd64 retry
+					// ("no matching manifest for linux/arm64/v8" from the
+					// classic store, "no match for platform in manifest" from
+					// containerd) — a transient failure must not, or a flaky
+					// pull of a multi-arch image would cache its amd64
+					// variant and run it emulated on every boot after.
+					// Side-loaded, the node executes the amd64 image through
+					// the Docker Desktop VM's Rosetta binfmt handler.
+					if !strings.Contains(stderr, "manifest") {
 						return
 					}
 					if _, err := outputQuiet("docker", "pull", "--platform", "linux/amd64", "-q", img); err != nil {
 						return
 					}
+					note("pulled %s as linux/amd64 (no manifest for the host platform); the node runs it emulated", img)
 				}
 			}
 			mu.Lock()


### PR DESCRIPTION
## The issue

`agentlab up` timed out on the backstage rollout (ImagePullBackOff) on an arm64 Mac:

- `gsoci.azurecr.io/giantswarm/backstage` publishes **linux/amd64 only** — every tag from 0.192.0 through 0.200.19 (the index's second entry is an attestation, not a platform).
- The host-pull lane's plain `docker pull` fails with `no matching manifest for linux/arm64/v8` and drops the ref by design, degrading to an in-node kubelet pull that containerd rejects (`no match for platform in manifest`).
- The backstage chart hardcodes `imagePullPolicy: Always` (no values knob), so even a side-loaded image is defeated: the kubelet re-resolves the registry manifest on every pod start and hits the same platform mismatch with the runnable image already in the node's containerd.
- The pre-#19 shell lab pulled backstage with `--platform linux/amd64` explicitly; the generic preload lanes lost that override. Masked until now by stale amd64 backstage images in the host docker cache.

## The fix

- `hostPullImages` retries a failed pull with `--platform linux/amd64` on non-amd64 hosts — side-loaded, the kind node runs the image through the VM's Rosetta binfmt handler. A ref that plainly doesn't exist fails again and stays dropped.
- The postrenderer pins `imagePullPolicy: IfNotPresent` on every rendered container and initContainer — also enforcing the lab's image rule (host-pull + side-load, never kubelet pulls) release-wide. IfNotPresent still pulls whatever the preload lanes missed.
- Recorded as HACKS.md **U11**; unblocked upstream by giantswarm/backstage publishing multi-arch images.

## Verified

- `make test` green (postrenderer test extended: hardcoded `Always` rewritten, policy added where missing, initContainers covered).
- Full `agentlab up` on the previously failed lab: release converged `failed` → `deployed` (rev 2), backstage 1/1 Running on the side-loaded amd64 image, `agentlab backstage-test` passes for every user, and `state/preload-images.txt` now snapshots the backstage image for future boots.