### PR TITLE
feat: managed models in the lab — model-manager with the host Ollama, preflight, headless e2e proof

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,16 @@ with Dex doing the logins.
   OpenAI-compatible endpoints, OpenRouter, Gemini, Ollama) with the same
   env-var -> Secret key handling; entries removed from the config are pruned
   on the next run (see README "Extra model configs").
+- `platform.modelManager` (on by default when `agentlab configure` finds an
+  Ollama on the host) installs the umbrella's model-manager component with
+  the Ollama backend: the host Ollama's models become manageable from the
+  portal and as `x_model-manager_<tool>` through muster, every pulled model
+  auto-wired into kagent (native keyless `Ollama` provider). The endpoint is
+  autodetected (`docker network inspect kind` gateway, port 11434) and
+  proven reachable from a pod before the install; the API sits behind the
+  agentgateway route `https://agentgateway.<domain>/model-manager` with JWT
+  validation on (a Dex token is required; 401 without). Proof:
+  `./agentlab models-test` (see README "Managed models").
 - For verifying RBAC as a specific user, use `./agentlab login <email>` and
   `kubectl --kubeconfig kubeconfig.oidc` — that is the OIDC path.
 - The kind admin context (`kind-agentlab`) bypasses the platform and OIDC
@@ -82,6 +92,7 @@ go test ./internal/forms/ -run TestMinimalFormDrive -count=1 -v   # single test
 ./agentlab configure       # interactive form; --defaults keeps/writes the canonical lab
 ./agentlab up              # certs, kind cluster, Dex, RBAC, the agent platform — verified
 ./agentlab platform-test   # headless Dex -> muster -> mcp-kubernetes proof
+./agentlab models-test     # managed models: 401 -> pull -> ModelConfig -> agent turn -> MCP -> unload -> delete
 ./agentlab test            # RBAC assertions for every configured user
 ./agentlab backstage-test  # headless Backstage sign-in for every user
 ./agentlab down            # delete the cluster (certs/ kept, trust stores untouched)

--- a/HACKS.md
+++ b/HACKS.md
@@ -113,6 +113,20 @@ module into vendored-build mode: after the first `agentlab platform`, `go build`
 failed with "inconsistent vendoring".
 **Fix:** the chart is vendored into `.vendor/` instead.
 
+### H13. `agentlab platform` failed on Helm 4 server-side-apply conflicts after a dev-image swap — FIXED
+The documented way back from a dev-image swap (`kubectl set image` /
+`kubectl patch` on a platform Deployment, see the agentlab skill) was "re-run
+`agentlab platform`, which reconciles every Deployment to the vendored chart".
+Helm 4 applies server-side, so the swapped image field belongs to the
+`kubectl` field manager afterwards and the upgrade died on the conflict
+(`Apply failed with 1 conflict: conflict with "kubectl-set" ... image`); the
+workaround was deleting the Deployment by hand and re-running.
+**Fix:** the umbrella upgrade passes `--force-conflicts`: Helm takes the
+fields it renders back from any other manager, so a re-run really does
+reconcile the lab to the chart — a dev image is gone after `agentlab
+platform` (say so in the lab lock's owner file when other people share the
+cluster). Fields Helm does not render (an annotation added by hand) stay.
+
 ## Blocked upstream (documented, not fixable in this repo)
 
 ### U1. `muster-post-render.sh` patch: `allowPublicClientRegistration` edited into the rendered ConfigMap — FIXED upstream

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ export ANTHROPIC_API_KEY=sk-ant-...   # optional: powers the agents + Backstage 
 ./agentlab configure       # interactive form: cluster, users, components
 ./agentlab up              # certs, kind cluster, Dex, RBAC, the agent platform — verified
 ./agentlab platform-test   # headless proof: Dex -> muster -> mcp-kubernetes -> apiserver
+./agentlab models-test     # with an Ollama on the host: pull -> ModelConfig -> agent turn -> delete, through the platform
 ```
 
 Then trust the lab CA once and point Claude Code at the platform (`.mcp.json`
@@ -396,6 +397,88 @@ platform:
 One Lemonade-specific note: its FastFlowLM models default to a 4096-token
 context, which agent system prompts plus tool schemas outgrow quickly —
 raise it once with `lemonade config set ctx_size=16384`.
+
+#### Managed models: model-manager + host Ollama
+
+`extraModels` wires an endpoint and manages nothing: pulling or removing a
+model is CLI-on-host, and nothing shows what is downloaded or loaded. The
+managed mode puts the umbrella's **model-manager** component
+([giantswarm/model-manager](https://github.com/giantswarm/model-manager),
+the service behind the Model Manager epic) in front of the host's Ollama —
+inventory of downloaded and loaded models, pull with progress, load/unload,
+delete, and every pulled model wired into kagent automatically as a
+`ModelConfig` with the native, keyless `Ollama` provider. One block:
+
+```yaml
+platform:
+  agents: true                 # required: the ModelConfigs land in kagent
+  modelManager:
+    enabled: true
+    backend: ollama            # the lab's only backend (kserve needs GPUs + KServe)
+    # endpoint: http://192.168.1.10:11434   # optional; empty autodetects the host
+```
+
+`agentlab configure` turns it on for a fresh config when an Ollama answers on
+this machine (`--defaults --model-manager[=false]` forces it either way; the
+interactive form asks). The endpoint is **autodetected at platform time** as
+`http://<kind docker network gateway>:11434` — `docker network inspect kind`,
+the same address the section above documents for `extraModels` — so nobody
+types `172.21.0.1`; set `endpoint` for an Ollama elsewhere on the LAN.
+
+What `agentlab platform` (or `up`) does with it:
+
+- **Preflight, not README traps.** Before the install, a short-lived pod in
+  the cluster fetches `<endpoint>/api/version`. If that fails, the boot stops
+  right there with the diagnosis and the two fixes from the section above
+  spelled out — *connection refused* means Ollama listens on `127.0.0.1`
+  only (`OLLAMA_HOST=0.0.0.0`), a *timeout* means the host firewall drops
+  pod→host traffic on the docker bridge (allow TCP 11434 from the bridge
+  subnets, inside `172.16.0.0/12`) — instead of a model-manager pod
+  reporting an unhealthy backend after Helm's ten-minute wait.
+- **The umbrella's `components.model-manager`** goes on with the Ollama
+  backend (`model-manager.ollama.endpoint` = the detected address), its
+  agentgateway **route** at `https://agentgateway.<domain>/model-manager`
+  and, unlike the lab's kagent route, **JWT validation on**: the gateway
+  verifies the caller's Dex token against the lab Dex (JWKS over TLS at
+  `dex.dex.svc.cluster.local:5556/dex/keys`, trusted through the lab CA)
+  and answers 401 without one. model-manager checks no identity itself —
+  the gateway is the boundary, the same trust model as the kagent
+  controller route on real installations.
+- **The portal's service side.** The chart's Backstage app-config gains
+  `agentPlatform.modelManager.installations.agent-platform.apiBaseUrl:
+  https://agentgateway.<domain>/model-manager`; the portal backend forwards
+  the signed-in user's Dex ID token to it. What the Models tab shows on top
+  of that is the portal's business (giantswarm/backstage#2194).
+- **muster** registers the MCP endpoint (the chart's own `MCPServer` CR,
+  `Connected` is waited for) and the tools surface as
+  `x_model-manager_<tool>`: `list_models`, `get_model`, `list_loaded_models`,
+  `pull_model`, `load_model`, `unload_model`, `delete_model`, `wire_model`,
+  `unwire_model`, `list_jobs`, `get_job`, `cancel_job`, `get_backend` — ask
+  Claude Code to pull a model.
+
+The proof is `agentlab models-test` (`--model` picks another small,
+**tool-calling capable** model; the default `qwen2.5:0.5b` is ~400 MB —
+`smollm2:135m` pulls fine and then fails every agent turn with "does not
+support tools"). It goes through the platform path only and leaves nothing
+behind:
+
+```
+agentlab models-test
+==> Calling the model-manager API without a token         -> 401 at the gateway
+==> Logging in to Dex as admin@lab.local
+==> Backend through the gateway with the Dex token         -> ollama, healthy, capabilities
+==> Listing models
+==> Pulling qwen2.5:0.5b (progress via GET /api/v1/jobs/{id})
+==> Auto-created kagent ModelConfig                        -> Ollama provider, Accepted
+==> Agent turn on qwen2-5-0-5b (kagent Agent, runtime go -> host Ollama)
+==> MCP tools through muster (x_model-manager_*)           -> get_model
+==> Unloading qwen2.5:0.5b                                 -> gone from /loaded
+==> Deleting qwen2.5:0.5b                                  -> gone from Ollama, ModelConfig gone, list_models agrees
+```
+
+Both modes coexist: the static `extraModels` entries stay as they are
+(labeled `managed-by: agentlab`), model-manager's ModelConfigs carry
+`managed-by: model-manager`, and neither prunes the other's.
 
 ### Observability (Prometheus + mcp-prometheus)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,7 +139,39 @@ type Platform struct {
 	// CRs by `agentlab platform`; entries removed here are pruned on the next
 	// run. Inert unless agents are enabled.
 	ExtraModels []ExtraModel `yaml:"extraModels,omitempty"`
+	// Managed models: the umbrella's model-manager component with the Ollama
+	// backend, proxying the Ollama that runs on the lab host — pull, load,
+	// unload and delete models from the portal (or as x_model-manager_*
+	// tools through muster), each pulled model wired into kagent as a
+	// keyless ModelConfig automatically. Complements extraModels, which
+	// wires endpoints statically and manages nothing. Requires agents.
+	ModelManager ModelManager `yaml:"modelManager"`
 }
