### PR TITLE
feat: add extra model configs for the agents (platform.extraModels)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ with Dex doing the logins.
   deploy time and lives only in the Secrets `kagent/kagent-anthropic` and
   `backstage/backstage-anthropic` — never in `agentlab.yaml` or `state/`.
   Never inline a real key in config, templates, or rendered values.
+  `platform.extraModels` adds further ModelConfigs (self-hosted
+  OpenAI-compatible endpoints, OpenRouter, Gemini, Ollama) with the same
+  env-var -> Secret key handling; entries removed from the config are pruned
+  on the next run (see README "Extra model configs").
 - For verifying RBAC as a specific user, use `./agentlab login <email>` and
   `kubectl --kubeconfig kubeconfig.oidc` — that is the OIDC path.
 - The kind admin context (`kind-agentlab`) bypasses the platform and OIDC

--- a/README.md
+++ b/README.md
@@ -292,6 +292,67 @@ pointing agents at muster; note that kagent forwards the *caller's* token to
 muster, so agent tool calls through muster need a real Dex token on the way
 in — headless pokes at the unsecured controller API won't have one.
 
+### Extra model configs (self-hosted, OpenRouter, Gemini, OpenAI)
+
+Beyond the default Anthropic ModelConfig, `platform.extraModels` in
+`agentlab.yaml` adds more — a self-hosted OpenAI-compatible endpoint (vLLM,
+llama.cpp, LM Studio), OpenRouter, Gemini, a plain GPT model, or an Ollama
+host. Each entry becomes a lab-labeled `ModelConfig` CR in the `kagent`
+namespace, selectable when composing an agent (the kagent UI's model dropdown,
+or `modelConfig` on an `Agent` CR):
+
+```yaml
+platform:
+  extraModels:
+    # A self-hosted vLLM — any OpenAI-compatible endpoint works the same way.
+    # No apiKeyEnv: the endpoint is keyless, a placeholder key is shipped.
+    - name: qwen3-8-27b
+      provider: OpenAI
+      model: qwen3-8-27b
+      baseUrl: https://qwen.example.internal/v1
+    # OpenRouter: also just an OpenAI-compatible endpoint plus a key.
+    - name: openrouter-deepseek
+      provider: OpenAI
+      model: deepseek/deepseek-chat
+      baseUrl: https://openrouter.ai/api/v1
+      apiKeyEnv: OPENROUTER_API_KEY
+    - name: gemini-flash
+      provider: Gemini
+      model: gemini-2.5-flash
+      apiKeyEnv: GEMINI_API_KEY
+    - name: local-llama
+      provider: Ollama
+      model: llama3.3
+      baseUrl: http://192.168.1.10:11434
+```
+
+`agentlab configure` asks for these interactively (the "extra model configs"
+confirm in the platform group); `agentlab platform` (or `agentlab up`)
+applies them and waits for the kagent controller to accept each one. Entries
+removed from `agentlab.yaml` are **pruned** on the next run — the managed-by
+label scopes the pruning to lab-created ModelConfigs, so the chart's default
+one is never touched.
+
+Key handling follows the Anthropic pattern: `apiKeyEnv` names a host env var
+read at deploy time, and the value lands only in the Secret
+`kagent/kagent-<name>` (created once, left alone — delete it and re-run to
+rotate; never in `agentlab.yaml` or `state/`). The key *inside* the Secret is
+provider-derived (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`)
+because the kagent controller injects it as an env var of exactly that name
+and the ADK runtime looks up those canonical names. That is also why keyless
+endpoints still get a Secret with a placeholder value: the runtime requires
+the env var to *exist* — an agent pod without it crashloops before ever
+talking to the endpoint.
+
+Two practical notes for self-hosted endpoints: the URL must be reachable
+**from inside the kind node's pods** (a LAN IP or resolvable hostname —
+`localhost` would be the pod itself), and a self-signed certificate needs
+`insecureTLS: true` on the entry (rendered as the ModelConfig's
+`tls.disableVerify`). `Gemini` takes no `baseUrl` (the CRD has no endpoint
+field for it), and `Ollama` requires one (its `host`) and is keyless.
+Providers needing more than a model + endpoint + key (AzureOpenAI, Bedrock,
+Vertex) are out of the lab's vocabulary — create their ModelConfigs by hand.
+
 ### Observability (Prometheus + mcp-prometheus)
 
 An **optional component, on by default** (`platform.observability` in

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,21 +167,30 @@ type ExtraModel struct {
 	InsecureTLS bool `yaml:"insecureTLS,omitempty"`
 }
 
-// ModelProviders is the fixed provider vocabulary for extra models, mapped to
-// the key name inside the Secret. The kagent controller injects that key as
-// an env var of the same name into agent pods, and the ADK runtime looks up
-// exactly these canonical names — so the key name is provider-derived, not
-// configurable. Ollama is keyless (empty key = no Secret).
+// The provider vocabulary for extra models, spelled exactly as the kagent
+// ModelConfig CRD's provider enum spells them.
+const (
+	ProviderOpenAI    = "OpenAI"
+	ProviderAnthropic = "Anthropic"
+	ProviderGemini    = "Gemini"
+	ProviderOllama    = "Ollama"
+)
+
+// ModelProviders maps each provider to the key name inside the Secret. The
+// kagent controller injects that key as an env var of the same name into
+// agent pods, and the ADK runtime looks up exactly these canonical names —
+// so the key name is provider-derived, not configurable. Ollama is keyless
+// (empty key = no Secret).
 var ModelProviders = map[string]string{
-	"OpenAI":    "OPENAI_API_KEY",
-	"Anthropic": "ANTHROPIC_API_KEY",
-	"Gemini":    "GOOGLE_API_KEY",
-	"Ollama":    "",
+	ProviderOpenAI:    "OPENAI_API_KEY",
+	ProviderAnthropic: "ANTHROPIC_API_KEY",
+	ProviderGemini:    "GOOGLE_API_KEY",
+	ProviderOllama:    "",
 }
 
 // ModelProviderNames is ModelProviders' keys in a stable order, for the form
 // options and error messages.
-var ModelProviderNames = []string{"OpenAI", "Anthropic", "Gemini", "Ollama"}
+var ModelProviderNames = []string{ProviderOpenAI, ProviderAnthropic, ProviderGemini, ProviderOllama}
 
 // SecretName is the Kubernetes Secret (in ns kagent) holding this model's key.
 func (m ExtraModel) SecretName() string { return "kagent-" + m.Name }
@@ -404,11 +413,11 @@ func (m ExtraModel) Validate() error {
 		return fmt.Errorf("%s: apiKeyEnv %q: %w", m.Name, m.APIKeyEnv, err)
 	}
 	switch m.Provider {
-	case "Gemini":
+	case ProviderGemini:
 		if m.BaseURL != "" {
 			return fmt.Errorf("%s: Gemini takes no baseUrl (the ModelConfig CRD has no endpoint field for it)", m.Name)
 		}
-	case "Ollama":
+	case ProviderOllama:
 		if m.BaseURL == "" {
 			return fmt.Errorf("%s: Ollama requires baseUrl (the host serving the API, e.g. http://192.168.1.10:11434)", m.Name)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,7 +133,65 @@ type Platform struct {
 	// at this pinned SHA. Once released this becomes an OCI ref.
 	APSRepo string `yaml:"apsRepo"`
 	APSRef  string `yaml:"apsRef"`
+	// Additional kagent ModelConfigs beyond the chart-rendered default
+	// (aiModel): self-hosted OpenAI-compatible endpoints (vLLM, Ollama),
+	// OpenRouter, Gemini, plain OpenAI. Rendered as lab-labeled ModelConfig
+	// CRs by `agentlab platform`; entries removed here are pruned on the next
+	// run. Inert unless agents are enabled.
+	ExtraModels []ExtraModel `yaml:"extraModels,omitempty"`
 }
+
+// ExtraModel is one additional kagent ModelConfig. API keys are NOT config:
+// APIKeyEnv only names the host env var read at deploy time — the value lands
+// in the Secret kagent-<name>, never in this file or in rendered state/.
+type ExtraModel struct {
+	// ModelConfig CR name; also names the key Secret kagent-<name>.
+	Name string `yaml:"name"`
+	// One of ModelProviders (a subset of the kagent CRD's enum: the providers
+	// expressible with just a model + base URL).
+	Provider string `yaml:"provider"`
+	// The provider's model id (what the endpoint serves, e.g. `qwen3-8-27b`
+	// for a local vLLM or `deepseek/deepseek-chat` on OpenRouter).
+	Model string `yaml:"model"`
+	// Endpoint override. Required for Ollama (the in-cluster default would be
+	// useless), optional for OpenAI/Anthropic (any compatible endpoint:
+	// vLLM `http://host:8000/v1`, OpenRouter `https://openrouter.ai/api/v1`),
+	// not applicable to Gemini.
+	BaseURL string `yaml:"baseUrl,omitempty"`
+	// Host env var holding the API key at deploy time. Empty means a keyless
+	// endpoint: the Secret is still created with a placeholder, because the
+	// kagent ADK runtime requires the provider's env var to exist.
+	APIKeyEnv string `yaml:"apiKeyEnv,omitempty"`
+	// Skip TLS verification on the provider connection (ModelConfig spec.tls.
+	// disableVerify) — for self-hosted endpoints with self-signed certs.
+	InsecureTLS bool `yaml:"insecureTLS,omitempty"`
+}
+
+// ModelProviders is the fixed provider vocabulary for extra models, mapped to
+// the key name inside the Secret. The kagent controller injects that key as
+// an env var of the same name into agent pods, and the ADK runtime looks up
+// exactly these canonical names — so the key name is provider-derived, not
+// configurable. Ollama is keyless (empty key = no Secret).
+var ModelProviders = map[string]string{
+	"OpenAI":    "OPENAI_API_KEY",
+	"Anthropic": "ANTHROPIC_API_KEY",
+	"Gemini":    "GOOGLE_API_KEY",
+	"Ollama":    "",
+}
+
+// ModelProviderNames is ModelProviders' keys in a stable order, for the form
+// options and error messages.
+var ModelProviderNames = []string{"OpenAI", "Anthropic", "Gemini", "Ollama"}
+
+// SecretName is the Kubernetes Secret (in ns kagent) holding this model's key.
+func (m ExtraModel) SecretName() string { return "kagent-" + m.Name }
+
+// SecretKey is the key inside the Secret — the provider's canonical env var
+// name. Empty for keyless providers (no Secret attached at all).
+func (m ExtraModel) SecretKey() string { return ModelProviders[m.Provider] }
+
+// NeedsSecret reports whether this model's ModelConfig references a Secret.
+func (m ExtraModel) NeedsSecret() bool { return m.SecretKey() != "" }
 
 // PlatformTLS is an externally provisioned certificate for the edge; see
 // Platform.TLS.
