### PR TITLE
feat: per-server OAuth sign-in — muster as OAuth client + the lab-oauth-fixture MCPServer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,13 @@ with Dex doing the logins.
 - The Kubernetes tools come from the umbrella's bundled `mcp-kubernetes`
   MCPServer and use muster's per-server prefixing: `x_mcp-kubernetes_<tool>`
   (e.g. `x_mcp-kubernetes_list`), no `management_cluster` argument.
+- muster's OAuth *client* role is on (`oauth.mcpClient`), and the lab ships
+  one `Auth Required` downstream to sign in to: the MCPServer
+  `lab-oauth-fixture`, which points muster at its own protected `/mcp`. It
+  exists for the per-server sign-in path (`core_auth_login`, the portal's
+  Sign in button); `platform-test` and `backstage-test` assert the challenge.
+  Not a real integration — never "fix" its Auth Required state, and after a
+  muster pod roll it reads `Failed` for about a minute by design.
 - With `platform.observability: true` (the default), a minimal Prometheus
   (the GS kube-prometheus-stack constituent of the observability bundle, with
   the server re-enabled) and mcp-prometheus install too; the tools surface as

--- a/HACKS.md
+++ b/HACKS.md
@@ -334,6 +334,14 @@ can be dropped (it would render nothing here either way).
   vendored and gitignored; out of scope here.
 - **`login-browser.py` fixed callback port 5555** — must be pre-registered in
   Dex's `redirectURIs`; a random port would break the static client. By design.
+- **The OAuth sign-in fixture aggregates muster itself** (`lab-oauth-fixture`
+  → muster's own protected `/mcp`, `internal/lab/oauthfixture.go`) — the one
+  way to get a downstream that stays `Auth Required` behind an authorization
+  server that accepts muster's CIMD client id without adding a workload (Dex
+  knows only static clients). Costs: `Failed` for about a minute after a muster
+  restart (self-dial before the listener is up; `agentlab platform` waits it
+  out), and a completed sign-in connects muster to itself. Both accepted; see
+  README "Signing in to a downstream server".
 - **A twice-replaced, once-trusted CA lingers only until the next trust op** —
   a `platform.domain` change stashes the outgoing CA under `certs/replaced/`,
   and both `agentlab trust` and `untrust` sweep every stashed CA out of the

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then bring the lab up:
 export ANTHROPIC_API_KEY=sk-ant-...   # optional: powers the agents + Backstage AI chat
 ./agentlab configure       # interactive form: cluster, users, components
 ./agentlab up              # certs, kind cluster, Dex, RBAC, the agent platform — verified