+
+// ModelManager configures the umbrella's model-manager component in the lab.
+type ModelManager struct {
+	// On, `agentlab platform` enables components.model-manager with the
+	// Ollama backend, its agentgateway route (JWT-validated: the portal
+	// backend forwards the user's Dex token) and the muster registration.
+	// `agentlab configure` turns it on for a fresh config when an Ollama
+	// answers on the host.
+	Enabled bool `yaml:"enabled"`
+	// The serving backend. The lab supports `ollama` only: kserve needs
+	// GPU nodes and a KServe install this kind cluster does not have.
+	Backend string `yaml:"backend,omitempty"`
+	// The Ollama API base URL as pods reach it. Empty autodetects
+	// http://<kind docker network gateway>:11434 at platform time — the
+	// same address the README documents for extraModels (`docker network
+	// inspect kind`). Set it for an Ollama elsewhere on the LAN.
+	Endpoint string `yaml:"endpoint,omitempty"`
+}
+
+// ModelManagerBackendOllama is the one backend the lab runs.
+const ModelManagerBackendOllama = "ollama"
+
+// OllamaPort is Ollama's default API port, the one the autodetected endpoint
+// assumes on the host.
+const OllamaPort = 11434
 
 // ExtraModel is one additional kagent ModelConfig. API keys are NOT config:
 // APIKeyEnv only names the host env var read at deploy time — the value lands
@@ -270,6 +302,7 @@ func Default() *Config {
 			MusterPort:    8090,
 			Domain:        "127.0.0.1.nip.io",
 			GatewayPort:   443,
+			ModelManager:  ModelManager{Backend: ModelManagerBackendOllama},
 			APSRepo:       "https://github.com/giantswarm/agent-platform-standalone",
 			APSRef:        "50f0d84ce81f470330bbe8766c0eb171a88a2395", // main: backstage 0.203.0 (#59) — stream agent replies in the portal session view
 		},
@@ -435,6 +468,9 @@ func (c *Config) Normalize() {
 	if c.Backstage.Enabled {
 		c.Platform.Enabled = true
 	}
+	if c.Platform.ModelManager.Backend == "" {
+		c.Platform.ModelManager.Backend = ModelManagerBackendOllama
+	}
 }
 
 func (c *Config) Validate() error {
@@ -503,10 +539,35 @@ func (c *Config) Validate() error {
 		}
 		seenModels[m.Name] = true
 	}
+	if err := c.Platform.ModelManager.Validate(c.Platform.Agents); err != nil {
+		return fmt.Errorf("platform.modelManager: %w", err)
+	}
 	if err := ValidatePort(strconv.Itoa(c.Backstage.Port)); err != nil {
 		return fmt.Errorf("backstage.port: %w", err)
 	}
 	return nil
+}
+
+var httpURLRe = regexp.MustCompile(`^https?://[^/]+`)
+
+// Validate checks the model-manager block; agents reports whether the kagent
+// runtime is on (model-manager wires ModelConfigs into it).
+func (m ModelManager) Validate(agents bool) error {
+	if m.Backend != "" && m.Backend != ModelManagerBackendOllama {
+		return fmt.Errorf("backend %q: the lab supports %q only (kserve needs GPU nodes and KServe)", m.Backend, ModelManagerBackendOllama)
+	}
+	if m.Endpoint != "" && !httpURLRe.MatchString(m.Endpoint) {
+		return fmt.Errorf("endpoint %q: must be an http(s) URL, e.g. http://172.21.0.1:%d", m.Endpoint, OllamaPort)
+	}
+	if m.Enabled && !agents {
+		return fmt.Errorf("requires platform.agents (model-manager wires pulled models into kagent ModelConfigs)")
+	}
+	return nil
+}
+
+// ModelManagerEnabled reports whether the platform installs model-manager.
+func (c *Config) ModelManagerEnabled() bool {
+	return c.Platform.Enabled && c.Platform.Agents && c.Platform.ModelManager.Enabled
 }
 
 // AdminUser returns the first user in platform-admins: the identity the up
@@ -575,6 +636,18 @@ func (c *Config) BackstageBaseURL() string { return c.gatewayURL("backstage") }
 func (c *Config) ObservabilityBaseURL() string {
 	return c.gatewayURL("observability") + "/prometheus"
 }
+
+// AgentgatewayBaseURL is the agentgateway hostname through the edge: the
+// path-prefixed platform APIs (the kagent controller at /kagent,
+// model-manager at /model-manager) live here, same as the chart's Backstage
+// app-config derives them.
+func (c *Config) AgentgatewayBaseURL() string { return c.gatewayURL("agentgateway") }
+
+// ModelManagerBaseURL is the model-manager API through the edge — the
+// umbrella's components.model-manager.route (pathPrefix /model-manager,
+// stripped before the service, so its REST API sits at <base>/api/v1). The
+// route's JWT policy wants a Dex token on every call.
+func (c *Config) ModelManagerBaseURL() string { return c.AgentgatewayBaseURL() + "/model-manager" }
 
 // BackstageDirectURL bypasses the edge (hostNetwork port mapping), kept for
 // debugging.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -304,7 +304,7 @@ func Default() *Config {
 			GatewayPort:   443,
 			ModelManager:  ModelManager{Backend: ModelManagerBackendOllama},
 			APSRepo:       "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:        "50f0d84ce81f470330bbe8766c0eb171a88a2395", // main: backstage 0.203.0 (#59) — stream agent replies in the portal session view
+			APSRef:        "203cfe9118e5c25cfa705d725f97396ad4781e2f", // main: the optional model-manager component (#75, chart v0.11.0)
 		},
 		Backstage: Backstage{
 			Enabled: true,

--- a/internal/config/models_test.go
+++ b/internal/config/models_test.go
@@ -105,3 +105,51 @@ func TestConfigValidateExtraModels(t *testing.T) {
 		t.Fatalf("valid extra model rejected: %v", err)
 	}
 }
