### PR TITLE
fix: drop vestigial x/mod replace pin so go install works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,5 +40,3 @@ require (
 	golang.org/x/sys v0.47.0 // indirect
 	howett.net/plist v1.0.0 // indirect
 )
-
-replace golang.org/x/mod => golang.org/x/mod v0.40.0


### PR DESCRIPTION
`golang.org/x/mod` dropped out of the module graph entirely (verified: `go list -m all` has no x/mod after tidy), so the nancy CVE pin no longer protects anything. Removing it unblocks `go install github.com/giantswarm/agentlab@latest`, which refuses any module with replace directives — acceptance criterion of #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)