@@ -291,12 +349,72 @@ func ValidateClusterName(s string) error {
 	return nil
 }
 
-// ValidateAIModel constrains the model to Anthropic: both consumers (the
-// kagent ModelConfig provider and Backstage's ai-chat prefix routing) are
-// wired for Anthropic only, keyed by the one $ANTHROPIC_API_KEY secret.
+// ValidateAIModel constrains the DEFAULT model to Anthropic: both consumers
+// (the kagent ModelConfig provider and Backstage's ai-chat prefix routing)
+// are wired for Anthropic only, keyed by the one $ANTHROPIC_API_KEY secret.
+// Other providers go through platform.extraModels instead.
 func ValidateAIModel(s string) error {
 	if !strings.HasPrefix(s, "claude-") {
-		return fmt.Errorf("must be a claude-* model (the lab only wires Anthropic)")
+		return fmt.Errorf("must be a claude-* model (other providers go in platform.extraModels)")
+	}
+	return nil
+}
+
+// reservedModelNames collide with what the kagent chart / the lab already
+// own: the chart-rendered default ModelConfig, and the name whose Secret
+// (kagent-anthropic) the default ModelConfig references.
+var reservedModelNames = []string{"default-model-config", "anthropic"}
+
+// ValidateModelName is the one home of the extra-model-name rule; the huh
+// form uses it directly as an input validator.
+func ValidateModelName(s string) error {
+	if !nameRe.MatchString(s) {
+		return fmt.Errorf("lowercase alphanumeric and dashes only")
+	}
+	if slices.Contains(reservedModelNames, s) {
+		return fmt.Errorf("%q is reserved (the default ModelConfig and its Secret)", s)
+	}
+	return nil
+}
+
+var envNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ValidateAPIKeyEnv accepts an env var name or empty (keyless endpoint).
+func ValidateAPIKeyEnv(s string) error {
+	if s != "" && !envNameRe.MatchString(s) {
+		return fmt.Errorf("not an environment variable name")
+	}
+	return nil
+}
+
+// Validate checks one extra model entry; string-typed like the port
+// validators where the form shares it, entry-level here.
+func (m ExtraModel) Validate() error {
+	if err := ValidateModelName(m.Name); err != nil {
+		return fmt.Errorf("name %q: %w", m.Name, err)
+	}
+	key, known := ModelProviders[m.Provider]
+	if !known {
+		return fmt.Errorf("%s: unknown provider %q (one of %s)", m.Name, m.Provider, strings.Join(ModelProviderNames, ", "))
+	}
+	if m.Model == "" {
+		return fmt.Errorf("%s: model is required", m.Name)
+	}
+	if err := ValidateAPIKeyEnv(m.APIKeyEnv); err != nil {
+		return fmt.Errorf("%s: apiKeyEnv %q: %w", m.Name, m.APIKeyEnv, err)
+	}
+	switch m.Provider {
+	case "Gemini":
+		if m.BaseURL != "" {
+			return fmt.Errorf("%s: Gemini takes no baseUrl (the ModelConfig CRD has no endpoint field for it)", m.Name)
+		}
+	case "Ollama":
+		if m.BaseURL == "" {
+			return fmt.Errorf("%s: Ollama requires baseUrl (the host serving the API, e.g. http://192.168.1.10:11434)", m.Name)
+		}
+	}
+	if key == "" && m.APIKeyEnv != "" {
+		return fmt.Errorf("%s: %s is keyless — apiKeyEnv would be silently ignored", m.Name, m.Provider)
 	}
 	return nil
 }