+
+func TestModelManagerValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		mm      ModelManager
+		agents  bool
+		wantErr string
+	}{
+		{"off", ModelManager{}, false, ""},
+		{"on with agents", ModelManager{Enabled: true, Backend: ModelManagerBackendOllama}, true, ""},
+		{"on, endpoint override", ModelManager{Enabled: true, Endpoint: "http://192.168.1.10:11434"}, true, ""},
+		{"on without agents", ModelManager{Enabled: true}, false, "requires platform.agents"},
+		{"kserve", ModelManager{Enabled: true, Backend: "kserve"}, true, "supports \"ollama\" only"},
+		{"bad endpoint", ModelManager{Enabled: true, Endpoint: "172.21.0.1:11434"}, true, "http(s) URL"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.mm.Validate(tc.agents)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestModelManagerEnabledNeedsPlatformAndAgents(t *testing.T) {
+	cfg := Default()
+	cfg.Platform.ModelManager.Enabled = true
+	if !cfg.ModelManagerEnabled() {
+		t.Fatalf("enabled with the default platform+agents should report on")
+	}
+	cfg.Platform.Agents = false
+	if cfg.ModelManagerEnabled() {
+		t.Fatalf("agents off must switch model-manager off")
+	}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "platform.modelManager") {
+		t.Fatalf("validate should reject model-manager without agents, got %v", err)
+	}
+	if cfg.ModelManagerBaseURL() != "https://agentgateway.127.0.0.1.nip.io/model-manager" {
+		t.Fatalf("unexpected model-manager base URL %q", cfg.ModelManagerBaseURL())
+	}
+}

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -65,6 +65,7 @@ func Run(cfg *config.Config, accessible bool) error {
 	apsRef := cfg.Platform.APSRef
 	agentsEnabled := cfg.Platform.Agents
 	observabilityEnabled := cfg.Platform.Observability
+	modelManagerEnabled := cfg.Platform.ModelManager.Enabled
 	agentsPort := strconv.Itoa(cfg.Platform.AgentsPort)
 	aiModel := cfg.AIModel
 	customizeModels := false
@@ -159,6 +160,12 @@ func Run(cfg *config.Config, accessible bool) error {
 				Affirmative("Install").
 				Negative("Skip").
 				Value(&observabilityEnabled),
+			huh.NewConfirm().
+				Title("Manage this machine's Ollama models from the platform (model-manager)?").
+				Description("Optional, needs the agents runtime: the umbrella's model-manager component with\nthe Ollama backend — pull, load/unload and delete models from the portal or as\nx_model-manager_* tools, each pulled model wired into kagent as a ModelConfig.\nPods reach the host Ollama through the kind docker gateway (bind it to 0.0.0.0).").
+				Affirmative("Manage").
+				Negative("Skip").
+				Value(&modelManagerEnabled),
 			huh.NewInput().
 				Title("Claude model").
 				Description("Used by the platform agents' ModelConfig and Backstage's AI chat.\nThe API key comes from $ANTHROPIC_API_KEY at deploy time, never from this file.").
@@ -199,6 +206,9 @@ func Run(cfg *config.Config, accessible bool) error {
 	cfg.Platform.APSRef = apsRef
 	cfg.Platform.Agents = agentsEnabled
 	cfg.Platform.Observability = observabilityEnabled
+	// Managed models wire into kagent; without the runtime the confirm has
+	// nothing to manage into.
+	cfg.Platform.ModelManager.Enabled = modelManagerEnabled && agentsEnabled
 	cfg.Platform.AgentsPort = mustAtoi(agentsPort)
 	cfg.AIModel = aiModel
 	cfg.Backstage.Port = mustAtoi(backstagePort)

--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -20,8 +20,9 @@ func TestRunTUIDrive(t *testing.T) {
 		"\r", // group 2: customize users? -> keep as is
 		"\r", // group 3: platform + backstage preselected; submit as is
 		// platform group: muster port, aps ref, agents confirm, agents ui
-		// port, observability confirm, claude model, extra models confirm
-		"\r", "\r", "\r", "\r", "\r", "\r", "\r",
+		// port, observability confirm, model-manager confirm, claude model,
+		// extra models confirm
+		"\r", "\r", "\r", "\r", "\r", "\r", "\r", "\r",
 		"\r", // backstage group: port
 	)
 	testOutput = io.Discard
@@ -42,6 +43,9 @@ func TestRunTUIDrive(t *testing.T) {
 	}
 	if !cfg.Platform.Observability {
 		t.Errorf("observability not enabled (the confirm should keep the default)")
+	}
+	if cfg.Platform.ModelManager.Enabled {
+		t.Errorf("model-manager enabled (the confirm should keep the default off)")
 	}
 	if !cfg.Backstage.Enabled {
 		t.Errorf("backstage not enabled by multiselect")

--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -73,6 +73,17 @@ func outputQuiet(name string, args ...string) (string, error) {
 	return buf.String(), err
 }
 
+// outputAll captures stdout AND stderr together, for probe-style commands
+// whose diagnosis is in the error text (a probe pod's wget message).
+func outputAll(name string, args ...string) (string, error) {
+	var buf bytes.Buffer
+	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	return buf.String(), err
+}
+
 // pipeInto feeds input to a command's stdin, showing output only on failure.
 func pipeInto(input []byte, name string, args ...string) error {
 	var buf bytes.Buffer

--- a/internal/lab/mcpsession.go
+++ b/internal/lab/mcpsession.go
@@ -1,0 +1,144 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// musterSession is one MCP Streamable-HTTP session against the lab muster
+// through the edge, authenticated with a Dex id_token as Bearer (muster lists
+// the agent-platform client under trustedAudiences). The same path Claude
+// Code takes after its browser login; PlatformTest carries an inline copy of
+// this dance, the models proof reuses it through this helper.
+type musterSession struct {
+	client *http.Client
+	url    string
+	token  string
+	id     string
+	seq    int
+}
+
+// openMusterSession initializes an MCP session and returns it ready for
+// tools/call requests.
+func openMusterSession(cfg *config.Config, token, clientName string) (*musterSession, error) {
+	client, err := labHTTPClient(60 * time.Second)
+	if err != nil {
+		return nil, err
+	}
+	s := &musterSession{client: client, url: cfg.MusterBaseURL() + "/mcp", token: token}
+	resp, err := s.post("", fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":%q,"version":"1"}}}`, clientName))
+	if err != nil {
+		return nil, err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	s.id = resp.Header.Get("Mcp-Session-Id")
+	if s.id == "" {
+		return nil, fmt.Errorf("no MCP session id — muster rejected the token:\n%.300s", strings.TrimSpace(string(body)))
+	}
+	if resp, err := s.post(s.id, `{"jsonrpc":"2.0","method":"notifications/initialized"}`); err == nil {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	s.seq = 1
+	return s, nil
+}
+
+func (s *musterSession) post(sessionID, payload string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, s.url, strings.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	return s.client.Do(req)
+}
+
+// callTool runs one MCP tools/call and returns the parsed JSON-RPC response.
+func (s *musterSession) callTool(name string, args map[string]any) (map[string]any, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	s.seq++
+	payload, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": s.seq, "method": "tools/call",
+		"params": map[string]any{"name": name, "arguments": args},
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.post(s.id, string(payload))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	parsed, err := parseMCPResponse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing muster response to %s: %w\n%.300s", name, err, strings.TrimSpace(string(raw)))
+	}
+	if rpcErr, ok := parsed["error"].(map[string]any); ok {
+		return nil, fmt.Errorf("muster %s: %v", name, rpcErr["message"])
+	}
+	return parsed, nil
+}
+
+// listTools returns the names of every tool muster aggregates (its core
+// list_tools tool, the way the Backstage muster plugin and Claude Code see it).
+func (s *musterSession) listTools() ([]string, error) {
+	res, err := s.callTool("list_tools", nil)
+	if err != nil {
+		return nil, err
+	}
+	var toolList struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal([]byte(innerText(res)), &toolList); err != nil {
+		return nil, fmt.Errorf("parsing list_tools payload: %w", err)
+	}
+	names := make([]string, 0, len(toolList.Tools))
+	for _, t := range toolList.Tools {
+		names = append(names, t.Name)
+	}
+	return names, nil
+}
+
+// callServerTool runs one aggregated server tool (x_<server>_<tool>) through
+// muster's call_tool and returns the tool's text payload. Tool results are
+// double-wrapped — result.content[0].text is JSON whose own content[0].text
+// is the actual payload — and the inner isError flag is the tool's verdict.
+func (s *musterSession) callServerTool(name string, args map[string]any) (string, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	res, err := s.callTool("call_tool", map[string]any{"name": name, "arguments": args})
+	if err != nil {
+		return "", err
+	}
+	var wrapped struct {
+		IsError bool `json:"isError"`
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	inner := innerText(res)
+	if err := json.Unmarshal([]byte(inner), &wrapped); err != nil || len(wrapped.Content) == 0 {
+		return "", fmt.Errorf("unexpected call_tool payload shape for %s: %.300s", name, inner)
+	}
+	if wrapped.IsError {
+		return "", fmt.Errorf("%s failed: %.300s", name, wrapped.Content[0].Text)
+	}
+	return wrapped.Content[0].Text, nil
+}

--- a/internal/lab/modelmanager.go
+++ b/internal/lab/modelmanager.go
@@ -1,0 +1,144 @@
+package lab
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The model-manager component (platform.modelManager in agentlab.yaml): the
+// umbrella's `model-manager` dependency with the Ollama backend, proxying the
+// Ollama that runs on the lab host. Pods reach the host only through the kind
+// docker network's gateway — the same address the README documents for
+// extraModels — so the endpoint is detected from `docker network inspect
+// kind` rather than asked for. Everything that can go wrong is host-side
+// plumbing (bind address, firewall), which preflightOllama turns into an
+// early, actionable failure instead of a model-manager pod that reports an
+// unhealthy backend after a ten-minute install.
+
+// modelManagerMCPServer is the MCPServer CR name the model-manager chart
+// registers with muster (model-manager.muster.mcpServer.name, the chart
+// default); muster prefixes its tools with it: x_model-manager_<tool>.
+const modelManagerMCPServer = "model-manager"
+
+// kindDockerNetwork is the docker network kind creates its nodes on.
+const kindDockerNetwork = "kind"
+
+// ollamaProbeImage runs the in-cluster reachability probe: busybox wget in
+// the alpine image the umbrella already ships elsewhere (small, present in
+// the host cache after the first run, side-loaded before the probe pod).
+const ollamaProbeImage = "gsoci.azurecr.io/giantswarm/alpine:3.22.1"
+
+// DetectHostOllama probes the host's own Ollama on loopback and reports its
+// version. It answers the configure-time question "is there an Ollama on
+// this machine at all?" — reachability from pods (bind address, firewall) is
+// preflightOllama's job at platform time.
+func DetectHostOllama() (version string, ok bool) {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/version", config.OllamaPort))
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+	var v struct {
+		Version string `json:"version"`
+	}
+	if err := decodeJSONBody(resp, &v); err != nil {
+		return "", false
+	}
+	return v.Version, true
+}
+
+// kindGatewayIP returns the IPv4 gateway of the kind docker network — the
+// address pods use to reach services on the host.
+func kindGatewayIP() (string, error) {
+	out, err := outputQuiet("docker", "network", "inspect", kindDockerNetwork,
+		"-f", `{{range .IPAM.Config}}{{.Gateway}}{{"\n"}}{{end}}`)
+	if err != nil {
+		return "", fmt.Errorf("docker network %q not found (the kind cluster creates it): %w", kindDockerNetwork, err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		ip := net.ParseIP(strings.TrimSpace(line))
+		if ip != nil && ip.To4() != nil {
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("docker network %q has no IPv4 gateway", kindDockerNetwork)
+}
+
+// resolveModelManagerEndpoint is the Ollama endpoint model-manager dials: the
+// configured override, else http://<kind gateway>:11434. The kind network
+// exists once the cluster does, so callers that render before a boot get an
+// error they may tolerate (render) or must not (platform).
+func resolveModelManagerEndpoint(cfg *config.Config) (string, error) {
+	if ep := cfg.Platform.ModelManager.Endpoint; ep != "" {
+		return strings.TrimSuffix(ep, "/"), nil
+	}
+	gw, err := kindGatewayIP()
+	if err != nil {
+		return "", fmt.Errorf("autodetecting the Ollama endpoint: %w (set platform.modelManager.endpoint to skip the detection)", err)
+	}
+	return fmt.Sprintf("http://%s:%d", gw, config.OllamaPort), nil
+}
+
+// preflightOllama proves host Ollama answers from INSIDE the cluster before
+// the platform install waits ten minutes on a model-manager whose backend is
+// unreachable. A short-lived pod fetches <endpoint>/api/version; the two
+// known host-side failures are spelled out with their fixes: the server
+// bound to 127.0.0.1 (connection refused from the bridge) and a host
+// firewall dropping pod->host traffic on the docker bridge (timeout).
+func preflightOllama(cfg *config.Config, endpoint string) error {
+	// The probe image goes host cache -> node like every lab image, so the
+	// pod never waits on an in-node pull (best-effort: a miss falls back to
+	// the kubelet's pull under the pod-running timeout).
+	sideloadImages(cfg, hostPullImages([]string{ollamaProbeImage}))
+	const pod = "ollama-preflight"
+	// A leftover from an interrupted run would make `kubectl run` refuse.
+	_ = runQuiet("kubectl", "-n", platformNamespace, "delete", "pod", pod, "--ignore-not-found", "--wait=false")
+	out, err := outputAll("kubectl", "-n", platformNamespace, "run", pod,
+		"--rm", "-i", "--quiet", "--restart=Never", "--pod-running-timeout=120s",
+		"--image="+ollamaProbeImage, "--image-pull-policy=IfNotPresent",
+		"--command", "--", "wget", "-qO-", "-T", "5", endpoint+"/api/version")
+	if err == nil && strings.Contains(out, `"version"`) {
+		version := strings.TrimSpace(out)
+		if len(version) > 60 {
+			version = version[:60] + "..."
+		}
+		note("host Ollama answers from inside the cluster: %s", version)
+		return nil
+	}
+	out = strings.TrimSpace(out)
+	reason := "the probe pod could not fetch it"
+	fixes := "  - bind Ollama to every interface, not loopback: OLLAMA_HOST=0.0.0.0 (systemd: an\n" +
+		"    Environment= drop-in on ollama.service), then restart it\n" +
+		"  - allow TCP " + fmt.Sprint(config.OllamaPort) + " from the docker bridge subnets (they fall inside\n" +
+		"    172.16.0.0/12) through the host firewall — pod->host traffic arrives on the\n" +
+		"    bridge like any other inbound connection"
+	switch {
+	case strings.Contains(out, "refused"):
+		reason = "connection refused — Ollama is not listening on the bridge address (the usual\n  cause: OLLAMA_HOST left at 127.0.0.1)"
+	case strings.Contains(out, "timed out"), strings.Contains(out, "timeout"):
+		reason = "connection timed out — the host firewall drops pod->host traffic on the docker\n  bridge (the request never reaches Ollama)"
+	}
+	return fmt.Errorf("host Ollama is not reachable from pods at %s: %s.\n"+
+		"  Fixes (README, \"Local backends on the lab host\"):\n%s\n"+
+		"  Then re-run `agentlab platform`, or set platform.modelManager.enabled: false.\n"+
+		"  Probe output: %.300s", endpoint, reason, fixes, out)
+}
+
+// modelManagerHint is the platform-up summary line for the component.
+func modelManagerHint(cfg *config.Config, endpoint string) string {
+	if !cfg.ModelManagerEnabled() {
+		return "  Model manager is disabled (platform.modelManager in agentlab.yaml)."
+	}
+	return fmt.Sprintf("  Model manager: Ollama backend at %s; REST %s/api/v1 (Dex token required),\n"+
+		"  MCP tools x_model-manager_* through muster; the portal's Models tab manages the same models.",
+		endpoint, cfg.ModelManagerBaseURL())
+}

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -1,0 +1,561 @@
+package lab
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// ModelsTestModel is the model the proof pulls and deletes: small (~400 MB)
+// and tool-calling capable, which a kagent agent turn requires (agents send
+// tool schemas with every request; smollm2:135m pulls fine and then fails
+// "does not support tools").
+const ModelsTestModel = "qwen2.5:0.5b"
+
+// modelsTestAgent is the throwaway kagent Agent the proof runs one turn on.
+const modelsTestAgent = "agentlab-models-test"
+
+// modelField is the request field naming a model in the model-manager API.
+const modelField = "model"
+
+// ModelsTest is the headless end-to-end proof of managed models, through the
+// platform path only: the model-manager REST API behind the agentgateway
+// route with a lab user's Dex token (and a 401 without one), then list ->
+// pull with observable progress -> the auto-created kagent ModelConfig
+// (native keyless Ollama provider) Accepted -> a kagent agent turn against it
+// -> the MCP tools through muster -> unload -> delete (gone from Ollama, the
+// ModelConfig gone). Leaves nothing behind.
+func ModelsTest(cfg *config.Config, email, model string) error {
+	if !cfg.ModelManagerEnabled() {
+		return fmt.Errorf("platform.modelManager is off in %s (needs platform.agents too) — enable it and run `agentlab platform` first", config.File)
+	}
+	user := cfg.FindUser(email)
+	if user == nil {
+		return fmt.Errorf("no user %q in %s", email, config.File)
+	}
+	// Generous: the first agent turn loads the model into Ollama.
+	client, err := labHTTPClient(180 * time.Second)
+	if err != nil {
+		return err
+	}
+	api := modelManagerAPI{client: client, base: cfg.ModelManagerBaseURL() + "/api/v1"}
+
+	step("Calling the model-manager API without a token (%s)", cfg.ModelManagerBaseURL())
+	status, _, header, err := api.do(http.MethodGet, "/backend", nil)
+	if err != nil {
+		return fmt.Errorf("model-manager is not reachable through the edge: %w — run `agentlab platform` first", err)
+	}
+	if status != http.StatusUnauthorized {
+		return fmt.Errorf("unauthenticated GET /api/v1/backend answered %d, wanted 401: the route's JWT policy is not enforcing", status)
+	}
+	note("401 without a token (WWW-Authenticate: %s)", firstNonEmpty(header.Get("WWW-Authenticate"), "-"))
+
+	step("Logging in to Dex as %s", email)
+	token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+		user.Email, user.Password, "openid email groups profile")
+	if err != nil {
+		return err
+	}
+	api.token = token
+	note("got an id_token")
+
+	step("Backend through the gateway with the Dex token")
+	var backend struct {
+		Backend      string          `json:"backend"`
+		Version      string          `json:"version"`
+		Endpoint     string          `json:"endpoint"`
+		Healthy      bool            `json:"healthy"`
+		Capabilities map[string]bool `json:"capabilities"`
+		Wiring       struct {
+			Namespace string `json:"namespace"`
+			AutoWire  bool   `json:"autoWire"`
+		} `json:"wiring"`
+	}
+	if err := api.getJSON("/backend", &backend); err != nil {
+		return err
+	}
+	if backend.Backend != config.ModelManagerBackendOllama || !backend.Healthy {
+		return fmt.Errorf("backend %q healthy=%v, wanted a healthy ollama backend (endpoint %s)", backend.Backend, backend.Healthy, backend.Endpoint)
+	}
+	caps := make([]string, 0, len(backend.Capabilities))
+	for name, on := range backend.Capabilities {
+		if on {
+			caps = append(caps, name)
+		}
+	}
+	slices.Sort(caps)
+	note("backend ollama %s at %s, healthy; capabilities: %s", backend.Version, backend.Endpoint, strings.Join(caps, ", "))
+	note("wiring: ModelConfigs in %s, autoWire=%v", backend.Wiring.Namespace, backend.Wiring.AutoWire)
+
+	step("Listing models")
+	names, err := api.modelNames("/models")
+	if err != nil {
+		return err
+	}
+	note("%d models: %s", len(names), strings.Join(names, ", "))
+	if slices.Contains(names, model) {
+		note("%s is left over from an earlier run — deleting it first", model)
+		if err := api.deleteModel(model); err != nil {
+			return err
+		}
+	}
+
+	step("Pulling %s (progress via GET /api/v1/jobs/{id})", model)
+	started := time.Now()
+	status, body, _, err := api.do(http.MethodPost, "/models/pull", map[string]any{modelField: model})
+	if err != nil {
+		return err
+	}
+	if status != http.StatusAccepted {
+		return fmt.Errorf("POST /models/pull answered %d, wanted 202: %.300s", status, body)
+	}
+	var pull struct {
+		Job struct {
+			ID string `json:"id"`
+		} `json:"job"`
+	}
+	if err := json.Unmarshal(body, &pull); err != nil || pull.Job.ID == "" {
+		return fmt.Errorf("pull did not return a job id: %.300s", body)
+	}
+	note("job %s accepted", pull.Job.ID)
+	if err := api.waitJob(pull.Job.ID, 30*time.Minute); err != nil {
+		return err
+	}
+	note("pulled in %s", time.Since(started).Round(time.Second))
+
+	step("Auto-created kagent ModelConfig")
+	mcName := ""
+	found := waitFor(30, 2*time.Second, func() bool {
+		var m struct {
+			ModelConfig struct {
+				Name string `json:"name"`
+			} `json:"modelConfig"`
+			Capabilities []string `json:"capabilities"`
+		}
+		if err := api.getJSON("/models/"+model, &m); err != nil {
+			return false
+		}
+		mcName = m.ModelConfig.Name
+		if mcName != "" && !slices.Contains(m.Capabilities, "tools") {
+			note("warning: %s reports no `tools` capability; the agent turn below will likely fail", model)
+		}
+		return mcName != ""
+	})
+	if !found {
+		return fmt.Errorf("GET /models/%s never reported a wired ModelConfig (autoWire=%v)", model, backend.Wiring.AutoWire)
+	}
+	if err := waitModelConfigAccepted(mcName); err != nil {
+		return err
+	}
+	spec, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName,
+		"-o", `jsonpath={.spec.provider} {.spec.model} {.spec.ollama.host} managed-by={.metadata.labels.app\.kubernetes\.io/managed-by}`)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(spec, config.ProviderOllama+" ") {
+		return fmt.Errorf("ModelConfig %s is not the native Ollama provider: %s", mcName, spec)
+	}
+	note("ModelConfig %s: %s (keyless native provider)", mcName, strings.TrimSpace(spec))
+
+	step("Agent turn on %s (kagent Agent, runtime go -> host Ollama)", mcName)
+	reply, err := agentTurn(client, cfg, mcName, "Reply with exactly the word pong and nothing else.")
+	if err != nil {
+		return err
+	}
+	note("agent replied: %q", excerpt(reply, 120))
+
+	step("MCP tools through muster (x_%s_*)", modelManagerMCPServer)
+	session, err := openMusterSession(cfg, token, "models-test")
+	if err != nil {
+		return err
+	}
+	tools, err := session.listTools()
+	if err != nil {
+		return err
+	}
+	toolPrefix := "x_" + modelManagerMCPServer + "_"
+	var mmTools []string
+	for _, t := range tools {
+		if strings.HasPrefix(t, toolPrefix) {
+			mmTools = append(mmTools, strings.TrimPrefix(t, toolPrefix))
+		}
+	}
+	if len(mmTools) == 0 {
+		return fmt.Errorf("muster aggregates no %s tools; check `kubectl -n %s get mcpservers.muster.giantswarm.io %s`", toolPrefix, platformNamespace, modelManagerMCPServer)
+	}
+	slices.Sort(mmTools)
+	note("%d tools: %s", len(mmTools), strings.Join(mmTools, ", "))
+	text, err := session.callServerTool(toolPrefix+"get_model", map[string]any{modelField: model})
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(text, model) {
+		return fmt.Errorf("%sget_model did not describe %s: %.300s", toolPrefix, model, text)
+	}
+	note("%sget_model sees %s (%s)", toolPrefix, model, excerpt(text, 100))
+
+	step("Unloading %s", model)
+	if status, body, _, err := api.do(http.MethodPost, "/models/unload", map[string]any{modelField: model}); err != nil {
+		return err
+	} else if status/100 != 2 {
+		return fmt.Errorf("POST /models/unload answered %d: %.300s", status, body)
+	}
+	unloaded := waitFor(15, 2*time.Second, func() bool {
+		loaded, err := api.modelNames("/loaded")
+		return err == nil && !slices.Contains(loaded, model)
+	})
+	if !unloaded {
+		return fmt.Errorf("%s still listed by GET /loaded after unload", model)
+	}
+	note("not loaded any more")
+
+	step("Deleting %s", model)
+	if err := api.deleteModel(model); err != nil {
+		return err
+	}
+	if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName); err == nil {
+		gone := waitFor(15, 2*time.Second, func() bool {
+			_, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName)
+			return err != nil
+		})
+		if !gone {
+			return fmt.Errorf("ModelConfig %s survived the delete", mcName)
+		}
+	}
+	note("ModelConfig %s is gone", mcName)
+	endpoint, err := resolveModelManagerEndpoint(cfg)
+	if err != nil {
+		return err
+	}
+	tags, err := ollamaTags(endpoint)
+	if err != nil {
+		return fmt.Errorf("reading the host Ollama's tags at %s: %w", endpoint, err)
+	}
+	if slices.Contains(tags, model) {
+		return fmt.Errorf("host Ollama still has %s after the delete", model)
+	}
+	note("host Ollama at %s no longer has it (%d models left)", endpoint, len(tags))
+	text, err = session.callServerTool(toolPrefix+"list_models", nil)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(text, `"`+model+`"`) {
+		return fmt.Errorf("%slist_models still lists %s", toolPrefix, model)
+	}
+	note("%slist_models agrees", toolPrefix)
+
+	fmt.Println()
+	fmt.Println("PASS: no token -> 401 at the gateway; Dex token -> model-manager REST through agentgateway")
+	fmt.Printf("PASS: list -> pull %s (progress) -> ModelConfig %s (Ollama provider) Accepted -> agent turn -> unload -> delete\n", model, mcName)
+	fmt.Printf("PASS: muster aggregates x_%s_* and calls them (get_model, list_models)\n", modelManagerMCPServer)
+	return nil
+}
+
+// modelManagerAPI is a minimal client of the model-manager REST API through
+// the edge, with the Dex token as Bearer once known.
+type modelManagerAPI struct {
+	client *http.Client
+	base   string
+	token  string
+}
+
+func (a *modelManagerAPI) do(method, path string, payload any) (int, []byte, http.Header, error) {
+	var body io.Reader
+	if payload != nil {
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return 0, nil, nil, err
+		}
+		body = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequest(method, a.base+path, body)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	if a.token != "" {
+		req.Header.Set("Authorization", "Bearer "+a.token)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw, resp.Header, nil
+}
+
+func (a *modelManagerAPI) getJSON(path string, out any) error {
+	status, body, _, err := a.do(http.MethodGet, path, nil)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("GET %s answered %d: %.300s", path, status, body)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("GET %s: parsing %.200s: %w", path, body, err)
+	}
+	return nil
+}
+
+// modelNames lists the model names of a /models-shaped response.
+func (a *modelManagerAPI) modelNames(path string) ([]string, error) {
+	var list struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := a.getJSON(path, &list); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(list.Models))
+	for _, m := range list.Models {
+		names = append(names, m.Name)
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// deleteModel deletes a model (its ModelConfig rides along) and waits until
+// the inventory no longer lists it.
+func (a *modelManagerAPI) deleteModel(model string) error {
+	status, body, _, err := a.do(http.MethodDelete, "/models/"+model, nil)
+	if err != nil {
+		return err
+	}
+	if status/100 != 2 && status != http.StatusNotFound {
+		return fmt.Errorf("DELETE /models/%s answered %d: %.300s", model, status, body)
+	}
+	gone := waitFor(15, 2*time.Second, func() bool {
+		names, err := a.modelNames("/models")
+		return err == nil && !slices.Contains(names, model)
+	})
+	if !gone {
+		return fmt.Errorf("%s still listed after the delete", model)
+	}
+	note("deleted (status %d)", status)
+	return nil
+}
+
+// waitJob polls one job until it finishes, printing progress as it crosses
+// each tenth — the observable-progress part of the proof.
+func (a *modelManagerAPI) waitJob(id string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	lastBucket := -1
+	for time.Now().Before(deadline) {
+		var job struct {
+			Phase          string  `json:"phase"`
+			Status         string  `json:"status"`
+			Percent        float64 `json:"percent"`
+			BytesCompleted int64   `json:"bytesCompleted"`
+			BytesTotal     int64   `json:"bytesTotal"`
+			Error          string  `json:"error"`
+		}
+		if err := a.getJSON("/jobs/"+id, &job); err != nil {
+			return err
+		}
+		if bucket := int(job.Percent) / 10; bucket > lastBucket && job.BytesTotal > 0 {
+			note("%3.0f%%  %s / %s  %s", job.Percent, humanBytes(job.BytesCompleted), humanBytes(job.BytesTotal), job.Status)
+			lastBucket = bucket
+		}
+		switch job.Phase {
+		case "succeeded":
+			return nil
+		case "failed", "cancelled":
+			return fmt.Errorf("job %s %s: %s", id, job.Phase, firstNonEmpty(job.Error, job.Status))
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("job %s did not finish within %s", id, timeout)
+}
+
+// agentTurn creates a throwaway kagent Agent on the ModelConfig, waits for
+// it to be Ready, sends one A2A message/send and returns the agent's text.
+// The Agent is deleted on every path.
+func agentTurn(client *http.Client, cfg *config.Config, modelConfig, prompt string) (string, error) {
+	manifest := fmt.Sprintf(`apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app.kubernetes.io/managed-by: agentlab
+spec:
+  type: Declarative
+  description: agentlab models-test probe (deleted after the run)
+  declarative:
+    runtime: go
+    modelConfig: %s
+    systemMessage: You are a terse assistant. Answer in one short line.
+`, modelsTestAgent, kagentNamespace, modelConfig)
+	if err := pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-"); err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = runQuiet("kubectl", "-n", kagentNamespace, "delete", "agents.kagent.dev", modelsTestAgent, "--ignore-not-found", "--wait=false")
+	}()
+	if err := runQuiet("kubectl", "-n", kagentNamespace, "wait", "--for=condition=Ready", "--timeout=240s",
+		"agents.kagent.dev/"+modelsTestAgent); err != nil {
+		return "", fmt.Errorf("agent %s never became Ready: %w", modelsTestAgent, err)
+	}
+	// The pod may report Ready a moment before the ADK listens; a short retry
+	// absorbs that, the client timeout covers the model load.
+	payload := fmt.Sprintf(`{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","role":"user","messageId":%q,"parts":[{"kind":"text","text":%q}]}}}`,
+		randHex(8), prompt)
+	a2aURL := fmt.Sprintf("%s/api/a2a/%s/%s?user_id=admin@kagent.dev", cfg.KagentUIBaseURL(), kagentNamespace, modelsTestAgent)
+	var reply string
+	var lastErr error
+	answered := waitFor(6, 5*time.Second, func() bool {
+		reply, lastErr = a2aSend(client, a2aURL, payload, prompt)
+		return lastErr == nil
+	})
+	if !answered {
+		return "", fmt.Errorf("A2A turn against %s failed: %w", modelsTestAgent, lastErr)
+	}
+	return reply, nil
+}
+
+// a2aSend posts one JSON-RPC message/send and returns the agent's text: the
+// last text part that is not the prompt, wherever the Task/Message shape put
+// it (status.message, artifacts, history).
+func a2aSend(client *http.Client, url, payload, prompt string) (string, error) {
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("A2A answered %d: %.300s", resp.StatusCode, raw)
+	}
+	var rpc map[string]any
+	if err := json.Unmarshal(raw, &rpc); err != nil {
+		return "", fmt.Errorf("parsing the A2A response: %w: %.300s", err, raw)
+	}
+	if e, ok := rpc["error"].(map[string]any); ok {
+		return "", fmt.Errorf("A2A error: %v", e["message"])
+	}
+	texts := collectStrings(rpc["result"], "text")
+	var reply string
+	for _, t := range texts {
+		if strings.TrimSpace(t) != "" && t != prompt {
+			reply = t
+		}
+	}
+	if reply == "" {
+		return "", fmt.Errorf("no text part in the A2A result: %.300s", raw)
+	}
+	if state := collectStrings(rpc["result"], "state"); len(state) > 0 && state[len(state)-1] == "failed" {
+		return "", fmt.Errorf("A2A task failed: %s", excerpt(reply, 200))
+	}
+	return reply, nil
+}
+
+// collectStrings walks a decoded JSON tree in document order and returns
+// every string value stored under key.
+func collectStrings(node any, key string) []string {
+	var out []string
+	var walk func(any)
+	walk = func(n any) {
+		switch v := n.(type) {
+		case map[string]any:
+			if s, ok := v[key].(string); ok {
+				out = append(out, s)
+			}
+			// Deterministic order: sorted keys.
+			keys := make([]string, 0, len(v))
+			for k := range v {
+				keys = append(keys, k)
+			}
+			slices.Sort(keys)
+			for _, k := range keys {
+				walk(v[k])
+			}
+		case []any:
+			for _, item := range v {
+				walk(item)
+			}
+		}
+	}
+	walk(node)
+	return out
+}
+
+// ollamaTags lists the models the host Ollama has (its /api/tags), dialed
+// directly from the lab host — the ground truth the delete is checked against.
+func ollamaTags(endpoint string) ([]string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(endpoint + "/api/tags")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var tags struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := decodeJSONBody(resp, &tags); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		names = append(names, m.Name)
+	}
+	return names, nil
+}
+
+func decodeJSONBody(resp *http.Response, out any) error {
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: %.200s", resp.Status, raw)
+	}
+	return json.Unmarshal(raw, out)
+}
+
+func humanBytes(n int64) string {
+	switch {
+	case n >= 1<<30:
+		return fmt.Sprintf("%.1f GiB", float64(n)/(1<<30))
+	case n >= 1<<20:
+		return fmt.Sprintf("%.0f MiB", float64(n)/(1<<20))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
+}
+
+func excerpt(s string, n int) string {
+	s = strings.ReplaceAll(strings.TrimSpace(s), "\n", " ")
+	if len(s) > n {
+		return s[:n] + "..."
+	}
+	return s
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -272,6 +272,23 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		}
 	}
 
+	// Managed models: the Ollama endpoint is detected from the kind docker
+	// network and proven reachable from inside the cluster BEFORE the
+	// install, so a host-side misconfiguration (bind address, firewall) fails
+	// here with its fix instead of after helm's ten-minute wait.
+	modelManagerEndpoint := ""
+	if cfg.ModelManagerEnabled() {
+		endpoint, err := resolveModelManagerEndpoint(cfg)
+		if err != nil {
+			return err
+		}
+		modelManagerEndpoint = endpoint
+		step("Checking host Ollama is reachable from pods (%s)", endpoint)
+		if err := preflightOllama(cfg, endpoint); err != nil {
+			return err
+		}
+	}
+
 	if _, _, err := renderManifest(cfg, "agent-platform-values.yaml.tmpl"); err != nil {
 		return err
 	}
@@ -307,6 +324,11 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 	// the DCR chart-bug workaround, HTTPRoute strip, kagent-ui nodePort pin.
 	// Helm 4 accepts only plugin-type post-renderers, so the binary is wrapped
 	// in a generated plugin (see helmplugin.go) that HELM_PLUGINS points at.
+	// --force-conflicts: Helm 4 applies server-side, and a deployment whose
+	// image was swapped for a dev build with `kubectl set image`/`patch` is
+	// then owned by another field manager — without the flag the upgrade
+	// fails on the conflict instead of reconciling the lab back to the chart,
+	// which is what re-running `agentlab platform` promises (HACKS.md H13).
 	pluginsDir, err := ensurePostRenderPlugin()
 	if err != nil {
 		return err
@@ -316,6 +338,7 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		"-n", platformNamespace,
 		"-f", StateDir+"/agent-platform-values.yaml",
 		"--post-renderer", postRenderPluginName,
+		"--force-conflicts",
 		"--wait", "--timeout", "10m"); err != nil {
 		return err
 	}
@@ -327,6 +350,14 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 	if cfg.Platform.Observability {
 		step("Waiting for muster to connect to the Prometheus MCP")
 		if err := waitMCPServerConnected(mcpPrometheusRelease); err != nil {
+			return err
+		}
+	}
+	if cfg.ModelManagerEnabled() {
+		// The model-manager chart renders its own MCPServer CR; Connected
+		// proves the pod serves MCP and muster aggregates x_model-manager_*.
+		step("Waiting for muster to connect to model-manager")
+		if err := waitMCPServerConnected(modelManagerMCPServer); err != nil {
 			return err
 		}
 	}
@@ -450,7 +481,8 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 
 %s
 %s
-%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, obsHint, tryItBlock(cfg))
+%s
+%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, modelManagerHint(cfg, modelManagerEndpoint), obsHint, tryItBlock(cfg))
 	// Everything the platform runs is in the node now — record it so the next
 	// boot side-loads instead of pulling.
 	snapshotPreloadImages(cfg)

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -48,6 +48,12 @@ type tmplData struct {
 	AllGroups           []string
 	KubernetesClientSecret,
 	AgentPlatformClientSecret string
+	// ModelManagerEnabled mirrors cfg.ModelManagerEnabled(); the endpoint is
+	// the Ollama URL model-manager dials (autodetected from the kind docker
+	// network — empty when the cluster does not exist yet, which only a
+	// pre-boot `agentlab render` sees; platformUp resolves it strictly).
+	ModelManagerEnabled  bool
+	ModelManagerEndpoint string
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -55,8 +61,17 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 	if err != nil {
 		return nil, err
 	}
+	endpoint := ""
+	if cfg.ModelManagerEnabled() {
+		if endpoint, err = resolveModelManagerEndpoint(cfg); err != nil {
+			note("model-manager endpoint left empty in the render: %v", err)
+			endpoint = ""
+		}
+	}
 	return &tmplData{
 		Config:                    cfg,
+		ModelManagerEnabled:       cfg.ModelManagerEnabled(),
+		ModelManagerEndpoint:      endpoint,
 		CertsDir:                  certsDir,
 		MusterNodePort:            config.MusterNodePort,
 		KagentUINodePort:          config.KagentUINodePort,

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -62,6 +62,17 @@ gatewayApi:
 # choke point, muster keeps all per-server connection logic and OAuth.
 ingress:
   mode: agentgateway-muster
+{{- if .ModelManagerEnabled }}
+
+gateway:
+  # The model-manager route's JWT policy makes the data plane fetch Dex's
+  # JWKS on 5556; the chart guards that this egress is declared (it only
+  # renders a network-policy rule, and the lab runs no policies).
+  jwksEgress:
+    enabled: true
+    namespace: dex
+    port: 5556
+{{- end }}
 
 components:
   agentgateway:
@@ -85,6 +96,32 @@ components:
     # listens on the host's loopback.
     controllerRoute:
       enabled: true
+{{- end }}
+{{- if .ModelManagerEnabled }}
+  # Managed models (platform.modelManager): the umbrella's model-manager
+  # dependency with the Ollama backend (its own values are in the
+  # `model-manager:` block below). The route exposes its REST API on the
+  # edge at https://agentgateway.{{ .Platform.Domain }}/model-manager — the
+  # chart's Backstage app-config points the portal backend there
+  # (agentPlatform.modelManager.installations.agent-platform.apiBaseUrl).
+  # Unlike the kagent route above, JWT validation is ON: the portal forwards
+  # the user's Dex ID token and the gateway is the identity boundary
+  # (model-manager checks none itself), so an unauthenticated call answers
+  # 401. The lab Dex serves its JWKS over TLS at the issuer path, hence the
+  # in-cluster host, the /dex/keys path and the TLS origination against the
+  # lab CA (jwks.tls.caSecretName defaults to global.identity.ca.secretName).
+  model-manager:
+    enabled: true
+    route:
+      enabled: true
+      jwtAuthentication:
+        enabled: true
+        jwks:
+          host: dex.dex.svc.cluster.local
+          port: 5556
+          path: /dex/keys
+          tls:
+            enabled: true
 {{- end }}
   backstage:
     enabled: {{ .Backstage.Enabled }}
@@ -235,6 +272,18 @@ kagent:
         enabled: false
       logging:
         enabled: false
+{{- end }}
+
+{{- if .ModelManagerEnabled }}
+# The model-manager chart's own values (the umbrella pins the Service name,
+# the kagent namespace and the muster registration in its contract). The
+# Ollama backend dials the host through the kind docker network's gateway —
+# autodetected by `agentlab platform` (platform.modelManager.endpoint
+# overrides). Agent pods dial the same address, so agentHost stays empty.
+model-manager:
+  backend: ollama
+  ollama:
+    endpoint: {{ .ModelManagerEndpoint | printf "%q" }}
 {{- end }}
 
 {{- if .Backstage.Enabled }}

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -171,6 +171,9 @@ func tryItBlock(cfg *config.Config) string {
 	if cfg.Platform.Enabled {
 		cmds = append(cmds, [2]string{"agentlab platform-test", "headless smoke test of the whole platform"})
 	}
+	if cfg.ModelManagerEnabled() {
+		cmds = append(cmds, [2]string{"agentlab models-test", "pull -> ModelConfig -> agent turn -> unload -> delete, through the platform"})
+	}
 	width := 0
 	for _, c := range cmds {
 		width = max(width, len(c[0]))

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ Then:        claude mcp add --transport http muster https://muster.127.0.0.1.nip
 		labCmd("untrust", "Remove the lab CA from the system and browser trust stores", lab.Untrust),
 		labCmd("platform", "Install the Giant Swarm agent platform (muster + Kubernetes MCP)", lab.PlatformUp),
 		platformTestCmd(),
+		modelsTestCmd(),
 		labCmd("platform-down", "Remove the agent platform (leaves Dex and the cluster alone)", lab.PlatformDown),
 		labCmd("backstage", "Retired: Backstage deploys with the platform now (backstage.enabled + `agentlab up`)", lab.BackstageUp),
 		backstageTestCmd(),
@@ -117,6 +118,7 @@ func loadOrCreateConfig() (*config.Config, error) {
 	fmt.Printf("No %s yet — let's create one.\n\n", config.File)
 	cfg = config.Default()
 	reportPortChanges(cfg.ChooseFreePorts())
+	detectModelManager(cfg)
 	if err := forms.Run(cfg, accessibleMode()); err != nil {
 		return nil, err
 	}
@@ -142,6 +144,20 @@ func reportPortChanges(changes []config.PortChange) {
 	fmt.Println()
 }
 
+// detectModelManager turns managed models on for a FRESH configuration when
+// an Ollama answers on this machine: the lab then installs the umbrella's
+// model-manager component with the Ollama backend. Reachability from pods
+// (bind address, firewall) is checked at platform time, with the fixes.
+func detectModelManager(cfg *config.Config) {
+	version, ok := lab.DetectHostOllama()
+	if !ok {
+		return
+	}
+	cfg.Platform.ModelManager.Enabled = true
+	fmt.Printf("Found Ollama %s on this machine: managed models (model-manager, Ollama backend) enabled.\n", version)
+	fmt.Printf("Turn it off with `agentlab configure --defaults --model-manager=false`.\n\n")
+}
+
 // accessibleMode switches huh to its prompt-per-question accessible mode;
 // also what screen readers want.
 func accessibleMode() bool {
@@ -150,7 +166,7 @@ func accessibleMode() bool {
 
 func configureCmd() *cobra.Command {
 	var defaults, accessible bool
-	var platform, agents, observability, backstage bool
+	var platform, agents, observability, backstage, modelManager bool
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Ask for the lab configuration interactively and save agentlab.yaml",
@@ -161,9 +177,11 @@ func configureCmd() *cobra.Command {
 				// Only a FRESH config gets its ports moved off occupied
 				// defaults: an existing agentlab.yaml describes a cluster
 				// whose kind mappings are already fixed (and would count as
-				// "occupied" themselves while the lab runs).
+				// "occupied" themselves while the lab runs). Same for the
+				// model-manager detection: an existing file keeps its choice.
 				cfg = config.Default()
 				reportPortChanges(cfg.ChooseFreePorts())
+				detectModelManager(cfg)
 			} else if err != nil {
 				return err
 			}
@@ -176,6 +194,9 @@ func configureCmd() *cobra.Command {
 				}
 				if cmd.Flags().Changed("observability") {
 					cfg.Platform.Observability = observability
+				}
+				if cmd.Flags().Changed("model-manager") {
+					cfg.Platform.ModelManager.Enabled = modelManager
 				}
 				if cmd.Flags().Changed("backstage") {
 					cfg.Backstage.Enabled = backstage
@@ -201,6 +222,13 @@ func configureCmd() *cobra.Command {
 			for _, m := range cfg.Platform.ExtraModels {
 				fmt.Printf("  extra model %s (%s %s)\n", m.Name, m.Provider, m.Model)
 			}
+			if cfg.ModelManagerEnabled() {
+				endpoint := cfg.Platform.ModelManager.Endpoint
+				if endpoint == "" {
+					endpoint = "autodetected from the kind docker network at platform time"
+				}
+				fmt.Printf("  models     managed by model-manager (%s backend, %s)\n", cfg.Platform.ModelManager.Backend, endpoint)
+			}
 			fmt.Println("\nNext: agentlab up")
 			return nil
 		},
@@ -210,6 +238,7 @@ func configureCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&agents, "agents", false, "with --defaults: enable/disable the agents runtime (kagent, part of the platform install)")
 	cmd.Flags().BoolVar(&observability, "observability", false, "with --defaults: enable/disable the observability stack (Prometheus + mcp-prometheus)")
 	cmd.Flags().BoolVar(&backstage, "backstage", false, "with --defaults: enable/disable Backstage (implies the platform)")
+	cmd.Flags().BoolVar(&modelManager, "model-manager", false, "with --defaults: enable/disable managed models (the model-manager component with the host Ollama; needs agents)")
 	cmd.Flags().BoolVar(&accessible, "accessible", false, "prompt-per-question form mode (for screen readers and plain terminals)")
 	return cmd
 }
@@ -279,6 +308,28 @@ func platformTestCmd() *cobra.Command {
 			return lab.PlatformTest(cfg, email)
 		},
 	}
+}
+
+func modelsTestCmd() *cobra.Command {
+	var model string
+	cmd := &cobra.Command{
+		Use:   "models-test [email]",
+		Short: "Headless managed-models proof: 401 without a token, then pull -> ModelConfig -> agent turn -> MCP via muster -> unload -> delete",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			email := cfg.AdminUser().Email
+			if len(args) == 1 {
+				email = args[0]
+			}
+			return lab.ModelsTest(cfg, email, model)
+		},
+	}
+	cmd.Flags().StringVar(&model, "model", lab.ModelsTestModel, "the Ollama model to pull and delete (small and tool-calling capable)")
+	return cmd
 }
 
 func backstageTestCmd() *cobra.Command {


### PR DESCRIPTION
Closes #46. Lab side of the Model Manager epic giantswarm/giantswarm#37590 (the Ollama backend ADR); the chart side is giantswarm/agent-platform-standalone#75 (component `model-manager`, #70).

## What

`platform.modelManager` puts the umbrella's **model-manager** component (Ollama backend) in front of the Ollama on the lab host: the host's models become manageable from the portal and as `x_model-manager_<tool>` through muster, every pulled model auto-wired into kagent as a keyless `Ollama` ModelConfig. `extraModels` stays as it is; the two coexist.

| Piece | Where |
|---|---|
| `platform.modelManager.{enabled, backend, endpoint}` + validation; `configure` detects a host Ollama for a fresh config (`--defaults --model-manager[=false]`, the form asks) | `internal/config/config.go`, `main.go`, `internal/forms/forms.go` |
| Endpoint autodetection `http://<kind docker network gateway>:11434` (`docker network inspect kind`), the extraModels address | `internal/lab/modelmanager.go` |
| Preflight: a short-lived pod fetches `<endpoint>/api/version` before the install; failure = the two host-side fixes spelled out (bind `OLLAMA_HOST=0.0.0.0` on *refused*, host firewall on the docker bridge subnets on *timeout*) | `internal/lab/modelmanager.go`, `platform.go` |
| Values: `components.model-manager` on with the route at `https://agentgateway.<domain>/model-manager` and **JWT validation on** (lab Dex JWKS over TLS via the lab CA), `gateway.jwksEgress`, `model-manager.ollama.endpoint` | `internal/lab/templates/agent-platform-values.yaml.tmpl` |
| `agentlab models-test`: 401 without a token → Dex token → backend → list → pull (progress) → auto-ModelConfig Accepted → kagent agent turn (A2A) → MCP tools via muster → unload → delete (Ollama, ModelConfig, `list_models` agree) | `internal/lab/modelstest.go`, `mcpsession.go` |
| `helm upgrade --force-conflicts` so `agentlab platform` reconciles dev-image swaps again on Helm 4 (HACKS.md H13) | `internal/lab/platform.go`, `HACKS.md` |
| README "Managed models: model-manager + host Ollama", CLAUDE.md | docs |

## Judgment calls

- The lab supports the `ollama` backend only (validated): kserve needs GPU nodes and a KServe install this kind cluster does not have.
- Managed models require `platform.agents` (the ModelConfigs land in kagent); the form's confirm silently follows the agents toggle.
- The JWT boundary is ON in the lab for model-manager (unlike the lab's kagent route): the portal backend forwards the user's Dex ID token, and a call without one must get 401 — that is the trust model the chart documents, so the lab proves it.
- The default `apsRef` bump to the agent-platform-standalone main tip containing the component lands as a follow-up commit on this branch once #75 is merged.

## Verification

Evidence (lab run from the chart branch, then from the released chart) is posted on #46 when the run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
