### PR TITLE
feat: bump default apsRef to agent-platform-standalone main (backstage 0.201.0)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,7 +193,7 @@ func Default() *Config {
 			Domain:      "127.0.0.1.nip.io",
 			GatewayPort: 443,
 			APSRepo:     "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:      "ee2eeac0aeea55603805bcdabb65adc9138746e2", // main: backstage 0.200.26 (#49) — first multi-arch image (arm64), Deployments pages degrade without Mimir
+			APSRef:      "a6d2c0f197de4197c897cfef906f5ed4f4804fa4", // main: backstage 0.201.0 (#54) — sessions can be continued from the portal
 		},
 		Backstage: Backstage{
 			Enabled: true,


### PR DESCRIPTION
Bumps the default `platform.apsRef` to agent-platform-standalone `a6d2c0f1` (giantswarm/agent-platform-standalone#54), which pins **backstage 0.201.0**.

backstage 0.201.0 ships giantswarm/backstage#2172: a message composer on the Agent Platform session detail page — sessions can be continued from the portal.

Verified in this lab (kind, full platform): created a declarative kagent agent, seeded a session via A2A under kagent's default user, then in the portal opened the session, sent a follow-up from the composer, and the agent's context-aware reply arrived through the existing polling. The sessions list correctly shows the "not scoped to you" banner because lab kagent runs without per-user identity.

Part of giantswarm/giantswarm#37559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)