### PR TITLE
refactor: rename Go module to github.com/giantswarm/agentlab

### DIFF
--- a/.circleci/workflows.yml
+++ b/.circleci/workflows.yml
@@ -12,7 +12,7 @@ workflows:
     jobs:
     - architect/go-build:
         name: go-build
-        binary: agentplatform-kind
+        binary: agentlab
         context: architect
         # Run unit tests through `make test` rather than the orb's hardcoded
         # `go test ./...`, so CI and local agent runs use the same command.
@@ -47,7 +47,7 @@ workflows:
     - architect/upload-release-assets:
         context: architect
         name: upload-release-assets
-        binary: agentplatform-kind
+        binary: agentlab
         requires:
         - go-build
         filters:

--- a/README.md
+++ b/README.md
@@ -35,12 +35,11 @@ Install the `agentlab` binary one of three ways:
 # From source (clone this repo first):
 go build -o agentlab .
 
-# Via go install — the binary lands as `agentplatform-kind`, rename it once:
-go install github.com/giantswarm/agentplatform-kind@latest
-mv "$(go env GOPATH)/bin/agentplatform-kind" "$(go env GOPATH)/bin/agentlab"
+# Via go install:
+go install github.com/giantswarm/agentlab@latest
 
-# From a GitHub release — assets are named agentplatform-kind-<os>-<arch>:
-curl -Lo agentlab https://github.com/giantswarm/agentplatform-kind/releases/latest/download/agentplatform-kind-linux-amd64
+# From a GitHub release — assets are named agentlab-<os>-<arch>:
+curl -Lo agentlab https://github.com/giantswarm/agentlab/releases/latest/download/agentlab-linux-amd64
 chmod +x agentlab
 ```
 
@@ -173,7 +172,7 @@ platform:
 The edge then serves your certificate instead of a minted wildcard (renewals:
 re-run `agentlab platform` after the files change). Caveat: the Dex login
 page still serves the lab-CA cert — the issuer cannot move under your domain
-yet ([#20](https://github.com/giantswarm/agentplatform-kind/issues/20)) — so
+yet ([#20](https://github.com/giantswarm/agentlab/issues/20)) — so
 the login hop keeps warning until you `agentlab trust`.
 
 ## The agent platform (muster + Kubernetes MCP)

--- a/cliff.toml
+++ b/cliff.toml
@@ -105,7 +105,7 @@ commit_parsers = [
 # below. The token is passed automatically via the workflow's GITHUB_TOKEN.
 [remote.github]
 owner = "giantswarm"
-repo = "agentplatform-kind"
+repo = "agentlab"
 
 # Template for the rendered release notes. Body is what gets posted to the
 # GitHub Release; header and footer are empty so the release page shows only

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/agentplatform-kind
+module github.com/giantswarm/agentlab
 
 go 1.25.8
 

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -12,7 +12,7 @@ import (
 
 	"charm.land/huh/v2"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 var emailRe = regexp.MustCompile(`^[^@\s]+@[^@\s]+$`)

--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 const keyDelay = 30 * time.Millisecond

--- a/internal/lab/adk.go
+++ b/internal/lab/adk.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // healADKImages works around HACKS.md U8: kagent-controller composes the

--- a/internal/lab/backstage.go
+++ b/internal/lab/backstage.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // BackstageUp is the retired bespoke deployment path: Backstage now deploys

--- a/internal/lab/backstagetest.go
+++ b/internal/lab/backstagetest.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // handlerPayloadRe extracts the authorization payload Backstage's handler page

--- a/internal/lab/browser.go
+++ b/internal/lab/browser.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // BrowserLogin runs the real OIDC authorization-code flow: opens the browser

--- a/internal/lab/down.go
+++ b/internal/lab/down.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // Down destroys the kind cluster. Certs are kept: the CA is only worth

--- a/internal/lab/flux.go
+++ b/internal/lab/flux.go
@@ -1,7 +1,7 @@
 package lab
 
 import (
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // fluxChartVersion pins the fluxcd-community flux2 chart (Flux v2.9.1),

--- a/internal/lab/kubeconfig.go
+++ b/internal/lab/kubeconfig.go
@@ -6,7 +6,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 const (

--- a/internal/lab/login.go
+++ b/internal/lab/login.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // Login performs the headless password-grant login, writes the raw id_token

--- a/internal/lab/oidc.go
+++ b/internal/lab/oidc.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // labDomain is the platform's public domain, set once at command start

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 const platformNamespace = "agent-platform"

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // PlatformTest is the headless end-to-end proof: Dex login -> muster

--- a/internal/lab/postrender.go
+++ b/internal/lab/postrender.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // PostRender is the Helm post-renderer for the agent-platform-standalone

--- a/internal/lab/postrender_test.go
+++ b/internal/lab/postrender_test.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 const postRenderInput = `---

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // The lab's image rule: images are ALWAYS pulled on the HOST and side-loaded

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 //go:embed templates/*.tmpl templates/static/*

--- a/internal/lab/test.go
+++ b/internal/lab/test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // Test is the end-to-end RBAC proof: every configured user gets a real token

--- a/internal/lab/trust.go
+++ b/internal/lab/trust.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/smallstep/truststore"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // Trust installs the lab CA into the system trust store (one sudo prompt)

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // Up brings up the whole lab: certs, kind cluster, Dex, RBAC, an end-to-end

--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/giantswarm/agentplatform-kind/internal/config"
-	"github.com/giantswarm/agentplatform-kind/internal/forms"
-	"github.com/giantswarm/agentplatform-kind/internal/lab"
+	"github.com/giantswarm/agentlab/internal/config"
+	"github.com/giantswarm/agentlab/internal/forms"
+	"github.com/giantswarm/agentlab/internal/lab"
 )
 
 func main() {


### PR DESCRIPTION
The repository was renamed from `agentplatform-kind` to `agentlab` to match the CLI it ships (bumblebee decision). This aligns everything inside the repo with the new name:

- `go.mod` module path and all internal imports
- CircleCI `binary` name, so release assets become `agentlab-<os>-<arch>`
- git-cliff `remote.github.repo`
- README install instructions — `go install github.com/giantswarm/agentlab@latest` now lands the binary as `agentlab` directly, no rename step needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)