### PR TITLE
feat: Backstage Deployments/Clusters metrics from the lab Prometheus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,10 @@ with Dex doing the logins.
   to answer CPU/memory questions about the lab. Chart pins are Go consts in
   `internal/lab/observability.go`; the bundle itself is deliberately NOT
   installed (MC-shaped: Flux HelmReleases, Alloy -> Mimir, no local PromQL).
+  Backstage's Clusters/Deployments metrics work too: the lab serves the
+  Mimir-shaped endpoint (`observability.<domain>/prometheus` on the edge →
+  the lab Prometheus) and overrides the umbrella's `mimirEnabled: false` in
+  its app-config overlay (backstage-catalog.yaml.tmpl).
 - The agents runtime (kagent) installs with the platform by default but is
   optional (`platform.agents` in `agentlab.yaml`) — on real clusters agent
   delivery runs through Flux/GitOps, which the lab does not run as a GitOps

--- a/README.md
+++ b/README.md
@@ -329,11 +329,28 @@ lab Prometheus scrapes them (its monitor/rule selectors are opened with
 `*NilUsesHelmValues: false` — upstream's default would only select monitors
 carrying the kps release label).
 
+**Backstage's own metrics views ride along too.** The Clusters and
+Deployments pages query Mimir through gs-backend's `MimirService`, hardcoded
+to `https://observability.<baseDomain>/prometheus/api/v1/query`; the umbrella
+sets `mimirEnabled: false` because standalone installations have no such
+endpoint. With observability on, the lab provides exactly that endpoint — an
+HTTPRoute on the edge (`observability.<domain>`, `/prometheus` prefix-strip →
+the lab Prometheus, whose query API is what Mimir's is compatible with) — and
+overrides `mimirEnabled: true` in its app-config overlay. The gs frontend
+attributes samples without Mimir's `cluster_id` label to the installation
+itself, which is exactly right for a single-cluster lab, so the
+Deployments/Clusters metrics show real numbers. Note the endpoint is
+unauthenticated read-only PromQL on the (localhost-only) lab edge: a real MC
+fronts it with an auth gateway validating the Bearer token, plain Prometheus
+ignores it — wider than muster's OAuth, accepted for the lab.
+
 `agentlab platform-test` grows a phase when the component is on: it lists the
 `x_mcp-prometheus_*` tools through muster, runs `execute_query` with `up`,
-and then asserts the platform itself is being scraped (muster, valkey,
-mcp-prometheus, and kagent when agents run all report `up == 1`), proving
-Dex → muster → mcp-prometheus → Prometheus end to end. Logs:
+asserts the platform itself is being scraped (muster, valkey,
+mcp-prometheus, and kagent when agents run all report `up == 1`), and then
+runs the Deployments page's exact workload query against the edge
+observability endpoint — proving Dex → muster → mcp-prometheus → Prometheus
+and the Backstage metrics path end to end. Logs:
 `agentlab logs prometheus`, `agentlab logs mcp-prometheus`.
 
 ### Why `localhost` and not `127.0.0.1`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -431,6 +431,14 @@ func (c *Config) MusterDirectURL() string {
 // BackstageBaseURL is Backstage's public URL through the agentgateway edge.
 func (c *Config) BackstageBaseURL() string { return c.gatewayURL("backstage") }
 
+// ObservabilityBaseURL is the lab Prometheus's public query API through the
+// edge, at the /prometheus prefix Backstage's Mimir integration expects
+// (observability-route.yaml.tmpl). Backstage itself always dials it in-cluster
+// on 443 (the CoreDNS rewrite), so only host-side callers see GatewayPort.
+func (c *Config) ObservabilityBaseURL() string {
+	return c.gatewayURL("observability") + "/prometheus"
+}
+
 // BackstageDirectURL bypasses the edge (hostNetwork port mapping), kept for
 // debugging.
 func (c *Config) BackstageDirectURL() string {

--- a/internal/lab/observability.go
+++ b/internal/lab/observability.go
@@ -81,6 +81,18 @@ func observabilityUp(cfg *config.Config) error {
 	}
 	note("Prometheus is serving (PromQL inside the cluster: http://prometheus-operated.%s:9090)",
 		observabilityNamespace)
+
+	// The edge route Backstage's Mimir integration queries
+	// (observability-route.yaml.tmpl); paired with the mimirEnabled override
+	// in backstage-catalog.yaml.tmpl. Applied regardless of Backstage so the
+	// endpoint is also there for humans and platform-test.
+	if _, routePath, err := renderManifest(cfg, "observability-route.yaml.tmpl"); err != nil {
+		return err
+	} else if err := runQuiet("kubectl", "apply", "-f", routePath); err != nil {
+		return err
+	}
+	note("PromQL on the edge: %s/api/v1/query (what Backstage's Deployments/Clusters metrics use)",
+		cfg.ObservabilityBaseURL())
 	return nil
 }
 

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -242,8 +242,15 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		// mounted into the chart's Backstage; must exist before the pod starts.
 		if _, catalogPath, err := renderManifest(cfg, "backstage-catalog.yaml.tmpl"); err != nil {
 			return err
-		} else if err := runQuiet("kubectl", "apply", "-f", catalogPath); err != nil {
+		} else if applied, err := output("kubectl", "apply", "-f", catalogPath); err != nil {
 			return err
+		} else if strings.Contains(applied, "configured") {
+			// Backstage reads app-config at startup only, so a changed overlay
+			// (e.g. flipping platform.observability toggles mimirEnabled) needs
+			// a pod roll on re-runs. Started here and absorbed by the umbrella
+			// install's --wait right below; on a fresh install the deployment
+			// does not exist yet and the first pod reads the final config.
+			_ = runQuiet("kubectl", "-n", platformNamespace, "rollout", "restart", "deploy/backstage")
 		}
 		// The create flow's Deploy button kube:applies Flux CRs; these two
 		// controllers are the delivery engine that turns them into an

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -238,6 +239,35 @@ func PlatformTest(cfg *config.Config, email string) error {
 		}
 		note("all platform targets are up: %s", strings.Join(expected, ", "))
 		verdict += "\nPASS: Claude Code -> muster (Dex) -> mcp-prometheus -> Prometheus (platform targets scraped)"
+
+		// The Backstage metrics path: gs-backend's MimirService queries
+		// https://observability.<domain>/prometheus/api/v1/query — the lab
+		// serves it via observability-route.yaml.tmpl. Run the exact
+		// workload query shape the Deployments page uses and expect the
+		// muster deployment in the answer (present whenever the platform
+		// runs, unlike backstage's own).
+		obsQueryURL := cfg.ObservabilityBaseURL() + "/api/v1/query?query=" +
+			url.QueryEscape(`max without(app, container, customer, endpoint, instance, job, pipeline, pod, provider, region, service, service_priority) (kube_deployment_spec_replicas)`)
+		step("Querying the Backstage metrics endpoint on the edge (%s)", cfg.ObservabilityBaseURL())
+		body := ""
+		answered := waitFor(10, 3*time.Second, func() bool {
+			resp, err := client.Get(obsQueryURL)
+			if err != nil {
+				return false
+			}
+			defer func() { _ = resp.Body.Close() }()
+			raw, _ := io.ReadAll(resp.Body)
+			body = string(raw)
+			return resp.StatusCode == http.StatusOK &&
+				strings.Contains(body, `"deployment":"muster"`)
+		})
+		if !answered {
+			return fmt.Errorf("the edge observability endpoint never answered the Deployments-page query "+
+				"(last body: %.200s);\ncheck `kubectl -n monitoring get httproute observability` and the edge",
+				body)
+		}
+		note("the Deployments-page query answers through the edge (deployment=muster found)")
+		verdict += "\nPASS: Backstage metrics path -> edge -> Prometheus (Mimir-shaped /prometheus API)"
 	}
 
 	fmt.Println()

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -133,6 +133,7 @@ var manifests = map[string]struct {
 	"flux-values.yaml.tmpl":                  {out: "flux-values.yaml"},
 	"kube-prometheus-stack-values.yaml.tmpl": {out: "kube-prometheus-stack-values.yaml"},
 	"mcp-prometheus-values.yaml.tmpl":        {out: "mcp-prometheus-values.yaml"},
+	"observability-route.yaml.tmpl":          {out: "observability-route.yaml"},
 	"demo-workflow.yaml.tmpl":                {out: "demo-workflow.yaml"},
 	"coredns.yaml.tmpl":                      {out: "coredns.yaml"},
 	"gateway-nodeport.yaml.tmpl":             {out: "gateway-nodeport.yaml"},

--- a/internal/lab/templates/backstage-catalog.yaml.tmpl
+++ b/internal/lab/templates/backstage-catalog.yaml.tmpl
@@ -78,3 +78,25 @@ data:
           target: /lab-catalog/agent-deployment-template.yaml
           rules:
             - allow: [Template]
+{{- if .Platform.Observability }}
+    # The umbrella hardcodes mimirEnabled: false — standalone installations
+    # have no GS observability stack at observability.<baseDomain>. With
+    # platform.observability the lab provides exactly that endpoint
+    # (observability-route.yaml.tmpl: the lab Prometheus's query API behind
+    # the Mimir-shaped /prometheus prefix), so the override turns the
+    # Deployments/Clusters metrics back on. Deep-merged over the umbrella's
+    # app-config (this file is listed after it in extraAppConfig), and the
+    # gs frontend's cluster_id fallback maps every sample to this
+    # installation — right for a single-cluster lab.
+    #
+    # The key is the umbrella's Helm RELEASE name (its app-config registers
+    # gs.installations.<release name>), NOT the cluster name — same trap as
+    # backstagetest.go's `?installation=` parameter. Any other key creates a
+    # SECOND installation without authProvider, which the gs frontend skips
+    # with a console warning while the override silently lands on the wrong
+    # entry.
+    gs:
+      installations:
+        agent-platform:
+          mimirEnabled: true
+{{- end }}

--- a/internal/lab/templates/observability-route.yaml.tmpl
+++ b/internal/lab/templates/observability-route.yaml.tmpl
@@ -1,0 +1,53 @@
+# Publishes the lab Prometheus's query API on the edge at the URL Backstage's
+# MimirService is hardcoded to: https://observability.<baseDomain>/prometheus
+# (gs-backend queries <that>/api/v1/query with the signed-in user's OIDC
+# token). Mimir's query API is Prometheus-compatible and the gs frontend
+# falls back to the installation name when the Mimir-only cluster_id label is
+# absent, so the plain lab Prometheus behind a /prometheus prefix-strip is a
+# drop-in — this is what puts real numbers on the Deployments/Clusters pages
+# (paired with the mimirEnabled override in backstage-catalog.yaml.tmpl).
+#
+# The endpoint is unauthenticated read-only PromQL on the lab edge: a real MC
+# fronts observability.<baseDomain> with an auth gateway that validates the
+# Bearer token; plain Prometheus ignores it. Same lab stance as the rest of
+# the edge (localhost-only kind mapping), just wider than muster's OAuth —
+# called out in README.md.
+#
+# Lives in the observability namespace so the backendRef needs no
+# ReferenceGrant (the umbrella's kagent UI route uses the same pattern); the
+# Gateway name/namespace are the chart-owned edge, hardcoded like
+# gateway-nodeport.yaml.tmpl. Only the /prometheus prefix is routed — the
+# Prometheus web UI's absolute asset paths would need / and are not the
+# point.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: observability
+  namespace: monitoring
+  labels:
+    app: agentlab
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: agentgateway
+      namespace: agent-platform
+      sectionName: https
+  hostnames:
+    - observability.{{ .Platform.Domain }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /prometheus
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /
+      backendRefs:
+        # The operator-owned headless Service, same name-stability argument
+        # as PROMETHEUS_URL in mcp-prometheus-values.yaml.tmpl.
+        - name: prometheus-operated
+          port: 9090


### PR DESCRIPTION
## What

With `platform.observability` on, Backstage's own metrics views (Deployments, Clusters) now work against the lab Prometheus — follow-up to #37, which wired metrics only into the muster/MCP path.

- **Edge route**: `observability.<domain>/prometheus` → prefix-strip → `prometheus-operated.monitoring:9090` (HTTPRoute in the monitoring namespace, kagent-UI-route pattern, no ReferenceGrant needed). This is the exact URL gs-backend's `MimirService` hardcodes (`https://observability.<baseDomain>/prometheus/api/v1/query`); Mimir's query API is Prometheus-compatible, and the gs frontend attributes samples without Mimir's `cluster_id` label to the installation itself — right for a single-cluster lab.
- **`mimirEnabled: true` override** in the lab's app-config overlay, deep-merged over the umbrella's hardcoded `false`. The key is the umbrella's **release** name (`agent-platform`), not the cluster name — any other key silently creates a second installation the gs frontend skips ("OIDC auth provider is not configured"), found the hard way and documented in the template.
- **App-config changes now roll the Backstage pod** on platform re-runs (app-config is read at startup only); the umbrella install's `--wait` absorbs the roll. Fresh installs are unaffected (the CM exists before the pod starts).
- **platform-test grows a phase**: runs the Deployments page's exact workload query (`max without(...) (kube_deployment_spec_replicas)`) against the edge endpoint and expects the muster deployment.

## Trade-off

The endpoint is unauthenticated read-only PromQL on the (localhost-only) lab edge: a real MC fronts `observability.<baseDomain>` with an auth gateway validating the Bearer token; plain Prometheus ignores it. Wider than muster's OAuth — called out in the README.

## Tested live

- agentgateway accepts the route (Accepted/ResolvedRefs) and honors `URLRewrite ReplacePrefixMatch`; the MimirService-shaped query answers through the edge from the host (lab CA) and from inside the Backstage pod (CoreDNS rewrite + NODE_EXTRA_CA_CERTS).
- `agentlab platform` re-run: CM change rolled Backstage once; `platform-test` passes all phases including the new one.
- In the portal (signed in as Lab Admin): the Deployments page lists **all 23 lab workloads** (Deployments/StatefulSets/DaemonSets + the created agent's HelmRelease) with status, replicas, versions and labels — entirely served by the lab Prometheus; the workload details pane shows desired/ready replicas and labels.
- `go test ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)