### PR TITLE
feat: fresh configs pick free host ports and say what moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ agentgateway edge, Backstage on, three users, Dex on 32000.
 `--backstage=false` skips the portal. On a plain terminal or screen reader,
 `agentlab configure --accessible` runs the form as one prompt per question.
 
+When a **new** configuration is created (interactively or via `--defaults`),
+every host-side port is probed on 127.0.0.1 first — the address all kind port
+mappings bind — and any default that is already occupied is moved to a nearby
+free port, with a message saying what moved where (443 falls back to 8443).
+An existing `agentlab.yaml` is never renumbered: its cluster's port mappings
+are already fixed, and while the lab runs its own ports would probe as
+occupied.
+
 To exercise the identity itself:
 
 ```bash

--- a/internal/config/ports.go
+++ b/internal/config/ports.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// PortChange records one port of a freshly created configuration that was
+// moved off its default because something on this machine already listens
+// there. Field is the agentlab.yaml path, What names the component for the
+// human-facing message, Note carries an extra caveat where a non-default
+// port has consequences beyond the number itself.
+type PortChange struct {
+	Field    string
+	What     string
+	From, To int
+	Note     string
+}
+
+func (ch PortChange) String() string {
+	s := fmt.Sprintf("%s: %d is in use, using %d instead (%s", ch.Field, ch.From, ch.To, ch.What)
+	if ch.Note != "" {
+		s += "; " + ch.Note
+	}
+	return s + ")"
+}
+
+// ChooseFreePorts probes every host-side port of a freshly created
+// configuration on 127.0.0.1 — the address all kind port mappings bind — and
+// moves each occupied one to a nearby free port, returning what changed so
+// the caller can tell the user. Meant for new configs only: an existing
+// agentlab.yaml describes a cluster whose mappings are already fixed, where
+// silently renumbering would only mislead.
+func (c *Config) ChooseFreePorts() []PortChange {
+	return c.chooseFreePorts(portTaken)
+}
+
+// chooseFreePorts is ChooseFreePorts with the probe injected, so tests can
+// run against a fixed set of "occupied" ports instead of the machine.
+func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
+	// Every port with a fixed meaning in the lab, so replacements never
+	// collide with each other or with it: the config's own host ports, the
+	// browser-login callback (host-side, pre-registered in Dex), and the
+	// pinned NodePorts (they share the node's port space with DexPort's
+	// NodePort, and keeping host ports off them avoids same-number
+	// coincidences in debugging).
+	reserved := map[int]bool{
+		c.DexPort:              true,
+		c.Backstage.Port:       true,
+		c.Platform.MusterPort:  true,
+		c.Platform.AgentsPort:  true,
+		c.Platform.GatewayPort: true,
+		BrowserCallbackPort:    true,
+		MusterNodePort:         true,
+		KagentUINodePort:       true,
+		GatewayNodePort:        true,
+	}
+
+	scan := func(lo, hi int) (int, bool) {
+		for p := lo; p <= hi; p++ {
+			if !reserved[p] && !taken(p) {
+				return p, true
+			}
+		}
+		return 0, false
+	}
+
+	var changes []PortChange
+	move := func(field, what string, port *int, pick func() (int, bool), note func(to int) string) {
+		if !taken(*port) {
+			return
+		}
+		to, ok := pick()
+		if !ok {
+			// Nowhere to go (the range is exhausted); leave the port alone
+			// and let `agentlab up` fail with the real bind error.
+			return
+		}
+		reserved[to] = true
+		ch := PortChange{Field: field, What: what, From: *port, To: to}
+		if note != nil {
+			ch.Note = note(to)
+		}
+		changes = append(changes, ch)
+		*port = to
+	}
+	noNote := func(int) string { return "" }
+
+	// Dex must stay in the NodePort range (host port == NodePort); scan
+	// upward from the default and wrap around the range.
+	move("dexPort", "the Dex issuer", &c.DexPort, func() (int, bool) {
+		if p, ok := scan(c.DexPort+1, 32767); ok {
+			return p, true
+		}
+		return scan(30000, c.DexPort-1)
+	}, noNote)
+
+	move("platform.musterPort", "muster's direct debug access", &c.Platform.MusterPort, func() (int, bool) {
+		return scan(c.Platform.MusterPort+1, 65535)
+	}, noNote)
+
+	move("platform.agentsPort", "the kagent UI", &c.Platform.AgentsPort, func() (int, bool) {
+		return scan(c.Platform.AgentsPort+1, 65535)
+	}, noNote)
+
+	// The edge prefers 8443 over 444: dodging the whole privileged range
+	// keeps later probes honest (they can bind instead of dial), and 8443 is
+	// the conventional alternate HTTPS port.
+	move("platform.gatewayPort", "the agentgateway edge", &c.Platform.GatewayPort, func() (int, bool) {
+		lo := c.Platform.GatewayPort + 1
+		if c.Platform.GatewayPort < 1024 {
+			lo = 8443
+		}
+		return scan(lo, 65535)
+	}, func(to int) string {
+		return fmt.Sprintf("public URLs gain :%d; the chart's Backstage app-config assumes a port-free baseUrl, expect rough edges", to)
+	})
+
+	move("backstage.port", "Backstage's direct debug access", &c.Backstage.Port, func() (int, bool) {
+		return scan(c.Backstage.Port+1, 65535)
+	}, noNote)
+
+	return changes
+}
+
+// portTaken reports whether anything on this machine already occupies
+// 127.0.0.1:<port>, the exact address every kind port mapping binds. A bind
+// probe catches every listener (including 0.0.0.0 binds, which conflict with
+// a later 127.0.0.1 bind); privileged ports (the gateway's 443) may refuse
+// the bind with EACCES even when free — docker binds those as root — so they
+// fall back to dialing, where only an actual listener answers.
+func portTaken(port int) bool {
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	l, err := net.Listen("tcp", addr)
+	if err == nil {
+		_ = l.Close()
+		return false
+	}
+	if errors.Is(err, syscall.EADDRINUSE) {
+		return true
+	}
+	conn, err := net.DialTimeout("tcp", addr, 250*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/internal/config/ports_test.go
+++ b/internal/config/ports_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"net"
+	"testing"
+)
+
+// takenSet builds a probe stub that reports exactly the given ports occupied.
+func takenSet(ports ...int) func(int) bool {
+	set := map[int]bool{}
+	for _, p := range ports {
+		set[p] = true
+	}
+	return func(p int) bool { return set[p] }
+}
+
+func TestChooseFreePortsNothingTaken(t *testing.T) {
+	cfg := Default()
+	want := Default()
+	if changes := cfg.chooseFreePorts(takenSet()); len(changes) != 0 {
+		t.Fatalf("expected no changes, got %v", changes)
+	}
+	got := []int{cfg.DexPort, cfg.Platform.MusterPort, cfg.Platform.AgentsPort, cfg.Platform.GatewayPort, cfg.Backstage.Port}
+	exp := []int{want.DexPort, want.Platform.MusterPort, want.Platform.AgentsPort, want.Platform.GatewayPort, want.Backstage.Port}
+	for i := range got {
+		if got[i] != exp[i] {
+			t.Fatalf("port mutated without conflicts: got %v, want %v", got, exp)
+		}
+	}
+}
+
+func TestChooseFreePortsMovesEveryTakenPort(t *testing.T) {
+	cfg := Default()
+	changes := cfg.chooseFreePorts(takenSet(
+		cfg.DexPort, cfg.Platform.MusterPort, cfg.Platform.AgentsPort,
+		cfg.Platform.GatewayPort, cfg.Backstage.Port,
+	))
+	if len(changes) != 5 {
+		t.Fatalf("expected 5 changes, got %d: %v", len(changes), changes)
+	}
+	if cfg.DexPort != 32001 {
+		t.Errorf("dexPort = %d, want 32001", cfg.DexPort)
+	}
+	if cfg.Platform.MusterPort != 8091 {
+		t.Errorf("musterPort = %d, want 8091", cfg.Platform.MusterPort)
+	}
+	if cfg.Platform.AgentsPort != 8082 {
+		t.Errorf("agentsPort = %d, want 8082", cfg.Platform.AgentsPort)
+	}
+	if cfg.Platform.GatewayPort != 8443 {
+		t.Errorf("gatewayPort = %d, want 8443", cfg.Platform.GatewayPort)
+	}
+	if cfg.Backstage.Port != 7008 {
+		t.Errorf("backstage.port = %d, want 7008", cfg.Backstage.Port)
+	}
+	for _, ch := range changes {
+		if ch.Field == "" || ch.What == "" || ch.From == ch.To {
+			t.Errorf("malformed change: %+v", ch)
+		}
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("moved config no longer validates: %v", err)
+	}
+}
+
+// The kagent UI scan must hop over the muster default (8090): it is another
+// lab port even when muster itself did not need to move.
+func TestChooseFreePortsSkipsOtherLabPorts(t *testing.T) {
+	cfg := Default()
+	occupied := []int{cfg.Platform.AgentsPort} // 8081
+	for p := 8082; p <= 8089; p++ {
+		occupied = append(occupied, p)
+	}
+	cfg.chooseFreePorts(takenSet(occupied...))
+	if cfg.Platform.AgentsPort != 8091 {
+		t.Fatalf("agentsPort = %d, want 8091 (8090 is muster's)", cfg.Platform.AgentsPort)
+	}
+}
+
+func TestChooseFreePortsGatewayPrefers8443(t *testing.T) {
+	cfg := Default()
+	changes := cfg.chooseFreePorts(takenSet(443, 8443))
+	if cfg.Platform.GatewayPort != 8444 {
+		t.Fatalf("gatewayPort = %d, want 8444", cfg.Platform.GatewayPort)
+	}
+	if len(changes) != 1 || changes[0].Note == "" {
+		t.Fatalf("expected one gateway change carrying the non-443 note, got %v", changes)
+	}
+}
+
+func TestChooseFreePortsDexWrapsWithinNodePortRange(t *testing.T) {
+	cfg := Default()
+	var occupied []int
+	for p := cfg.DexPort; p <= 32767; p++ {
+		occupied = append(occupied, p)
+	}
+	cfg.chooseFreePorts(takenSet(occupied...))
+	if cfg.DexPort != 30000 {
+		t.Fatalf("dexPort = %d, want 30000 (wrap to the bottom of the NodePort range)", cfg.DexPort)
+	}
+}
+
+// Two ports moving in the same run must not land on the same replacement.
+func TestChooseFreePortsReplacementsDoNotCollide(t *testing.T) {
+	cfg := Default()
+	cfg.Platform.MusterPort = 9000
+	cfg.Platform.AgentsPort = 9001
+	cfg.chooseFreePorts(takenSet(9000, 9001))
+	if cfg.Platform.MusterPort == cfg.Platform.AgentsPort {
+		t.Fatalf("muster and agents both landed on %d", cfg.Platform.MusterPort)
+	}
+	if cfg.Platform.MusterPort != 9002 || cfg.Platform.AgentsPort != 9003 {
+		t.Fatalf("musterPort = %d, agentsPort = %d; want 9002 and 9003",
+			cfg.Platform.MusterPort, cfg.Platform.AgentsPort)
+	}
+}
+
+// When a range holds no free port at all, the original stays put (and `up`
+// reports the real bind error) instead of looping or panicking.
+func TestChooseFreePortsExhaustedRangeKeepsPort(t *testing.T) {
+	cfg := Default()
+	cfg.chooseFreePorts(func(int) bool { return true })
+	if cfg.DexPort != 32000 {
+		t.Fatalf("dexPort = %d, want the untouched 32000", cfg.DexPort)
+	}
+}
+
+func TestPortTakenProbe(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	if !portTaken(port) {
+		t.Errorf("port %d has a listener but probes free", port)
+	}
+	_ = l.Close()
+	if portTaken(port) {
+		t.Errorf("port %d is closed but probes taken", port)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -116,6 +116,7 @@ func loadOrCreateConfig() (*config.Config, error) {
 	}
 	fmt.Printf("No %s yet — let's create one.\n\n", config.File)
 	cfg = config.Default()
+	reportPortChanges(cfg.ChooseFreePorts())
 	if err := forms.Run(cfg, accessibleMode()); err != nil {
 		return nil, err
 	}
@@ -124,6 +125,21 @@ func loadOrCreateConfig() (*config.Config, error) {
 	}
 	fmt.Printf("Saved %s.\n\n", config.File)
 	return cfg, nil
+}
+
+// reportPortChanges tells the user which default ports were already occupied
+// on this machine and what the fresh configuration uses instead. The form (or
+// the saved file) shows the adjusted numbers, but only this message explains
+// why they differ from the documented defaults.
+func reportPortChanges(changes []config.PortChange) {
+	if len(changes) == 0 {
+		return
+	}
+	fmt.Println("Some default ports are already in use on this machine; picked free ones:")
+	for _, ch := range changes {
+		fmt.Printf("  %s\n", ch)
+	}
+	fmt.Println()
 }
 
 // accessibleMode switches huh to its prompt-per-question accessible mode;
@@ -142,7 +158,12 @@ func configureCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if errors.Is(err, os.ErrNotExist) {
+				// Only a FRESH config gets its ports moved off occupied
+				// defaults: an existing agentlab.yaml describes a cluster
+				// whose kind mappings are already fixed (and would count as
+				// "occupied" themselves while the lab runs).
 				cfg = config.Default()
+				reportPortChanges(cfg.ChooseFreePorts())
 			} else if err != nil {
 				return err
 			}


### PR DESCRIPTION
## What

When agentlab creates a **new** default configuration (the interactive form on first run, or `configure --defaults`), it now detects host ports that are already in use, picks nearby free ones, and tells the user what moved where:

```
Some default ports are already in use on this machine; picked free ones:
  platform.musterPort: 8090 is in use, using 8092 instead (muster's direct debug access)
  platform.agentsPort: 8081 is in use, using 8082 instead (the kagent UI)
  backstage.port: 7007 is in use, using 7008 instead (Backstage's direct debug access)
```

## How

- Probes every host-side port (`dexPort`, `platform.musterPort`, `platform.agentsPort`, `platform.gatewayPort`, `backstage.port`) on **127.0.0.1** — the exact address every kind port mapping binds. Bind probe first (also catches 0.0.0.0 listeners); privileged ports (the gateway's 443) fall back to a dial probe, since docker binds those as root while the probe runs unprivileged.
- Replacements scan upward and skip the lab's other ports (the config's own ports, the fixed 5555 browser callback, the pinned NodePorts), so two moves in one run never collide. Dex wraps within the NodePort range 30000-32767; 443 falls back to the conventional 8443, with a note that public URLs gain the port.
- **Existing `agentlab.yaml` files are never renumbered**: their cluster's kind mappings are already fixed, and while the lab runs its own ports would probe as occupied.
- Deterministic unit tests via an injected probe, plus one real-listener probe test.

## Verified

- `go test ./...`, `go vet`, `golangci-lint run -E gosec -E goconst` clean.
- Live: bound 8081+7007, ran `configure --defaults` → output above, yaml carries 8082/7008 (and it caught this machine's real 8090/8091 occupants). Re-running with the existing yaml changes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)