-./agentlab platform-test   # headless proof: Dex -> muster -> mcp-kubernetes -> apiserver
+./agentlab platform-test   # headless proof: Dex -> muster -> mcp-kubernetes -> apiserver, + the per-server OAuth sign-in challenge
 ./agentlab models-test     # with an Ollama on the host: pull -> ModelConfig -> agent turn -> delete, through the platform
 ```
 
@@ -232,6 +232,55 @@ the rendered Dex config closes that loop; its `redirectURIs` must equal
 `mcp-kubernetes` is deliberately unauthenticated on the cluster network
 (the bundled `MCPServer` CR carries no auth block) and talks to the apiserver
 with its own ServiceAccount. muster is the single enforcement point.
+
+### Signing in to a downstream server (muster as OAuth client)
+
+muster plays two OAuth roles. Towards Claude Code and Backstage it is the
+**server** (above). Towards a downstream MCP server that declares
+`auth.type: oauth` it is the **client**: `core_auth_login` (what the portal's
+per-server **Sign in** button calls) answers a challenge — a
+`https://muster.<domain>/oauth/proxy/start?state=…` URL — the browser follows
+it through the downstream's authorization server, and muster keeps the token
+per session. The umbrella leaves that role off (`oauth.mcpClient`), so the
+lab's values turn it on with the edge URL as `publicUrl` (the chart derives
+the callback `/oauth/proxy/callback` and serves muster's client ID metadata
+document at `/.well-known/oauth-client.json`), the way real installations run
+it.
+
+Nothing the lab aggregates needs a per-user login, though — mcp-kubernetes,
+mcp-prometheus and model-manager are unauthenticated in-cluster — so
+`agentlab platform` ships one downstream that does: the MCPServer
+`lab-oauth-fixture` (`oauth-fixture.yaml.tmpl`, annotated as a fixture). It
+points muster at its **own** protected `/mcp` endpoint, which answers 401 with
+RFC 9728 metadata naming muster's own OAuth 2.1 server as the authorization
+server. The CR therefore sits at `Auth Required` for good, every
+`core_auth_login` yields a fresh challenge, and the challenge chain is the
+real one: proxy start → muster `/oauth/authorize` → Dex. A Dex-protected stub
+could not serve the same purpose (Dex knows only static clients; the proxy
+identifies itself by CIMD), and a dedicated OAuth-protected stub server would
+add a workload plus an authorization server that knows muster, for the same
+401. What the self-aggregation costs: right after a muster restart the CR
+reads `Failed` (muster dials itself before its listener is up) until the
+reconnect backoff flips it to `Auth Required`, about a minute — `agentlab
+platform` waits for that — and
+completing the sign-in connects muster to itself, surfacing its own tools
+under `x_lab-oauth-fixture_`. Harmless and per session; the fixture is there
+to be signed in *to*.
+
+`agentlab platform-test` proves the path headlessly on a fresh MCP session
+(the shape of one portal user's session): `list_tools` flags the fixture under
+`servers_requiring_auth`; `core_auth_login` answers a challenge on
+`/oauth/proxy/start` with a state; a second call answers a **fresh** state (a
+re-clicked Sign in gets its own challenge, giantswarm/backstage#2203); and the
+URL redeems — GET-ing it redirects to the authorization server rather than
+rejecting the state. `agentlab backstage-test` proves the portal hop for every
+user: the fixture is listed `Auth Required` and `POST /api/muster/auth/login`
+answers `status: auth_required` with the same URL shape, on that user's own
+forwarded token.
+
+To drive the UI: **Agent Platform → MCP Servers**, expand `lab-oauth-fixture`,
+**Sign in** — the popup lands on muster's authorization page, then Dex. After a
+muster pod roll the row reads `Failed` for about a minute (Reconnect, or wait).
 
 ### Agents (kagent)
 
@@ -571,6 +620,7 @@ same one-URL trick, just spelled with a name.
 | `networkPolicy.enabled: false`, `kyvernoPolicies.enabled: false` | The umbrella's own policy objects. No Cilium and no Kyverno in kind, so both would render CRs whose API groups the cluster does not serve. |
 | The muster/kagent ServiceMonitors, valkey PodMonitor and muster PrometheusRule follow `platform.observability` | Without it there is no Prometheus Operator, so none of those CRDs exist and the releases fail to render. With it they are scraped by the lab Prometheus — whose selectors are opened up (`*NilUsesHelmValues: false`) because upstream's default selects only monitors carrying the kps release label, and the platform's monitors come from other releases. Flipping observability rolls the muster pod once (the toggle changes its metrics-exporter env). |
 | `platform.observability`: the GS kube-prometheus-stack constituent installed directly, Prometheus server re-enabled, instead of the observability-bundle | The bundle is MC-shaped (Flux HelmReleases with a hardcoded remote kubeconfig, Alloy → Mimir, no local PromQL endpoint). See [Observability](#observability-prometheus--mcp-prometheus). |
+| `muster.muster.oauth.mcpClient.enabled: true` + the `lab-oauth-fixture` MCPServer | The umbrella leaves muster's OAuth *client* role — the proxy behind `core_auth_login` and the portal's Sign in — off; real installations turn it on, and without it no per-server sign-in can be exercised. The fixture is the one `Auth Required` downstream to sign in to (muster's own protected `/mcp`); see [Signing in to a downstream server](#signing-in-to-a-downstream-server-muster-as-oauth-client). |
 | `muster.rbac.{mcpServerEditor,workflowEditor}.subjects` → `oidc:platform-admins` | The umbrella binds muster's editor Roles to Giant Swarm's admin groups, which do not exist here. Rebound to the lab's own admin group (`--oidc-groups-prefix=oidc:`, same spelling as the lab RBAC). Lists replace, so the GS groups are dropped. |
 | muster patched to `hostNetwork` + `maxSurge: 0` | Same issuer trick as the apiserver and Backstage. `maxSurge: 0` because two hostNetwork pods cannot both bind `:8090` on a one-node cluster. Applied by `agentlab post-render` — Helm 4 accepts only plugin-type post-renderers, so the install generates a `postrenderer/v1` plugin in `state/helm-plugins/` whose command is the agentlab binary itself, and passes it via `HELM_PLUGINS` + `--post-renderer agentlab-postrender`. The plain-Helm replacement for the Flux `postRenderers` the meta-package forwarded to helm-controller. |
 | `components.kagent.enabled` from `platform.agents`, `controller.auth.mode: unsecure`, kagent ServiceMonitor + OTel off | Agents are part of what the lab tests, so kagent is on by default (the umbrella defaults it off) but optional — `platform.agents: false` skips the runtime. `unsecure` because the GS `trusted-proxy` mode assumes a JWT-validating agentgateway in front; no Prometheus Operator / OTLP gateway in kind. See [Agents (kagent)](#agents-kagent). |
@@ -692,7 +742,9 @@ muster accepts the token because its `aud` carries `muster` — see
 [`trustedPeers` points the other way round](#trustedpeers-points-the-other-way-round).
 
 `agentlab backstage-test` drives the whole sign-in headlessly for every
-configured user and then proves the muster hop with that user's own token:
+configured user and then proves the muster hop with that user's own token —
+including the per-server **Sign in** path (`/api/muster/auth/login`) against
+the lab's `Auth Required` fixture:
 
 ```
 === dev@lab.local ===
@@ -700,7 +752,8 @@ configured user and then proves the muster hop with that user's own token:
   token audience  [kubernetes muster backstage]
   backstage user  user:default/dev
   ownership refs  [user:default/dev]
-  muster servers  [(mcp-kubernetes, Connected)]
+  muster servers  [(mcp-kubernetes, Connected), (mcp-prometheus, Connected), (lab-oauth-fixture, Auth Required)]
+  sign-in challenge lab-oauth-fixture -> https://muster.127.0.0.1.nip.io/oauth/proxy/start?state=… (client id via cimd)
   muster workflows [lab-cluster-overview]
   muster core tools 28 exposed
   agent deploy template registered (template:default/agent-deployment)
@@ -987,6 +1040,7 @@ internal/lab/                  everything operational:
   test.go                        RBAC assertions for every configured user
   login.go browser.go            password grant / authorization-code flow
   platform.go platformtest.go    agent platform install + MCP smoke test
+  oauthfixture.go                the Auth Required MCPServer fixture + the per-server sign-in proof
   backstage.go backstagetest.go  Backstage deploy + headless sign-in proof
   postrender.go                  helm post-renderer (hostNetwork, route strip, nodePort pin)
   helmplugin.go                  generates the Helm 4 postrenderer plugin wrapping it

--- a/internal/lab/backstagetest.go
+++ b/internal/lab/backstagetest.go
@@ -180,6 +180,29 @@ func backstageSignIn(cfg *config.Config, user *config.User) error {
 		return resp.StatusCode, payload, nil
 	}
 
+	// musterPost is the mutation shape of the same hop: a JSON body, the raw
+	// answer back (the routes normalise muster's tool results themselves).
+	musterPost := func(path string, body any) (int, []byte, error) {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, err
+		}
+		req, err := http.NewRequest(http.MethodPost, cfg.BackstageBaseURL()+"/api/muster"+path, strings.NewReader(string(payload)))
+		if err != nil {
+			return 0, nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+bsToken)
+		req.Header.Set("backstage-muster-authorization", dexIDToken)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := follow.Do(req)
+		if err != nil {
+			return 0, nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+		raw, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, raw, nil
+	}
+
 	// The umbrella's app-config names the muster installation after the Helm
 	// release, not the kind cluster.
 	installation := "?installation=" + platformRelease
@@ -199,6 +222,46 @@ func backstageSignIn(cfg *config.Config, user *config.User) error {
 		}
 	}
 	fmt.Printf("  muster servers  [%s]\n", strings.Join(pairs, ", "))
+
+	// The per-server sign-in path behind the portal's Sign in button
+	// (backstage#2203), with this user's own forwarded token: the lab's
+	// fixture (oauthfixture.go) is listed as Auth Required, and /auth/login
+	// hands back muster's challenge — the OAuth proxy start URL with a state
+	// — normalised to status auth_required.
+	fixtureState := "missing"
+	for _, s := range servers {
+		if m, ok := s.(map[string]any); ok && m[nameKey] == oauthFixtureServer {
+			fixtureState = fmt.Sprintf("%v", m["state"])
+		}
+	}
+	if !isAuthRequiredState(fixtureState) {
+		return fmt.Errorf("MCPServer %s is %q, not Auth Required — the sign-in fixture is missing or broken (`agentlab platform` creates it)",
+			oauthFixtureServer, fixtureState)
+	}
+	status, raw, err := musterPost("/auth/login"+installation, map[string]any{"server": oauthFixtureServer})
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("muster /auth/login FAILED %d: %.200s", status, raw)
+	}
+	var login struct {
+		Status         string `json:"status"`
+		AuthURL        string `json:"authUrl"`
+		Message        string `json:"message"`
+		ClientIDMethod string `json:"clientIdMethod"`
+	}
+	if err := json.Unmarshal(raw, &login); err != nil {
+		return fmt.Errorf("parsing /auth/login answer: %w\n%.200s", err, raw)
+	}
+	if login.Status != "auth_required" {
+		return fmt.Errorf("/auth/login for %s answered status %q, not auth_required: %.300s", oauthFixtureServer, login.Status, login.Message)
+	}
+	if want := cfg.MusterBaseURL() + oauthProxyStartPath + "?state="; !strings.HasPrefix(login.AuthURL, want) {
+		return fmt.Errorf("/auth/login sign-in URL %q is not muster's proxy start endpoint (want %s…)", login.AuthURL, want)
+	}
+	fmt.Printf("  sign-in challenge %s -> %s%s?state=… (client id via %s)\n",
+		oauthFixtureServer, cfg.MusterBaseURL(), oauthProxyStartPath, login.ClientIDMethod)
 
 	status, payload, err = muster("/workflows" + installation)
 	if err != nil {

--- a/internal/lab/mcpsession.go
+++ b/internal/lab/mcpsession.go
@@ -115,30 +115,48 @@ func (s *musterSession) listTools() ([]string, error) {
 	return names, nil
 }
 
-// callServerTool runs one aggregated server tool (x_<server>_<tool>) through
-// muster's call_tool and returns the tool's text payload. Tool results are
-// double-wrapped — result.content[0].text is JSON whose own content[0].text
-// is the actual payload — and the inner isError flag is the tool's verdict.
-func (s *musterSession) callServerTool(name string, args map[string]any) (string, error) {
+// toolEnvelope is the target tool's full result as muster's call_tool
+// meta-tool serialises it into result.content[0].text: the tool's own
+// content, its isError verdict and, for tools that carry machine-readable
+// output (core_auth_login's sign-in URL), structuredContent.
+type toolEnvelope struct {
+	IsError bool `json:"isError"`
+	Content []struct {
+		Text string `json:"text"`
+	} `json:"content"`
+	StructuredContent map[string]any `json:"structuredContent"`
+}
+
+// callToolEnvelope runs one tool through muster's call_tool — the way every
+// aggregated server tool (x_<server>_<tool>) and every core_* tool is reached
+// — and returns the tool's full result envelope; the caller judges isError.
+func (s *musterSession) callToolEnvelope(name string, args map[string]any) (*toolEnvelope, error) {
 	if args == nil {
 		args = map[string]any{}
 	}
 	res, err := s.callTool("call_tool", map[string]any{"name": name, "arguments": args})
 	if err != nil {
+		return nil, err
+	}
+	var env toolEnvelope
+	inner := innerText(res)
+	if err := json.Unmarshal([]byte(inner), &env); err != nil || len(env.Content) == 0 {
+		return nil, fmt.Errorf("unexpected call_tool payload shape for %s: %.300s", name, inner)
+	}
+	return &env, nil
+}
+
+// callServerTool runs one aggregated server tool (x_<server>_<tool>) through
+// muster's call_tool and returns the tool's text payload. Tool results are
+// double-wrapped — result.content[0].text is JSON whose own content[0].text
+// is the actual payload — and the inner isError flag is the tool's verdict.
+func (s *musterSession) callServerTool(name string, args map[string]any) (string, error) {
+	env, err := s.callToolEnvelope(name, args)
+	if err != nil {
 		return "", err
 	}
-	var wrapped struct {
-		IsError bool `json:"isError"`
-		Content []struct {
-			Text string `json:"text"`
-		} `json:"content"`
+	if env.IsError {
+		return "", fmt.Errorf("%s failed: %.300s", name, env.Content[0].Text)
 	}
-	inner := innerText(res)
-	if err := json.Unmarshal([]byte(inner), &wrapped); err != nil || len(wrapped.Content) == 0 {
-		return "", fmt.Errorf("unexpected call_tool payload shape for %s: %.300s", name, inner)
-	}
-	if wrapped.IsError {
-		return "", fmt.Errorf("%s failed: %.300s", name, wrapped.Content[0].Text)
-	}
-	return wrapped.Content[0].Text, nil
+	return env.Content[0].Text, nil
 }

--- a/internal/lab/oauthfixture.go
+++ b/internal/lab/oauthfixture.go
@@ -1,0 +1,202 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The per-server OAuth sign-in fixture.
+//
+// Every downstream the lab aggregates (mcp-kubernetes, mcp-prometheus,
+// model-manager) is unauthenticated in-cluster, so nothing exercises muster's
+// OAuth *client* role: the proxy behind core_auth_login and the portal's
+// per-server "Sign in" button, which hands the user a challenge URL, walks the
+// browser through the downstream's authorization server and keeps the token
+// per session. The lab turns that role on (muster.muster.oauth.mcpClient in
+// agent-platform-values.yaml.tmpl — the umbrella leaves it off, real
+// installations turn it on) and ships one downstream that declares auth.type
+// oauth and stays Auth Required, so the path can be driven and proven
+// headlessly. Why the fixture targets muster's own protected endpoint is
+// explained in templates/oauth-fixture.yaml.tmpl.
+
+const (
+	// oauthFixtureServer is the fixture MCPServer's name — what the proofs
+	// sign in to and what the portal lists.
+	oauthFixtureServer = "lab-oauth-fixture"
+	// oauthFixtureURL is muster's own protected /mcp, in-cluster (the muster
+	// Service; the pod is hostNetwork, so the Service forwards to the node).
+	oauthFixtureURL = "http://" + componentMuster + "." + platformNamespace + ".svc.cluster.local:8090/mcp"
+	// oauthProxyStartPath is muster's OAuth proxy start endpoint, the path
+	// every sign-in challenge points the browser at (muster's
+	// DefaultOAuthProxyStartPath; the chart renders no override).
+	oauthProxyStartPath = "/oauth/proxy/start"
+	// mcpServerStateAuthRequired is the CRD status.state of a reachable remote
+	// server that answered 401 — muster's api.StateAuthRequired, spelled the
+	// CRD way.
+	mcpServerStateAuthRequired = "Auth Required"
+)
+
+// ensureOAuthFixture applies the fixture and waits until muster reports it
+// Auth Required. After the umbrella install on purpose: the MCPServer CRD
+// ships with muster. On a fresh install the first dial 401s at once; on a
+// re-run the CR already exists and the new muster pod's startup dial found no
+// listener yet (Failed), so the wait spans muster's reconnect backoff — about
+// a minute, measured.
+func ensureOAuthFixture(cfg *config.Config) error {
+	step("Creating the OAuth sign-in fixture (MCPServer %s)", oauthFixtureServer)
+	_, path, err := renderManifest(cfg, "oauth-fixture.yaml.tmpl")
+	if err != nil {
+		return err
+	}
+	if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
+		return err
+	}
+	return waitMCPServerState(oauthFixtureServer, mcpServerStateAuthRequired)
+}
+
+// isAuthRequiredState accepts both spellings of muster's auth-required state:
+// the CRD's "Auth Required" and the service-state token "auth_required".
+func isAuthRequiredState(state string) bool {
+	return strings.EqualFold(strings.ReplaceAll(state, "_", " "), mcpServerStateAuthRequired)
+}
+
+// authChallenge is what core_auth_login answers for a server the session is
+// not signed in to: the prose plus the machine-readable sign-in URL (the
+// portal reads structuredContent.authUrl, never the text).
+type authChallenge struct {
+	authURL        string
+	state          string
+	clientIDMethod string
+}
+
+// signInChallenge runs core_auth_login for the fixture on the session and
+// parses the challenge, asserting the sign-in URL is muster's OAuth proxy
+// start endpoint on the public URL, carrying a state.
+func signInChallenge(cfg *config.Config, s *musterSession) (*authChallenge, error) {
+	// core_auth_login is a core tool: reachable only through muster's
+	// call_tool meta-tool, whose envelope carries the challenge's
+	// structuredContent — the same envelope the portal's backend unwraps.
+	env, err := s.callToolEnvelope("core_auth_login", map[string]any{"server": oauthFixtureServer})
+	if err != nil {
+		return nil, err
+	}
+	text := strings.TrimSpace(env.Content[0].Text)
+	if env.IsError {
+		return nil, fmt.Errorf("core_auth_login refused: %s", text)
+	}
+	authURL, _ := env.StructuredContent["authUrl"].(string)
+	if authURL == "" {
+		return nil, fmt.Errorf("core_auth_login answered no structuredContent.authUrl — not a challenge:\n%s", text)
+	}
+	wantPrefix := cfg.MusterBaseURL() + oauthProxyStartPath + "?state="
+	if !strings.HasPrefix(authURL, wantPrefix) {
+		return nil, fmt.Errorf("sign-in URL %q is not muster's proxy start endpoint (want %s…)", authURL, wantPrefix)
+	}
+	u, err := url.Parse(authURL)
+	if err != nil {
+		return nil, fmt.Errorf("sign-in URL %q: %w", authURL, err)
+	}
+	state := u.Query().Get("state")
+	if state == "" {
+		return nil, fmt.Errorf("sign-in URL %q carries an empty state", authURL)
+	}
+	method, _ := env.StructuredContent["clientIdMethod"].(string)
+	return &authChallenge{authURL: authURL, state: state, clientIDMethod: method}, nil
+}
+
+// proveOAuthSignIn is the headless per-server sign-in proof, on a fresh MCP
+// session (the shape of one portal user's session): list_tools flags the
+// fixture as requiring auth; core_auth_login answers a challenge whose URL is
+// muster's OAuth proxy start endpoint with a state; a second call answers a
+// fresh state (every Sign in click gets its own challenge, backstage#2203);
+// and the URL is redeemable — GET-ing it redirects the browser on to the
+// authorization server (muster's own /oauth/authorize here) instead of
+// rejecting the state.
+func proveOAuthSignIn(cfg *config.Config, token string) error {
+	step("Per-server OAuth sign-in: core_auth_login for the %s fixture", oauthFixtureServer)
+	// The challenge itself does not depend on the CR state, but right after a
+	// muster restart the CR reads Failed until muster's retry finds its own
+	// listener — and a Failed fixture is what the portal would show.
+	if err := waitMCPServerState(oauthFixtureServer, mcpServerStateAuthRequired); err != nil {
+		return err
+	}
+	s, err := openMusterSession(cfg, token, "platform-test-oauth")
+	if err != nil {
+		return err
+	}
+
+	res, err := s.callTool("list_tools", nil)
+	if err != nil {
+		return err
+	}
+	var listing struct {
+		ServersRequiringAuth []struct {
+			Name     string `json:"name"`
+			Status   string `json:"status"`
+			AuthTool string `json:"auth_tool"`
+		} `json:"servers_requiring_auth"`
+	}
+	if err := json.Unmarshal([]byte(innerText(res)), &listing); err != nil {
+		return fmt.Errorf("parsing list_tools payload: %w", err)
+	}
+	flagged := false
+	for _, srv := range listing.ServersRequiringAuth {
+		if srv.Name == oauthFixtureServer {
+			flagged = true
+			note("list_tools: %s status=%s auth_tool=%s", srv.Name, srv.Status, srv.AuthTool)
+		}
+	}
+	if !flagged {
+		return fmt.Errorf("list_tools does not list %s under servers_requiring_auth", oauthFixtureServer)
+	}
+
+	first, err := signInChallenge(cfg, s)
+	if err != nil {
+		return err
+	}
+	note("challenge: %s%s?state=%.12s… (client id via %s)",
+		cfg.MusterBaseURL(), oauthProxyStartPath, first.state, first.clientIDMethod)
+	second, err := signInChallenge(cfg, s)
+	if err != nil {
+		return fmt.Errorf("second core_auth_login: %w", err)
+	}
+	if second.state == first.state {
+		return fmt.Errorf("the second core_auth_login reused the first challenge's state — Sign in cannot be reopened with a fresh challenge")
+	}
+	note("a second core_auth_login answers a fresh state")
+
+	// Redeem the URL the way the browser would, minus following the redirect.
+	transport, err := labTLSTransport()
+	if err != nil {
+		return err
+	}
+	noFollow := &http.Client{Transport: transport, Timeout: 30 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	resp, err := noFollow.Get(second.authURL)
+	if err != nil {
+		return err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	location := resp.Header.Get("Location")
+	if resp.StatusCode < 300 || resp.StatusCode > 399 || location == "" {
+		return fmt.Errorf("the proxy start endpoint answered %d instead of redirecting to the authorization server:\n%.300s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	target, err := url.Parse(location)
+	if err != nil {
+		return fmt.Errorf("proxy start redirect %q: %w", location, err)
+	}
+	if !strings.Contains(target.Path, "authorize") {
+		return fmt.Errorf("the proxy start endpoint redirected to %s, not to an authorization endpoint", location)
+	}
+	note("proxy start redirects to %s://%s%s (the authorization server)", target.Scheme, target.Host, target.Path)
+	return nil
+}

--- a/internal/lab/oauthfixture_test.go
+++ b/internal/lab/oauthfixture_test.go
@@ -1,0 +1,83 @@
+package lab
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// TestOAuthFixtureTemplate pins the fixture CR to what the proofs look for:
+// the name the Go side asserts on, muster's own protected endpoint as the
+// target, an oauth auth block without SSO (forwardToken off, no token
+// exchange — either would make core_auth_login refuse the manual login), and
+// its purpose spelled out on the object.
+func TestOAuthFixtureTemplate(t *testing.T) {
+	raw, err := renderTemplate(config.Default(), "oauth-fixture.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := string(raw)
+	for _, want := range []string{
+		"kind: MCPServer",
+		"name: " + oauthFixtureServer,
+		"namespace: " + platformNamespace,
+		"url: " + oauthFixtureURL,
+		"type: streamable-http",
+		"type: oauth",
+		"forwardToken: false",
+		"autoStart: true",
+		"agentlab.giantswarm.io/purpose:",
+		"app.kubernetes.io/managed-by: agentlab",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered fixture missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "tokenExchange") {
+		t.Errorf("the fixture must not be an SSO server (token exchange):\n%s", out)
+	}
+	if got := strings.Count(out, "kind: MCPServer"); got != 1 {
+		t.Errorf("want exactly one MCPServer, got %d:\n%s", got, out)
+	}
+}
+
+// TestPlatformValuesEnableOAuthClient: the umbrella leaves muster's OAuth
+// client role (oauth.mcpClient) off; the lab's values turn it on with the
+// public URL every sign-in challenge must carry.
+func TestPlatformValuesEnableOAuthClient(t *testing.T) {
+	cfg := config.Default()
+	raw, err := renderTemplate(cfg, "agent-platform-values.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	out := string(raw)
+	if got := strings.Count(out, "mcpClient:"); got != 1 {
+		t.Fatalf("want exactly one mcpClient block, got %d:\n%s", got, out)
+	}
+	block := out[strings.Index(out, "mcpClient:"):]
+	if end := strings.Index(block, "\n      server:"); end > 0 {
+		block = block[:end]
+	}
+	for _, want := range []string{
+		"enabled: true",
+		`publicUrl: "` + cfg.MusterBaseURL() + `"`,
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("mcpClient block missing %q:\n%s", want, block)
+		}
+	}
+}
+
+func TestIsAuthRequiredState(t *testing.T) {
+	for _, s := range []string{"Auth Required", "auth_required", "AUTH REQUIRED"} {
+		if !isAuthRequiredState(s) {
+			t.Errorf("%q should read as auth required", s)
+		}
+	}
+	for _, s := range []string{"Connected", "Failed", "", "reauth_required"} {
+		if isAuthRequiredState(s) {
+			t.Errorf("%q must not read as auth required", s)
+		}
+	}
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -370,6 +370,11 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 	if err := runQuiet("kubectl", "apply", "-f", StateDir+"/demo-workflow.yaml"); err != nil {
 		return err
 	}
+	// The per-server OAuth sign-in fixture (oauthfixture.go) — after the
+	// install for the same CRD reason.
+	if err := ensureOAuthFixture(cfg); err != nil {
+		return err
+	}
 
 	// The agents' model key. The default ModelConfig (rendered by the kagent
 	// subchart from providers.anthropic) references this secret; agent pods
@@ -490,23 +495,29 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 }
 
 // waitMCPServerConnected polls one muster MCPServer CR (in the platform
-// namespace) until muster reports the downstream connection up. The name is
-// fully qualified because kagent ships its own MCPServer CRD
-// (mcpservers.kagent.dev), so the bare kind resolves to the wrong API group.
+// namespace) until muster reports the downstream connection up.
 func waitMCPServerConnected(name string) error {
+	return waitMCPServerState(name, "Connected")
+}
+
+// waitMCPServerState polls the MCPServer CR's status.state until it reads
+// want. The name is fully qualified because kagent ships its own MCPServer
+// CRD (mcpservers.kagent.dev), so the bare kind resolves to the wrong API
+// group.
+func waitMCPServerState(name, want string) error {
 	state := ""
-	connected := waitFor(40, 3*time.Second, func() bool {
+	reached := waitFor(40, 3*time.Second, func() bool {
 		state, _ = outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io", name,
 			"-o", "jsonpath={.status.state}")
-		return state == "Connected"
+		return state == want
 	})
-	if !connected {
-		return fmt.Errorf("MCPServer %s never reached Connected (last state: %q);\n"+
+	if !reached {
+		return fmt.Errorf("MCPServer %s never reached %s (last state: %q);\n"+
 			"check `agentlab logs muster`, `kubectl -n %s describe mcpservers.muster.giantswarm.io %s`\n"+
 			"and the server's rollout: `kubectl -n %s get deploy,pods`",
-			name, state, platformNamespace, name, platformNamespace)
+			name, want, state, platformNamespace, name, platformNamespace)
 	}
-	note("MCPServer %s: Connected", name)
+	note("MCPServer %s: %s", name, want)
 	return nil
 }
 

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -146,6 +146,14 @@ func PlatformTest(cfg *config.Config, email string) error {
 	note("namespaces: %s", strings.Join(names, ", "))
 
 	verdict := "PASS: Claude Code -> muster (Dex) -> mcp-kubernetes -> kind apiserver"
+
+	// The per-server sign-in path: muster as OAuth client, challenged by the
+	// lab's Auth Required fixture (oauthfixture.go).
+	if err := proveOAuthSignIn(cfg, token); err != nil {
+		return err
+	}
+	verdict += "\nPASS: per-server OAuth sign-in -> muster (OAuth client) -> challenge on " + oauthProxyStartPath +
+		" (fixture " + oauthFixtureServer + ")"
 	if cfg.Platform.Observability {
 		// Same singleton prefixing as mcp-kubernetes: the lab's mcpServers
 		// entry deliberately keeps the server out of muster's families

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -54,6 +54,10 @@ type tmplData struct {
 	// pre-boot `agentlab render` sees; platformUp resolves it strictly).
 	ModelManagerEnabled  bool
 	ModelManagerEndpoint string
+	// The per-server OAuth sign-in fixture (oauthfixture.go): the MCPServer
+	// name the proofs sign in to and the protected endpoint it points at.
+	OAuthFixtureServer string
+	OAuthFixtureURL    string
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -72,6 +76,8 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		Config:                    cfg,
 		ModelManagerEnabled:       cfg.ModelManagerEnabled(),
 		ModelManagerEndpoint:      endpoint,
+		OAuthFixtureServer:        oauthFixtureServer,
+		OAuthFixtureURL:           oauthFixtureURL,
 		CertsDir:                  certsDir,
 		MusterNodePort:            config.MusterNodePort,
 		KagentUINodePort:          config.KagentUINodePort,
@@ -150,6 +156,7 @@ var manifests = map[string]struct {
 	"mcp-prometheus-values.yaml.tmpl":        {out: "mcp-prometheus-values.yaml"},
 	"observability-route.yaml.tmpl":          {out: "observability-route.yaml"},
 	"demo-workflow.yaml.tmpl":                {out: "demo-workflow.yaml"},
+	"oauth-fixture.yaml.tmpl":                {out: "oauth-fixture.yaml"},
 	"extra-models.yaml.tmpl":                 {out: "extra-models.yaml"},
 	"coredns.yaml.tmpl":                      {out: "coredns.yaml"},
 	"gateway-nodeport.yaml.tmpl":             {out: "gateway-nodeport.yaml"},

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -197,6 +197,21 @@ muster:
         name: dex-ca
         key: ca.crt
     oauth:
+      # muster's OAuth *client* role: the proxy that signs a user in to a
+      # downstream MCP server declaring `auth.type: oauth` — behind
+      # core_auth_login and the portal's per-server "Sign in" button. The
+      # umbrella leaves it off (real installations turn it on); without it
+      # core_auth_login refuses with "OAuth proxy is not enabled" and no
+      # per-server sign-in can be exercised. publicUrl is where the
+      # downstream's authorization server sends the browser back — the chart
+      # defaults callbackPath to /oauth/proxy/callback (distinct from the
+      # server role's /oauth/callback) and serves the client ID metadata
+      # document at /.well-known/oauth-client.json. The one downstream that
+      # needs it is the lab's sign-in fixture, MCPServer
+      # {{ .OAuthFixtureServer }} (oauth-fixture.yaml.tmpl).
+      mcpClient:
+        enabled: true
+        publicUrl: "{{ .MusterBaseURL }}"
       server:
         enabled: true
         # The public URL through the edge: what Claude Code dials, and what

--- a/internal/lab/templates/oauth-fixture.yaml.tmpl
+++ b/internal/lab/templates/oauth-fixture.yaml.tmpl
@@ -1,0 +1,48 @@
+# A test fixture, not a real integration. Every downstream the lab aggregates
+# (mcp-kubernetes, mcp-prometheus, model-manager) is unauthenticated on the
+# cluster network, so nothing would otherwise exercise muster's OAuth *client*
+# role — the proxy behind core_auth_login and the portal's per-server
+# "Sign in" button. This MCPServer declares `auth.type: oauth` and stays
+# "Auth Required" forever: every core_auth_login against it answers a fresh
+# challenge (a /oauth/proxy/start URL with its own state), which is what
+# `agentlab platform-test` and `agentlab backstage-test` prove.
+#
+# The target is muster's OWN protected /mcp endpoint (its in-cluster Service).
+# It answers 401 with RFC 9728 resource metadata pointing at muster's own
+# OAuth 2.1 server, so the challenge chain is the real one — proxy start ->
+# muster /oauth/authorize -> Dex — and the authorization server accepts
+# muster's CIMD client id, which a Dex-protected stub could not (Dex knows
+# only static clients). A dedicated OAuth-protected stub server would cost a
+# workload plus an authorization server that knows muster, for the same 401.
+# What self-aggregation costs: right after a muster restart the CR reads
+# Failed (muster dials itself before its own listener is up) until the
+# reconnect backoff flips it to Auth Required, about a minute — `agentlab
+# platform` waits for that — and
+# a completed sign-in connects muster to itself, surfacing its own tools
+# under x_{{ .OAuthFixtureServer }}_. Harmless and per session; the fixture
+# exists to be signed in TO, not to be used.
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: {{ .OAuthFixtureServer }}
+  namespace: agent-platform
+  labels:
+    app.kubernetes.io/managed-by: agentlab
+    agentlab.giantswarm.io/fixture: oauth-sign-in
+  annotations:
+    agentlab.giantswarm.io/purpose: >-
+      Lab test fixture for the per-server OAuth sign-in path: points muster at
+      its own OAuth-protected /mcp endpoint so this server stays "Auth
+      Required" and every core_auth_login yields a fresh challenge. Proven by
+      `agentlab platform-test` and `agentlab backstage-test`. Not a real
+      integration; signing in connects muster to itself (harmless).
+spec:
+  description: >-
+    Lab fixture: an OAuth-protected MCP server that stays Auth Required, for
+    testing the per-server Sign in flow. Not a real integration.
+  type: streamable-http
+  url: {{ .OAuthFixtureURL }}
+  autoStart: true
+  auth:
+    type: oauth
+    forwardToken: false


### PR DESCRIPTION
## Problem

The lab's muster (agent-platform-standalone at `platform.apsRef`) ran with `oauth.server` on but **not** `oauth.mcpClient` — muster's OAuth *client* role, the proxy behind `core_auth_login` and the portal's per-server **Sign in** button. `core_auth_login` refused with "OAuth is not configured … OAuth proxy is not enabled", and no MCPServer in the lab declared `auth.type: oauth`. Verifying giantswarm/backstage#2203 (reopen Sign in with a fresh challenge) meant hand-patching the `muster-config` ConfigMap and creating an ad-hoc MCPServer.

## Change

- **Values** (`agent-platform-values.yaml.tmpl`): `muster.muster.oauth.mcpClient.enabled: true` with the edge URL as `publicUrl`. The umbrella's schema passes the `muster:` subtree through untouched (`additionalProperties: true`) and the muster chart (5.7.4) already renders `mcpClient` (callbackPath `/oauth/proxy/callback`, CIMD at `/.well-known/oauth-client.json` from its defaults) — **no agent-platform-standalone change needed**. Real installations run this role on too.
- **Fixture** (`oauth-fixture.yaml.tmpl`, `oauthfixture.go`): MCPServer `lab-oauth-fixture` (`auth.type: oauth`, annotated `agentlab.giantswarm.io/purpose`, `spec.description`), applied by `agentlab platform` after the install (the CRD ships with muster) and waited to `Auth Required`. Its target is muster's **own** protected `/mcp` (in-cluster Service): 401 with RFC 9728 metadata naming muster's own OAuth 2.1 server, so the CR stays Auth Required for good, every `core_auth_login` yields a fresh challenge, and the chain is real (proxy start → muster `/oauth/authorize` → Dex) with muster's CIMD client id accepted.
  - Why not a stub: a Dex-protected stub cannot work (Dex knows only static clients, the proxy identifies itself by CIMD); a dedicated OAuth-protected stub server adds a workload *plus* an authorization server that knows muster, for the same 401.
  - Cost of self-aggregation (documented in README/HACKS): after a muster pod roll the CR reads `Failed` for about a minute (measured 60s) until the reconnect backoff flips it — `agentlab platform` waits it out; completing the sign-in connects muster to itself (harmless, per session).
- **Proof, `platform-test`**: on a fresh MCP session, `list_tools` flags the fixture under `servers_requiring_auth`; `core_auth_login` (via `call_tool`, the same envelope the portal backend unwraps) answers a challenge whose URL is `<muster>/oauth/proxy/start?state=…`; a **second** call answers a fresh state; GET-ing the URL redirects to the authorization server.
- **Proof, `backstage-test`**: per user, the fixture is listed `Auth Required` and `POST /api/muster/auth/login` (backstage#2203's path) answers `status: auth_required` with the same URL shape on that user's forwarded token.
- `musterSession.callToolEnvelope` factors the `call_tool` envelope (incl. `structuredContent`) out of `callServerTool`; `waitMCPServerConnected` generalised to `waitMCPServerState`.
- README (new section "Signing in to a downstream server", deviations table, sample output, layout), CLAUDE.md, HACKS.md (accepted trade-off).

## Verification (lab, 2026-09-02)

`agentlab platform` with this binary → helm rev 12, muster log `OAuth proxy enabled with public URL: https://muster.127.0.0.1.nip.io` + self-hosted CIMD; `MCPServer lab-oauth-fixture: Auth Required` right after the install.

```
==> Per-server OAuth sign-in: core_auth_login for the lab-oauth-fixture fixture
    MCPServer lab-oauth-fixture: Auth Required
    list_tools: lab-oauth-fixture status=auth_required auth_tool=core_auth_login
    challenge: https://muster.127.0.0.1.nip.io/oauth/proxy/start?state=eyJzZXNzaW9u… (client id via cimd)
    a second core_auth_login answers a fresh state
    proxy start redirects to https://muster.127.0.0.1.nip.io/oauth/authorize (the authorization server)
PASS: per-server OAuth sign-in -> muster (OAuth client) -> challenge on /oauth/proxy/start (fixture lab-oauth-fixture)
```

`backstage-test` (admin/dev/viewer): `muster servers [(lab-oauth-fixture, Auth Required), (mcp-kubernetes, Connected), …]` and `sign-in challenge lab-oauth-fixture -> …/oauth/proxy/start?state=… (client id via cimd)` for each. `agentlab test` 10/10. `kubectl rollout restart deploy/muster` → fixture `Failed` for ~60s → `Auth Required`, within the wait. `go test ./...`, `golangci-lint` (gosec, goconst) clean.

Related: giantswarm/backstage#2203 (the UI fix this lets the lab verify), giantswarm/muster#1127 (wording).