@@ -365,6 +483,16 @@ func (c *Config) Validate() error {
 	}
 	if err := ValidatePort(strconv.Itoa(c.Platform.AgentsPort)); err != nil {
 		return fmt.Errorf("platform.agentsPort: %w", err)
+	}
+	seenModels := map[string]bool{}
+	for _, m := range c.Platform.ExtraModels {
+		if err := m.Validate(); err != nil {
+			return fmt.Errorf("platform.extraModels: %w", err)
+		}
+		if seenModels[m.Name] {
+			return fmt.Errorf("platform.extraModels: duplicate name %q", m.Name)
+		}
+		seenModels[m.Name] = true
 	}
 	if err := ValidatePort(strconv.Itoa(c.Backstage.Port)); err != nil {
 		return fmt.Errorf("backstage.port: %w", err)

--- a/internal/config/models_test.go
+++ b/internal/config/models_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtraModelValidate(t *testing.T) {
+	valid := ExtraModel{Name: "qwen3-8-27b", Provider: "OpenAI", Model: "qwen3-8-27b",
+		BaseURL: "http://192.168.1.10:8000/v1"}
+
+	cases := []struct {
+		name    string
+		mutate  func(m ExtraModel) ExtraModel
+		wantErr string // substring; empty = valid
+	}{
+		{"openai with base url", func(m ExtraModel) ExtraModel { return m }, ""},
+		{"openai without base url", func(m ExtraModel) ExtraModel { m.BaseURL = ""; return m }, ""},
+		{"openrouter with key env", func(m ExtraModel) ExtraModel {
+			m.BaseURL = "https://openrouter.ai/api/v1"
+			m.APIKeyEnv = "OPENROUTER_API_KEY"
+			return m
+		}, ""},
+		{"gemini", func(m ExtraModel) ExtraModel {
+			m.Provider = "Gemini"
+			m.BaseURL = ""
+			m.APIKeyEnv = "GEMINI_API_KEY"
+			return m
+		}, ""},
+		{"anthropic base url", func(m ExtraModel) ExtraModel {
+			m.Provider = "Anthropic"
+			return m
+		}, ""},
+		{"ollama", func(m ExtraModel) ExtraModel {
+			m.Provider = "Ollama"
+			m.BaseURL = "http://192.168.1.10:11434"
+			return m
+		}, ""},
+		{"bad name", func(m ExtraModel) ExtraModel { m.Name = "Qwen_3"; return m }, "lowercase"},
+		{"reserved default name", func(m ExtraModel) ExtraModel { m.Name = "default-model-config"; return m }, "reserved"},
+		{"reserved anthropic name", func(m ExtraModel) ExtraModel { m.Name = "anthropic"; return m }, "reserved"},
+		{"unknown provider", func(m ExtraModel) ExtraModel { m.Provider = "Bedrock"; return m }, "unknown provider"},
+		{"missing model", func(m ExtraModel) ExtraModel { m.Model = ""; return m }, "model is required"},
+		{"gemini with base url", func(m ExtraModel) ExtraModel {
+			m.Provider = "Gemini"
+			return m
+		}, "no baseUrl"},
+		{"ollama without base url", func(m ExtraModel) ExtraModel {
+			m.Provider = "Ollama"
+			m.BaseURL = ""
+			return m
+		}, "requires baseUrl"},
+		{"ollama with key env", func(m ExtraModel) ExtraModel {
+			m.Provider = "Ollama"
+			m.BaseURL = "http://h:11434"
+			m.APIKeyEnv = "X"
+			return m
+		}, "keyless"},
+		{"bad key env", func(m ExtraModel) ExtraModel { m.APIKeyEnv = "not a var"; return m }, "environment variable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.mutate(valid).Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestExtraModelSecretWiring(t *testing.T) {
+	m := ExtraModel{Name: "qwen", Provider: "OpenAI"}
+	if m.SecretName() != "kagent-qwen" || m.SecretKey() != "OPENAI_API_KEY" || !m.NeedsSecret() {
+		t.Errorf("OpenAI wiring: secret=%s key=%s needs=%v", m.SecretName(), m.SecretKey(), m.NeedsSecret())
+	}
+	if (ExtraModel{Provider: "Gemini"}).SecretKey() != "GOOGLE_API_KEY" {
+		t.Errorf("Gemini must map to GOOGLE_API_KEY (what the ADK runtime reads)")
+	}
+	if (ExtraModel{Provider: "Ollama"}).NeedsSecret() {
+		t.Errorf("Ollama is keyless")
+	}
+}
+
+func TestConfigValidateExtraModels(t *testing.T) {
+	cfg := Default()
+	cfg.Platform.ExtraModels = []ExtraModel{
+		{Name: "qwen", Provider: "OpenAI", Model: "qwen3-8-27b"},
+		{Name: "qwen", Provider: "OpenAI", Model: "qwen3-8-27b"},
+	}
+	if _, err := cfg.EnsureHashes(); err != nil {
+		t.Fatal(err)
+	}
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "duplicate name") {
+		t.Fatalf("duplicate models not rejected: %v", err)
+	}
+	cfg.Platform.ExtraModels = cfg.Platform.ExtraModels[:1]
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("valid extra model rejected: %v", err)
+	}
+}

--- a/internal/config/models_test.go
+++ b/internal/config/models_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestExtraModelValidate(t *testing.T) {
-	valid := ExtraModel{Name: "qwen3-8-27b", Provider: "OpenAI", Model: "qwen3-8-27b",
+	valid := ExtraModel{Name: "qwen3-8-27b", Provider: ProviderOpenAI, Model: "qwen3-8-27b",
 		BaseURL: "http://192.168.1.10:8000/v1"}
 
 	cases := []struct {
@@ -22,17 +22,17 @@ func TestExtraModelValidate(t *testing.T) {
 			return m
 		}, ""},
 		{"gemini", func(m ExtraModel) ExtraModel {
-			m.Provider = "Gemini"
+			m.Provider = ProviderGemini
 			m.BaseURL = ""
 			m.APIKeyEnv = "GEMINI_API_KEY"
 			return m
 		}, ""},
 		{"anthropic base url", func(m ExtraModel) ExtraModel {
-			m.Provider = "Anthropic"
+			m.Provider = ProviderAnthropic
 			return m
 		}, ""},
 		{"ollama", func(m ExtraModel) ExtraModel {
-			m.Provider = "Ollama"
+			m.Provider = ProviderOllama
 			m.BaseURL = "http://192.168.1.10:11434"
 			return m
 		}, ""},
@@ -42,16 +42,16 @@ func TestExtraModelValidate(t *testing.T) {
 		{"unknown provider", func(m ExtraModel) ExtraModel { m.Provider = "Bedrock"; return m }, "unknown provider"},
 		{"missing model", func(m ExtraModel) ExtraModel { m.Model = ""; return m }, "model is required"},
 		{"gemini with base url", func(m ExtraModel) ExtraModel {
-			m.Provider = "Gemini"
+			m.Provider = ProviderGemini
 			return m
 		}, "no baseUrl"},
 		{"ollama without base url", func(m ExtraModel) ExtraModel {
-			m.Provider = "Ollama"
+			m.Provider = ProviderOllama
 			m.BaseURL = ""
 			return m
 		}, "requires baseUrl"},
 		{"ollama with key env", func(m ExtraModel) ExtraModel {
-			m.Provider = "Ollama"
+			m.Provider = ProviderOllama
 			m.BaseURL = "http://h:11434"
 			m.APIKeyEnv = "X"
 			return m
@@ -75,14 +75,14 @@ func TestExtraModelValidate(t *testing.T) {
 }
 
 func TestExtraModelSecretWiring(t *testing.T) {
-	m := ExtraModel{Name: "qwen", Provider: "OpenAI"}
+	m := ExtraModel{Name: "qwen", Provider: ProviderOpenAI}
 	if m.SecretName() != "kagent-qwen" || m.SecretKey() != "OPENAI_API_KEY" || !m.NeedsSecret() {
 		t.Errorf("OpenAI wiring: secret=%s key=%s needs=%v", m.SecretName(), m.SecretKey(), m.NeedsSecret())
 	}
-	if (ExtraModel{Provider: "Gemini"}).SecretKey() != "GOOGLE_API_KEY" {
+	if (ExtraModel{Provider: ProviderGemini}).SecretKey() != "GOOGLE_API_KEY" {
 		t.Errorf("Gemini must map to GOOGLE_API_KEY (what the ADK runtime reads)")
 	}
-	if (ExtraModel{Provider: "Ollama"}).NeedsSecret() {
+	if (ExtraModel{Provider: ProviderOllama}).NeedsSecret() {
 		t.Errorf("Ollama is keyless")
 	}
 }
@@ -90,8 +90,8 @@ func TestExtraModelSecretWiring(t *testing.T) {
 func TestConfigValidateExtraModels(t *testing.T) {
 	cfg := Default()
 	cfg.Platform.ExtraModels = []ExtraModel{
-		{Name: "qwen", Provider: "OpenAI", Model: "qwen3-8-27b"},
-		{Name: "qwen", Provider: "OpenAI", Model: "qwen3-8-27b"},
+		{Name: "dup-model", Provider: ProviderOpenAI, Model: "qwen3-8-27b"},
+		{Name: "dup-model", Provider: ProviderOpenAI, Model: "qwen3-8-27b"},
 	}
 	if _, err := cfg.EnsureHashes(); err != nil {
 		t.Fatal(err)

--- a/internal/config/models_test.go
+++ b/internal/config/models_test.go
@@ -90,8 +90,8 @@ func TestExtraModelSecretWiring(t *testing.T) {
 func TestConfigValidateExtraModels(t *testing.T) {
 	cfg := Default()
 	cfg.Platform.ExtraModels = []ExtraModel{
-		{Name: "dup-model", Provider: ProviderOpenAI, Model: "qwen3-8-27b"},
-		{Name: "dup-model", Provider: ProviderOpenAI, Model: "qwen3-8-27b"},
+		{Name: "dup-model", Provider: ProviderOpenAI, Model: "some-model"},
+		{Name: "dup-model", Provider: ProviderOpenAI, Model: "other-model"},
 	}
 	if _, err := cfg.EnsureHashes(); err != nil {
 		t.Fatal(err)

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -17,6 +17,14 @@ import (
 
 var emailRe = regexp.MustCompile(`^[^@\s]+@[^@\s]+$`)
 
+// The keep/edit/remove vocabulary shared by the list editors (users, extra
+// models).
+const (
+	actionKeep   = "keep"
+	actionEdit   = "edit"
+	actionRemove = "remove"
+)
+
 // testInput/testOutput let tests drive the real TUI form with a scripted
 // keystroke stream instead of a terminal. nil outside of tests.
 var (
@@ -214,15 +222,15 @@ func editUsers(cfg *config.Config, accessible bool) error {
 	var kept []config.User
 	for i := range cfg.Users {
 		u := cfg.Users[i]
-		action := "keep"
+		action := actionKeep
 		err := newForm(huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(fmt.Sprintf("User %s", u.Email)).
 				Description(fmt.Sprintf("groups: %s", strings.Join(u.Groups, ", "))).
 				Options(
-					huh.NewOption("Keep", "keep"),
-					huh.NewOption("Edit", "edit"),
-					huh.NewOption("Remove", "remove"),
+					huh.NewOption("Keep", actionKeep),
+					huh.NewOption("Edit", actionEdit),
+					huh.NewOption("Remove", actionRemove),
 				).
 				Value(&action),
 		)).WithAccessible(accessible).Run()
@@ -230,15 +238,15 @@ func editUsers(cfg *config.Config, accessible bool) error {
 			return err
 		}
 		switch action {
-		case "keep":
+		case actionKeep:
 			kept = append(kept, u)
-		case "edit":
+		case actionEdit:
 			edited, err := userForm(u, accessible)
 			if err != nil {
 				return err
 			}
 			kept = append(kept, edited)
-		case "remove":
+		case actionRemove:
 		}
 	}
 
@@ -326,15 +334,15 @@ func editExtraModels(cfg *config.Config, accessible bool) error {
 	var kept []config.ExtraModel
 	for i := range cfg.Platform.ExtraModels {
 		m := cfg.Platform.ExtraModels[i]
-		action := "keep"
+		action := actionKeep
 		err := newForm(huh.NewGroup(
 			huh.NewSelect[string]().
 				Title(fmt.Sprintf("Model %s", m.Name)).
 				Description(fmt.Sprintf("%s %s%s", m.Provider, m.Model, baseURLNote(m.BaseURL))).
 				Options(
-					huh.NewOption("Keep", "keep"),
-					huh.NewOption("Edit", "edit"),
-					huh.NewOption("Remove", "remove"),
+					huh.NewOption("Keep", actionKeep),
+					huh.NewOption("Edit", actionEdit),
+					huh.NewOption("Remove", actionRemove),
 				).
 				Value(&action),
 		)).WithAccessible(accessible).Run()
@@ -342,15 +350,15 @@ func editExtraModels(cfg *config.Config, accessible bool) error {
 			return err
 		}
 		switch action {
-		case "keep":
+		case actionKeep:
 			kept = append(kept, m)
-		case "edit":
+		case actionEdit:
 			edited, err := extraModelForm(m, accessible)
 			if err != nil {
 				return err
 			}
 			kept = append(kept, edited)
-		case "remove":
+		case actionRemove:
 		}
 	}
 
@@ -368,7 +376,7 @@ func editExtraModels(cfg *config.Config, accessible bool) error {
 		if !addMore {
 			break
 		}
-		m, err := extraModelForm(config.ExtraModel{Provider: "OpenAI"}, accessible)
+		m, err := extraModelForm(config.ExtraModel{Provider: config.ProviderOpenAI}, accessible)
 		if err != nil {
 			return err
 		}
@@ -416,9 +424,9 @@ func extraModelForm(m config.ExtraModel, accessible bool) (config.ExtraModel, er
 			Value(&baseURL).
 			Validate(func(s string) error {
 				switch {
-				case provider == "Ollama" && s == "":
+				case provider == config.ProviderOllama && s == "":
 					return fmt.Errorf("required for Ollama")
-				case provider == "Gemini" && s != "":
+				case provider == config.ProviderGemini && s != "":
 					return fmt.Errorf("not applicable to Gemini")
 				}
 				return nil
@@ -428,8 +436,8 @@ func extraModelForm(m config.ExtraModel, accessible bool) (config.ExtraModel, er
 			Description("Host env var read at deploy time (e.g. OPENROUTER_API_KEY); the value lands\nonly in the Secret. Empty = keyless endpoint (a placeholder key is shipped).").
 			Value(&apiKeyEnv).
 			Validate(func(s string) error {
-				if provider == "Ollama" && s != "" {
-					return fmt.Errorf("Ollama is keyless — this would be silently ignored")
+				if provider == config.ProviderOllama && s != "" {
+					return fmt.Errorf("keyless provider — an API key env would be silently ignored")
 				}
 				return config.ValidateAPIKeyEnv(s)
 			}),

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -59,12 +59,24 @@ func Run(cfg *config.Config, accessible bool) error {
 	observabilityEnabled := cfg.Platform.Observability
 	agentsPort := strconv.Itoa(cfg.Platform.AgentsPort)
 	aiModel := cfg.AIModel
+	customizeModels := false
 	backstagePort := strconv.Itoa(cfg.Backstage.Port)
 
 	userSummary := func() string {
 		lines := make([]string, 0, len(cfg.Users))
 		for _, u := range cfg.Users {
 			lines = append(lines, fmt.Sprintf("%s (%s)", u.Email, strings.Join(u.Groups, ", ")))
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	modelSummary := func() string {
+		if len(cfg.Platform.ExtraModels) == 0 {
+			return "(none)"
+		}
+		lines := make([]string, 0, len(cfg.Platform.ExtraModels))
+		for _, m := range cfg.Platform.ExtraModels {
+			lines = append(lines, fmt.Sprintf("%s (%s %s)", m.Name, m.Provider, m.Model))
 		}
 		return strings.Join(lines, "\n")
 	}
@@ -144,6 +156,14 @@ func Run(cfg *config.Config, accessible bool) error {
 				Description("Used by the platform agents' ModelConfig and Backstage's AI chat.\nThe API key comes from $ANTHROPIC_API_KEY at deploy time, never from this file.").
 				Value(&aiModel).
 				Validate(config.ValidateAIModel),
+			huh.NewConfirm().
+				Title("Customize extra model configs?").
+				DescriptionFunc(func() string {
+					return "Additional kagent ModelConfigs beyond the default Claude one — a self-hosted\nOpenAI-compatible endpoint (vLLM, Ollama), OpenRouter, Gemini or plain OpenAI.\nCurrent extras:\n" + modelSummary()
+				}, &cfg.Platform.ExtraModels).
+				Affirmative("Edit them").
+				Negative("Keep as is").
+				Value(&customizeModels),
 		).Title("Agent platform").
 			WithHideFunc(func() bool { return !slices.Contains(components, "platform") }),
 
@@ -177,6 +197,11 @@ func Run(cfg *config.Config, accessible bool) error {
 
 	if customizeUsers {
 		if err := editUsers(cfg, accessible); err != nil {
+			return err
+		}
+	}
+	if customizeModels {
+		if err := editExtraModels(cfg, accessible); err != nil {
 			return err
 		}
 	}
@@ -292,6 +317,141 @@ func userForm(u config.User, accessible bool) (config.User, error) {
 	u.Groups = orderGroups(groups)
 	u.Username = strings.SplitN(email, "@", 2)[0]
 	return u, nil
+}
+
+// editExtraModels rebuilds the extra-model list interactively, mirroring
+// editUsers: each existing entry can be kept, edited or dropped, then new
+// ones can be appended.
+func editExtraModels(cfg *config.Config, accessible bool) error {
+	var kept []config.ExtraModel
+	for i := range cfg.Platform.ExtraModels {
+		m := cfg.Platform.ExtraModels[i]
+		action := "keep"
+		err := newForm(huh.NewGroup(
+			huh.NewSelect[string]().
+				Title(fmt.Sprintf("Model %s", m.Name)).
+				Description(fmt.Sprintf("%s %s%s", m.Provider, m.Model, baseURLNote(m.BaseURL))).
+				Options(
+					huh.NewOption("Keep", "keep"),
+					huh.NewOption("Edit", "edit"),
+					huh.NewOption("Remove", "remove"),
+				).
+				Value(&action),
+		)).WithAccessible(accessible).Run()
+		if err != nil {
+			return err
+		}
+		switch action {
+		case "keep":
+			kept = append(kept, m)
+		case "edit":
+			edited, err := extraModelForm(m, accessible)
+			if err != nil {
+				return err
+			}
+			kept = append(kept, edited)
+		case "remove":
+		}
+	}
+
+	for {
+		addMore := false
+		err := newForm(huh.NewGroup(
+			huh.NewConfirm().
+				Title("Add another model config?").
+				Description(fmt.Sprintf("%d extra model(s) so far. Removed ones are pruned from the cluster on the next run.", len(kept))).
+				Value(&addMore),
+		)).WithAccessible(accessible).Run()
+		if err != nil {
+			return err
+		}
+		if !addMore {
+			break
+		}
+		m, err := extraModelForm(config.ExtraModel{Provider: "OpenAI"}, accessible)
+		if err != nil {
+			return err
+		}
+		kept = append(kept, m)
+	}
+
+	cfg.Platform.ExtraModels = kept
+	return nil
+}
+
+func baseURLNote(u string) string {
+	if u == "" {
+		return ""
+	}
+	return " @ " + u
+}
+
+func extraModelForm(m config.ExtraModel, accessible bool) (config.ExtraModel, error) {
+	name := m.Name
+	provider := m.Provider
+	model := m.Model
+	baseURL := m.BaseURL
+	apiKeyEnv := m.APIKeyEnv
+	insecure := m.InsecureTLS
+
+	form := newForm(huh.NewGroup(
+		huh.NewInput().
+			Title("Name").
+			Description("Names the ModelConfig CR and its key Secret (kagent-<name>).").
+			Value(&name).
+			Validate(config.ValidateModelName),
+		huh.NewSelect[string]().
+			Title("Provider").
+			Description("OpenAI also covers every OpenAI-compatible endpoint (vLLM, OpenRouter, ...)\nvia the base URL below.").
+			Options(huh.NewOptions(config.ModelProviderNames...)...).
+			Value(&provider),
+		huh.NewInput().
+			Title("Model").
+			Description("The model id the endpoint serves, e.g. qwen3-8-27b or deepseek/deepseek-chat.").
+			Value(&model).
+			Validate(notEmpty),
+		huh.NewInput().
+			Title("Base URL").
+			Description("Endpoint override: vLLM http://host:8000/v1, OpenRouter\nhttps://openrouter.ai/api/v1. Required for Ollama, not applicable to Gemini.").
+			Value(&baseURL).
+			Validate(func(s string) error {
+				switch {
+				case provider == "Ollama" && s == "":
+					return fmt.Errorf("required for Ollama")
+				case provider == "Gemini" && s != "":
+					return fmt.Errorf("not applicable to Gemini")
+				}
+				return nil
+			}),
+		huh.NewInput().
+			Title("API key env var").
+			Description("Host env var read at deploy time (e.g. OPENROUTER_API_KEY); the value lands\nonly in the Secret. Empty = keyless endpoint (a placeholder key is shipped).").
+			Value(&apiKeyEnv).
+			Validate(func(s string) error {
+				if provider == "Ollama" && s != "" {
+					return fmt.Errorf("Ollama is keyless — this would be silently ignored")
+				}
+				return config.ValidateAPIKeyEnv(s)
+			}),
+		huh.NewConfirm().
+			Title("Skip TLS verification?").
+			Description("Only for self-hosted https endpoints with self-signed certificates.").
+			Affirmative("Skip verification").
+			Negative("Verify").
+			Value(&insecure),
+	)).WithAccessible(accessible)
+
+	if err := form.Run(); err != nil {
+		return config.ExtraModel{}, err
+	}
+
+	m.Name = name
+	m.Provider = provider
+	m.Model = model
+	m.BaseURL = baseURL
+	m.APIKeyEnv = apiKeyEnv
+	m.InsecureTLS = insecure
+	return m, m.Validate()
 }
 
 // orderGroups keeps the canonical group order regardless of selection order,

--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -17,9 +17,11 @@ const keyDelay = 30 * time.Millisecond
 func TestRunTUIDrive(t *testing.T) {
 	testInput = newPacedReader(keyDelay,
 		"\r", "\r", "\r", // group 1: cluster name, dex port, dex image
-		"\r",                               // group 2: customize users? -> keep as is
-		"\r",                               // group 3: platform + backstage preselected; submit as is
-		"\r", "\r", "\r", "\r", "\r", "\r", // platform group: muster port, aps ref, agents confirm, agents ui port, observability confirm, claude model
+		"\r", // group 2: customize users? -> keep as is
+		"\r", // group 3: platform + backstage preselected; submit as is
+		// platform group: muster port, aps ref, agents confirm, agents ui
+		// port, observability confirm, claude model, extra models confirm
+		"\r", "\r", "\r", "\r", "\r", "\r", "\r",
 		"\r", // backstage group: port
 	)
 	testOutput = io.Discard

--- a/internal/lab/models.go
+++ b/internal/lab/models.go
@@ -1,0 +1,172 @@
+package lab
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// kagentNamespace is where the kagent subchart puts its runtime and where
+// every ModelConfig and key Secret lives.
+const kagentNamespace = "kagent"
+
+// placeholderAPIKey fills a model's key Secret when the entry names no env
+// var (a keyless endpoint, e.g. a local vLLM). The Secret still has to exist
+// with the provider's canonical key: the kagent controller injects it as an
+// env var into agent pods and the ADK runtime requires that env var at
+// startup — an agent pod without it crashloops even against an endpoint that
+// never checks the value.
+const placeholderAPIKey = "agentlab-placeholder"
+
+// modelConfigResource is fully qualified on purpose: like MCPServer (muster
+// vs kagent.dev), a bare kind is one CRD collision away from resolving into
+// the wrong API group.
+const modelConfigResource = "modelconfigs.kagent.dev"
+
+// managedByAgentlab labels the extra ModelConfigs so pruning can be scoped to
+// lab-owned CRs — the chart-rendered default ModelConfig is never touched.
+const managedByAgentlab = "app.kubernetes.io/managed-by=agentlab"
+
+// ensureExtraModels reconciles the platform.extraModels entries into kagent
+// ModelConfig CRs plus their key Secrets, and prunes lab-labeled CRs whose
+// entry is gone from agentlab.yaml. Only called with the agents runtime
+// installed (the ModelConfig CRD ships with the kagent chart).
+func ensureExtraModels(cfg *config.Config) error {
+	_, path, err := renderManifest(cfg, "extra-models.yaml.tmpl")
+	if err != nil {
+		return err
+	}
+	if len(cfg.Platform.ExtraModels) > 0 {
+		step("Adding extra model configs (%d beyond the default %s)", len(cfg.Platform.ExtraModels), cfg.AIModel)
+	}
+	// Secrets before the CRs: the controller hashes the referenced Secret
+	// into the ModelConfig status, so the reference should resolve on the
+	// controller's first look.
+	for _, m := range cfg.Platform.ExtraModels {
+		if err := ensureModelKeySecret(m); err != nil {
+			return err
+		}
+	}
+	if len(cfg.Platform.ExtraModels) > 0 {
+		if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
+			return err
+		}
+	}
+	if err := pruneExtraModels(cfg); err != nil {
+		return err
+	}
+	for _, m := range cfg.Platform.ExtraModels {
+		if err := waitModelConfigAccepted(m.Name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureModelKeySecret creates the model's key Secret from the host env var
+// the entry names — the same env -> Secret path as the Anthropic key: real
+// credentials never enter agentlab.yaml or state/. An existing Secret is
+// left alone (delete it and re-run to rotate). A missing value degrades to
+// the placeholder so agent pods still boot; the model then fails auth at
+// call time, which is the visible, recoverable failure.
+func ensureModelKeySecret(m config.ExtraModel) error {
+	if !m.NeedsSecret() {
+		return nil
+	}
+	if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "secret", m.SecretName()); err == nil {
+		note("secret %s/%s already exists, leaving it alone (delete it and re-run to rotate)", kagentNamespace, m.SecretName())
+		return nil
+	}
+	key := placeholderAPIKey
+	switch {
+	case m.APIKeyEnv == "":
+		note("model %s: no apiKeyEnv configured — using a placeholder key (keyless endpoint)", m.Name)
+	case os.Getenv(m.APIKeyEnv) == "":
+		note("model %s: $%s is not set — using a placeholder key; agents on this model fail auth until:", m.Name, m.APIKeyEnv)
+		note("  kubectl -n %s delete secret %s && export %s=... && re-run `agentlab platform`", kagentNamespace, m.SecretName(), m.APIKeyEnv)
+	default:
+		key = os.Getenv(m.APIKeyEnv)
+	}
+	// Applied via stdin so the key never appears in a process's argv.
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+type: Opaque
+stringData:
+  %s: %q
+`, m.SecretName(), kagentNamespace, m.SecretKey(), key)
+	if err := pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-"); err != nil {
+		return err
+	}
+	if key != placeholderAPIKey {
+		note("created secret %s/%s from $%s", kagentNamespace, m.SecretName(), m.APIKeyEnv)
+	}
+	return nil
+}
+
+// pruneExtraModels deletes lab-labeled ModelConfigs (and their Secrets) whose
+// entry no longer exists in agentlab.yaml, so removing a model from the
+// config is a real removal on the next run.
+func pruneExtraModels(cfg *config.Config) error {
+	out, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource,
+		"-l", managedByAgentlab, "-o", "jsonpath={.items[*].metadata.name}")
+	if err != nil {
+		return nil // no CRD / no namespace: nothing lab-owned to prune
+	}
+	want := map[string]bool{}
+	for _, m := range cfg.Platform.ExtraModels {
+		want[m.Name] = true
+	}
+	for _, name := range strings.Fields(out) {
+		if want[name] {
+			continue
+		}
+		note("pruning model config %s (removed from %s)", name, config.File)
+		if err := runQuiet("kubectl", "-n", kagentNamespace, "delete", modelConfigResource, name); err != nil {
+			return err
+		}
+		// Its key Secret rides along; --ignore-not-found because keyless
+		// providers never had one.
+		if err := runQuiet("kubectl", "-n", kagentNamespace, "delete", "secret", "kagent-"+name, "--ignore-not-found"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extraModelsHint names the extra ModelConfigs in the platform-up summary,
+// e.g. " (+ qwen3-8-27b, gemini-flash)"; empty when there are none.
+func extraModelsHint(cfg *config.Config) string {
+	if len(cfg.Platform.ExtraModels) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(cfg.Platform.ExtraModels))
+	for _, m := range cfg.Platform.ExtraModels {
+		names = append(names, m.Name)
+	}
+	return " (+ " + strings.Join(names, ", ") + ")"
+}
+
+// waitModelConfigAccepted polls one ModelConfig until the controller accepts
+// it — the machine check that the provider/model/Secret combination is one
+// the runtime can mount, before anyone debugs it from a failing agent pod.
+func waitModelConfigAccepted(name string) error {
+	status := ""
+	accepted := waitFor(10, 2*time.Second, func() bool {
+		status, _ = outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, name,
+			"-o", `jsonpath={.status.conditions[?(@.type=="Accepted")].status}`)
+		return status == "True"
+	})
+	if !accepted {
+		return fmt.Errorf("ModelConfig %s never reached Accepted (last status: %q);\n"+
+			"check `kubectl -n %s describe %s %s`",
+			name, status, kagentNamespace, modelConfigResource, name)
+	}
+	note("ModelConfig %s: Accepted", name)
+	return nil
+}

--- a/internal/lab/models_test.go
+++ b/internal/lab/models_test.go
@@ -17,8 +17,8 @@ func TestExtraModelsTemplate(t *testing.T) {
 		{Name: "qwen3-8-27b", Provider: "OpenAI", Model: "qwen3-8-27b",
 			BaseURL: "https://qwen.example.com/v1", InsecureTLS: true},
 		{Name: "openrouter-deepseek", Provider: "OpenAI", Model: "deepseek/deepseek-chat",
-			BaseURL: "https://openrouter.ai/api/v1", APIKeyEnv: "OPENROUTER_API_KEY"},
-		{Name: "gemini-flash", Provider: "Gemini", Model: "gemini-2.5-flash", APIKeyEnv: "GEMINI_API_KEY"},
+			BaseURL: "https://openrouter.ai/api/v1", APIKeyEnv: "OPENROUTER_API_KEY"}, // #nosec G101 -- env var NAME, not a credential
+		{Name: "gemini-flash", Provider: "Gemini", Model: "gemini-2.5-flash", APIKeyEnv: "GEMINI_API_KEY"}, // #nosec G101 -- env var NAME, not a credential
 		{Name: "local-llama", Provider: "Ollama", Model: "llama3.3", BaseURL: "http://192.168.1.10:11434"},
 		{Name: "claude-proxy", Provider: "Anthropic", Model: "claude-haiku-4-5", BaseURL: "https://proxy.example.com"},
 	}

--- a/internal/lab/models_test.go
+++ b/internal/lab/models_test.go
@@ -1,0 +1,68 @@
+package lab
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// TestExtraModelsTemplate renders the extra-models template across every
+// provider shape and asserts the provider-specific spec blocks: the OpenAI
+// baseUrl section, the Ollama host mapping, the secret reference wiring, and
+// the tls escape hatch.
+func TestExtraModelsTemplate(t *testing.T) {
+	cfg := config.Default()
+	cfg.Platform.ExtraModels = []config.ExtraModel{
+		{Name: "qwen3-8-27b", Provider: "OpenAI", Model: "qwen3-8-27b",
+			BaseURL: "https://qwen.example.com/v1", InsecureTLS: true},
+		{Name: "openrouter-deepseek", Provider: "OpenAI", Model: "deepseek/deepseek-chat",
+			BaseURL: "https://openrouter.ai/api/v1", APIKeyEnv: "OPENROUTER_API_KEY"},
+		{Name: "gemini-flash", Provider: "Gemini", Model: "gemini-2.5-flash", APIKeyEnv: "GEMINI_API_KEY"},
+		{Name: "local-llama", Provider: "Ollama", Model: "llama3.3", BaseURL: "http://192.168.1.10:11434"},
+		{Name: "claude-proxy", Provider: "Anthropic", Model: "claude-haiku-4-5", BaseURL: "https://proxy.example.com"},
+	}
+	raw, err := renderTemplate(cfg, "extra-models.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := string(raw)
+
+	for _, want := range []string{
+		// the self-hosted vLLM: baseUrl under openAI, placeholder-backed secret, tls off
+		"name: qwen3-8-27b",
+		"apiKeySecret: kagent-qwen3-8-27b",
+		"apiKeySecretKey: OPENAI_API_KEY",
+		"baseUrl: https://qwen.example.com/v1",
+		"disableVerify: true",
+		// gemini: GOOGLE_API_KEY (the ADK's canonical name), no endpoint block
+		"apiKeySecretKey: GOOGLE_API_KEY",
+		// ollama: host, not baseUrl
+		"host: http://192.168.1.10:11434",
+		// anthropic override endpoint
+		"apiKeySecretKey: ANTHROPIC_API_KEY",
+		"baseUrl: https://proxy.example.com",
+		"app.kubernetes.io/managed-by: agentlab",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered extra-models missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "apiKeySecret: kagent-local-llama") {
+		t.Errorf("Ollama must not reference a secret:\n%s", out)
+	}
+	if strings.Count(out, "kind: ModelConfig") != len(cfg.Platform.ExtraModels) {
+		t.Errorf("want %d ModelConfigs:\n%s", len(cfg.Platform.ExtraModels), out)
+	}
+
+	// No extras -> comments only, nothing to apply (the lifecycle skips
+	// kubectl apply on an empty list).
+	cfg.Platform.ExtraModels = nil
+	raw, err = renderTemplate(cfg, "extra-models.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("render empty: %v", err)
+	}
+	if strings.Contains(string(raw), "kind:") {
+		t.Errorf("empty extraModels rendered objects:\n%s", raw)
+	}
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -346,7 +346,14 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 	// since the chart itself creates the kagent namespace.
 	if cfg.Platform.Agents {
 		step("Wiring the agents to Anthropic (ModelConfig model: %s)", cfg.AIModel)
-		if _, err := ensureAnthropicSecret("kagent", "kagent-anthropic"); err != nil {
+		if _, err := ensureAnthropicSecret(kagentNamespace, "kagent-anthropic"); err != nil {
+			return err
+		}
+		// The extra ModelConfigs from platform.extraModels (self-hosted
+		// endpoints, OpenRouter, Gemini, ...) — after the install for the same
+		// reason as the Secret above: the chart owns the kagent namespace and
+		// the ModelConfig CRD.
+		if err := ensureExtraModels(cfg); err != nil {
 			return err
 		}
 		// Agent pods need the golang-adk runtime image at kagent's own tag,
@@ -417,8 +424,8 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 			return httpUp(client, cfg.KagentUIBaseURL())
 		})
 		if uiUp {
-			agentsHint = fmt.Sprintf("  Agents (kagent) run with model %s; UI: %s",
-				cfg.AIModel, cfg.KagentUIBaseURL())
+			agentsHint = fmt.Sprintf("  Agents (kagent) run with model %s%s; UI: %s",
+				cfg.AIModel, extraModelsHint(cfg), cfg.KagentUIBaseURL())
 		} else {
 			agentsHint = fmt.Sprintf(`  Agents (kagent) run with model %s, but the UI is NOT reachable on %s.
   If 'docker port %s' shows no %d line, this cluster

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -135,6 +135,7 @@ var manifests = map[string]struct {
 	"mcp-prometheus-values.yaml.tmpl":        {out: "mcp-prometheus-values.yaml"},
 	"observability-route.yaml.tmpl":          {out: "observability-route.yaml"},
 	"demo-workflow.yaml.tmpl":                {out: "demo-workflow.yaml"},
+	"extra-models.yaml.tmpl":                 {out: "extra-models.yaml"},
 	"coredns.yaml.tmpl":                      {out: "coredns.yaml"},
 	"gateway-nodeport.yaml.tmpl":             {out: "gateway-nodeport.yaml"},
 	"backstage-catalog.yaml.tmpl":            {out: "backstage-catalog.yaml"},

--- a/internal/lab/templates/extra-models.yaml.tmpl
+++ b/internal/lab/templates/extra-models.yaml.tmpl
@@ -1,0 +1,42 @@
+# Extra kagent ModelConfigs beyond the chart-rendered default: one CR per
+# platform.extraModels entry in agentlab.yaml. Key material never renders
+# here — each CR references the Secret kagent-<name>, which `agentlab
+# platform` creates from the entry's apiKeyEnv on the host (or with a
+# placeholder for keyless endpoints: the kagent ADK runtime requires the
+# provider's env var to exist even when the endpoint never checks it).
+# The managed-by label scopes pruning: entries removed from agentlab.yaml
+# are deleted on the next run; the chart's default ModelConfig is never
+# touched.
+{{- range .Platform.ExtraModels }}
+---
+apiVersion: kagent.dev/v1alpha2
+kind: ModelConfig
+metadata:
+  name: {{ .Name }}
+  namespace: kagent
+  labels:
+    app.kubernetes.io/managed-by: agentlab
+spec:
+  provider: {{ .Provider }}
+  model: {{ .Model }}
+{{- if .NeedsSecret }}
+  apiKeySecret: {{ .SecretName }}
+  apiKeySecretKey: {{ .SecretKey }}
+{{- end }}
+{{- if .InsecureTLS }}
+  tls:
+    disableVerify: true
+{{- end }}
+{{- if eq .Provider "Ollama" }}
+  ollama:
+    host: {{ .BaseURL }}
+{{- else if .BaseURL }}
+{{- if eq .Provider "Anthropic" }}
+  anthropic:
+    baseUrl: {{ .BaseURL }}
+{{- else }}
+  openAI:
+    baseUrl: {{ .BaseURL }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/main.go
+++ b/main.go
@@ -198,6 +198,9 @@ func configureCmd() *cobra.Command {
 			fmt.Printf("  platform   %v (agents %v, observability %v)\n", cfg.Platform.Enabled, cfg.Platform.Agents, cfg.Platform.Observability)
 			fmt.Printf("  backstage  %v\n", cfg.Backstage.Enabled)
 			fmt.Printf("  ai model   %s (key from $%s at deploy time)\n", cfg.AIModel, lab.AnthropicKeyEnv)
+			for _, m := range cfg.Platform.ExtraModels {
+				fmt.Printf("  extra model %s (%s %s)\n", m.Name, m.Provider, m.Model)
+			}
 			fmt.Println("\nNext: agentlab up")
 			return nil
 		},


### PR DESCRIPTION
## What

Adds an option to run agents against **more models than the default Anthropic one**: a `platform.extraModels` list in `agentlab.yaml` — self-hosted OpenAI-compatible endpoints (vLLM, llama.cpp, LM Studio), OpenRouter, Gemini, plain OpenAI/GPT, or an Ollama host.

Each entry becomes a lab-labeled kagent `ModelConfig` CR (the kagent chart only renders the *default* one) plus a key Secret `kagent/kagent-<name>`, selectable in the kagent UI's model dropdown / `Agent.spec.declarative.modelConfig`.

```yaml
platform:
  extraModels:
    - name: qwen3-8-27b            # a self-hosted vLLM, keyless
      provider: OpenAI
      model: qwen3-8-27b
      baseUrl: https://qwen.example.internal/v1
    - name: openrouter-deepseek
      provider: OpenAI
      model: deepseek/deepseek-chat
      baseUrl: https://openrouter.ai/api/v1
      apiKeyEnv: OPENROUTER_API_KEY
    - name: gemini-flash
      provider: Gemini
      model: gemini-2.5-flash
      apiKeyEnv: GEMINI_API_KEY
```

## Design points

- **Key handling mirrors the Anthropic path**: `apiKeyEnv` names a host env var read at deploy time; the value lands only in the Secret, never in `agentlab.yaml` or `state/`.
- **The Secret key is provider-derived** (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GOOGLE_API_KEY`): the kagent controller injects it as an env var of exactly that name, and the ADK runtime looks up those canonical names.
- **Keyless endpoints still get a placeholder-valued Secret** — the ADK runtime crashloops without the env var, even against endpoints that never check it.
- **Pruning**: entries removed from `agentlab.yaml` are deleted (CR + Secret) on the next run, scoped by an `app.kubernetes.io/managed-by: agentlab` label so the chart's default ModelConfig is never touched.
- The lifecycle waits for the controller's `Accepted` condition per model; `agentlab configure` edits the list interactively like the users list; `insecureTLS` maps to the CRD's `tls.disableVerify` for self-signed endpoints.
- Providers needing more than model+endpoint+key (AzureOpenAI, Bedrock, Vertex) stay out of the vocabulary.

## Verification (live lab)

- `go test ./...` green, including the TUI keystroke drive with the new confirm.
- Real self-hosted endpoint: `qwen3-8-27b` (vLLM behind KServe) — `agentlab platform` created the CR + placeholder Secret, controller reported `Accepted`, an `Agent` on `modelConfig: qwen3-8-27b` came up `1/1 Running` (no crashloop on the placeholder key), and an A2A `message/send` returned a model answer (`"…6 times 7 is 42"`, usage metadata 613 tokens).
- Swap-and-prune re-run: replacing the entry with a `Gemini` one deleted the qwen CR + Secret and accepted the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)