### PR TITLE
fix: keep kubectl's attach warning out of the Ollama preflight note

### DIFF
--- a/internal/lab/modelmanager.go
+++ b/internal/lab/modelmanager.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 
@@ -32,6 +33,9 @@ const kindDockerNetwork = "kind"
 // the alpine image the umbrella already ships elsewhere (small, present in
 // the host cache after the first run, side-loaded before the probe pod).
 const ollamaProbeImage = "gsoci.azurecr.io/giantswarm/alpine:3.22.1"
+
+// ollamaVersionRe matches the {"version":"..."} document /api/version answers.
+var ollamaVersionRe = regexp.MustCompile(`\{\s*"version"\s*:\s*"[^"]*"\s*\}`)
 
 // DetectHostOllama probes the host's own Ollama on loopback and reports its
 // version. It answers the configure-time question "is there an Ollama on
@@ -107,9 +111,12 @@ func preflightOllama(cfg *config.Config, endpoint string) error {
 		"--image="+ollamaProbeImage, "--image-pull-policy=IfNotPresent",
 		"--command", "--", "wget", "-qO-", "-T", "5", endpoint+"/api/version")
 	if err == nil && strings.Contains(out, `"version"`) {
+		// The combined output also carries kubectl's own attach chatter
+		// ("warning: couldn't attach to pod ..., falling back to logs"), so
+		// pick the JSON document out of it.
 		version := strings.TrimSpace(out)
-		if len(version) > 60 {
-			version = version[:60] + "..."
+		if m := ollamaVersionRe.FindString(out); m != "" {
+			version = m
 		}
 		note("host Ollama answers from inside the cluster: %s", version)
 		return nil

--- a/internal/lab/modelmanager_test.go
+++ b/internal/lab/modelmanager_test.go
@@ -1,0 +1,10 @@
+package lab
+
+import "testing"
+
+func TestOllamaVersionRe(t *testing.T) {
+	out := "{\"version\":\"0.33.2\"}warning: couldn't attach to pod/ollama-preflight, falling back to streaming logs"
+	if got := ollamaVersionRe.FindString(out); got != `{"version":"0.33.2"}` {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #47 (giantswarm/agentlab#46). In the lab's second bring-up the preflight note read `host Ollama answers from inside the cluster: {"version":"0.33.2"}warning: couldn't attach to pod/ollama-p...` — `kubectl run --rm -i` prints its attach fallback to stderr, which the probe captures together with stdout for diagnosis. The note now picks the `{"version":"..."}` document out of the output (unit test included); the diagnosis path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)