### PR TITLE
feat: bump default apsRef to agent-platform-standalone main (backstage 0.203.0)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,7 +204,7 @@ func Default() *Config {
 			Domain:        "127.0.0.1.nip.io",
 			GatewayPort:   443,
 			APSRepo:       "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:        "7d6f12b6781ba1013c3939aa8e652fcb76dbace2", // main: backstage 0.202.0 (#55) — start sessions and answer agent questions from the portal
+			APSRef:        "50f0d84ce81f470330bbe8766c0eb171a88a2395", // main: backstage 0.203.0 (#59) — stream agent replies in the portal session view
 		},
 		Backstage: Backstage{
 			Enabled: true,


### PR DESCRIPTION
Points fresh labs at agent-platform-standalone `50f0d84` (v0.7.0), which pins backstage 0.203.0 — the session view now streams the agent's reply as it is produced ([giantswarm/backstage#2178](https://github.com/giantswarm/backstage/pull/2178), part of giantswarm/giantswarm#37572). Verified in a lab against a dev image of the same code before the release: sends go over the new `messages/stream` relay, first byte ~20 ms in, replies render once with clean poll reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)