### PR TITLE
feat: install an unreleased chart (platform.apsPath) and route agent inference through agentgateway (platform.llmRouting)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,17 @@ with Dex doing the logins.
   agentgateway route `https://agentgateway.<domain>/model-manager` with JWT
   validation on (a Dex token is required; 401 without). Proof:
   `./agentlab models-test` (see README "Managed models").
+- `platform.llmRouting` (off by default) routes agent inference through the
+  platform's agentgateway instead of straight out of the agent pods: a
+  cluster-internal `llm` listener on the edge Gateway plus the kagent
+  ModelConfig cutover, so the data plane emits per-agent GenAI metrics
+  (`agentgateway_gen_ai_client_token_usage_*`,
+  `agentgateway_gen_ai_client_cost_usd_total`, both carrying `agent` and
+  `agent_namespace`) that the lab Prometheus scrapes. The chart change is
+  unreleased (HACKS.md U13), so it needs `platform.apsPath` — a local
+  `agent-platform-standalone` checkout, curated from a local fleet checkout
+  with `hack/curate.sh -fleet-dir`, installed instead of `apsRef`. See the
+  README's "LLM routing" and "Installing an unreleased chart" sections.
 - For verifying RBAC as a specific user, use `./agentlab login <email>` and
   `kubectl --kubeconfig kubeconfig.oidc` — that is the OIDC path.
 - The kind admin context (`kind-agentlab`) bypasses the platform and OIDC

--- a/HACKS.md
+++ b/HACKS.md
@@ -168,6 +168,14 @@ does not exist in gsoci (verified 2026-08-27, `NAME_UNKNOWN`) and PR
 is still open (its head is exactly the pinned `APS_REF`).
 **Unblocks:** merge #11 and publish the chart; then the vendor block becomes
 `helm upgrade --install … oci://gsoci.azurecr.io/charts/giantswarm/agent-platform-standalone`.
+**Escape hatch:** `platform.apsPath` installs a local checkout instead of the
+pinned commit (`ensurePlatformChart` skips the fetch and only builds the
+chart's dependencies). It exists because the delivery chain consumes released
+artifacts at every hop — a change to `agentic-platform` is not installable
+here until it is published, which is when the lab is most useful. The
+`agent-platform-standalone` side of the same gap is `hack/curate.sh
+-fleet-dir` (giantswarm/agent-platform-standalone#93). Both stay useful after
+the OCI release: they are how the next unreleased chart change gets tested.
 
 ### U5. `platform.go`: mcp-kubernetes must be `--wait`ed serially before muster installs — RETIRED (#34)
 muster dials its MCPServers ~2s after starting; a failed first dial schedules
@@ -316,6 +324,19 @@ guard.
 **Unblocks:** giantswarm/kube-prometheus-stack-app — guard the PolicyException
 fallback with a Capabilities check like the sibling branches; then the value
 can be dropped (it would render nothing here either way).
+
+### U13. `platform.llmRouting` off by default — the chart change is unreleased
+Routing agent inference through the platform's agentgateway needs the
+`llmRouting` block, which only exists on
+[giantswarm/agent-platform#254](https://github.com/giantswarm/agent-platform/pull/254).
+The released umbrella declares no such key and its `values.schema.json`
+rejects an undeclared top-level one, so a lab that emitted the block by
+default would fail every install. The toggle therefore defaults to `false`
+and needs `platform.apsPath` (U4) pointing at a standalone chart curated from
+that branch.
+**Unblocks:** release the connectivity chart change and bump `platform.apsRef`
+to a standalone chart that carries `llmRouting`; then `platform.llmRouting`
+can default to `true` and stop needing `apsPath`.
 
 ## Accepted lab trade-offs (not hacks to fix)
 

--- a/README.md
+++ b/README.md
@@ -618,6 +618,77 @@ observability endpoint — proving Dex → muster → mcp-prometheus → Prometh
 and the Backstage metrics path end to end. Logs:
 `agentlab logs prometheus`, `agentlab logs mcp-prometheus`.
 
+### LLM routing (agent inference through agentgateway)
+
+**Off by default** (`platform.llmRouting`). On, agent inference stops going
+straight from the agent pods to `api.anthropic.com` and goes through the
+platform's own agentgateway instead, so one component observes every model
+call and the data plane emits GenAI metrics for it — tokens by type, cost in
+USD, request duration, and the calling agent as a label.
+
+Two things land together: the edge Gateway grows a cluster-internal `llm`
+listener on port 8081 (a pod port on the data plane — unrelated to
+`platform.agentsPort`, the *host* port for the kagent UI), and kagent's
+default ModelConfig dials it. The gateway holds no provider credential: the
+agent pods keep their own `$ANTHROPIC_API_KEY` and the client `x-api-key`
+header passes through untouched, so reach to the listener grants no spend.
+
+The metrics land in the lab Prometheus through the data-plane `PodMonitor`,
+which needs `platform.observability`. After one agent turn:
+
+```console
+$ agentlab login admin@lab.local   # or ask Claude Code through x_mcp-prometheus_execute_query
+$ curl -sS --cacert certs/ca.crt -G \
+    https://observability.127.0.0.1.nip.io/prometheus/api/v1/query \
+    --data-urlencode 'query=sum by (agent, agent_namespace) (agentgateway_gen_ai_client_cost_usd_total)'
+```
+
+`agent` is the agent's ServiceAccount name, resolved from the source IP
+against the agentgateway controller's pod store. It is **not** cryptographic
+identity — adequate for accounting, never for authorization. A caller the
+store does not know renders `unknown` and keeps the series.
+`agentgateway_cost_catalog_lookups_total{status="Exact"}` grows for a model
+the chart's price catalog knows; `Missing` means it does not.
+`agentgateway_gen_ai_server_time_to_first_token_*` only exists once something
+*streams* through the listener — a kagent agent turn does not, so those series
+stay absent under agent traffic alone.
+
+The chart change this rides on is unreleased, so the toggle needs a chart that
+carries it. See the next section.
+
+### Installing an unreleased chart (`platform.apsPath`)
+
+`platform.apsRef` pins the umbrella to a commit of
+`giantswarm/agent-platform-standalone`, which is generated from the *released*
+`agentic-platform` charts. So a change to those charts is not installable here
+until it is published — which is exactly when the lab is most useful. Two
+escape hatches close that gap:
+
+1. In an `agent-platform-standalone` checkout, curate from a local checkout of
+   the fleet charts instead of pulling the pin:
+
+   ```console
+   $ hack/curate.sh -fleet-dir ~/workspace/agentic-platform/helm
+   $ pre-commit run helm-schema-agent-platform-standalone --all-files
+   ```
+
+   A new top-level values key also needs its `keys:` rule in `curate.yaml`
+   (the transform is deny-unknown), and the schema regeneration is not
+   optional — Helm rejects a values key the committed `values.schema.json`
+   does not declare.
+
+2. Point the lab at that checkout:
+
+   ```console
+   $ agentlab configure --defaults --aps-path ~/workspace/agent-platform-standalone
+   $ agentlab platform
+   ```
+
+   `apsRepo`/`apsRef` are ignored while `apsPath` is set, and the boot says so
+   (`Using the local agent-platform-standalone at …`). The checkout is only
+   read — `helm dependency build` fills its gitignored `charts/`, nothing else
+   is written. Clear it with `--aps-path ""`.
+
 ### Why `localhost` and not `127.0.0.1`
 
 The issuer was originally `https://127.0.0.1:32000/dex`. muster refuses that:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strconv"
@@ -133,6 +134,23 @@ type Platform struct {
 	// at this pinned SHA. Once released this becomes an OCI ref.
 	APSRepo string `yaml:"apsRepo"`
 	APSRef  string `yaml:"apsRef"`
+	// LLMRouting sends agent inference through the agentgateway data plane
+	// instead of straight out of the agent pods, so one component observes
+	// every model call: the edge Gateway grows a cluster-internal LLM
+	// listener, the default kagent ModelConfig dials it, and the data plane
+	// emits per-agent GenAI metrics (agentgateway_gen_ai_*, cost in USD) the
+	// lab's Prometheus scrapes. Off by default: the chart change is
+	// unreleased, so it needs a chart that carries it — today that means
+	// apsPath pointing at a locally curated agent-platform-standalone.
+	// Requires agents (the ModelConfig cutover is the point).
+	LLMRouting bool `yaml:"llmRouting,omitempty"`
+	// APSPath installs the umbrella from a local checkout instead, skipping
+	// the git vendor step: the path to an agent-platform-standalone working
+	// copy, whose helm/agent-platform-standalone is used as-is. This is how
+	// an UNRELEASED chart change is tested in the lab — curate the standalone
+	// chart from a local fleet checkout there (`hack/curate.sh -fleet-dir`),
+	// then point the lab at it. apsRepo/apsRef are ignored while it is set.
+	APSPath string `yaml:"apsPath,omitempty"`
 	// Additional kagent ModelConfigs beyond the chart-rendered default
 	// (aiModel): self-hosted OpenAI-compatible endpoints (vLLM, Ollama),
 	// OpenRouter, Gemini, plain OpenAI. Rendered as lab-labeled ModelConfig
@@ -528,6 +546,15 @@ func (c *Config) Validate() error {
 	}
 	if err := ValidatePort(strconv.Itoa(c.Platform.AgentsPort)); err != nil {
 		return fmt.Errorf("platform.agentsPort: %w", err)
+	}
+	if c.Platform.LLMRouting && !c.Platform.Agents {
+		return fmt.Errorf("platform.llmRouting needs platform.agents: the cutover points kagent's default ModelConfig at the LLM listener, and without the runtime there is no model call to route")
+	}
+	if c.Platform.APSPath != "" {
+		chart := filepath.Join(c.Platform.APSPath, "helm", "agent-platform-standalone", "Chart.yaml")
+		if _, err := os.Stat(chart); err != nil {
+			return fmt.Errorf("platform.apsPath %q: %w (expected an agent-platform-standalone checkout)", c.Platform.APSPath, err)
+		}
 	}
 	seenModels := map[string]bool{}
 	for _, m := range c.Platform.ExtraModels {

--- a/internal/lab/llmrouting_test.go
+++ b/internal/lab/llmrouting_test.go
@@ -1,0 +1,97 @@
+package lab
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// TestPlatformValuesLLMRoutingOff: the toggle is off by default and the
+// values must then carry no llmRouting key at all. The released umbrella does
+// not declare one, and its values.schema.json rejects an undeclared top-level
+// key outright — a stray block would fail every default install.
+func TestPlatformValuesLLMRoutingOff(t *testing.T) {
+	cfg := config.Default()
+	if cfg.Platform.LLMRouting {
+		t.Fatalf("platform.llmRouting must default to false (the chart change is unreleased)")
+	}
+	out := renderPlatformValues(t, cfg)
+	if strings.Contains(out, "llmRouting") {
+		t.Errorf("llmRouting renders with the toggle off:\n%s", out)
+	}
+	if strings.Contains(out, "baseUrl: http://agentgateway.") {
+		t.Errorf("the ModelConfig cutover renders with the toggle off:\n%s", out)
+	}
+}
+
+// TestPlatformValuesLLMRoutingOn pins the two halves that must land together:
+// the listener the chart renders, and the base URL kagent's default
+// ModelConfig dials. One without the other is a broken lab — a listener
+// nothing uses, or agents pointed at a port with nothing behind it.
+func TestPlatformValuesLLMRoutingOn(t *testing.T) {
+	cfg := config.Default()
+	cfg.Platform.LLMRouting = true
+	out := renderPlatformValues(t, cfg)
+
+	wantURL := fmt.Sprintf("baseUrl: http://agentgateway.%s.svc:%d", platformNamespace, llmListenerPort)
+	for _, want := range []string{
+		"llmRouting:",
+		"enabled: true",
+		fmt.Sprintf("port: %d", llmListenerPort),
+		wantURL,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered values missing %q:\n%s", want, out)
+		}
+	}
+	// The listener port and the port in the base URL come from one constant;
+	// this asserts the rendered pair agrees, which a hand-edited template
+	// could break silently (the agents would dial a closed port).
+	listener := out[strings.Index(out, "llmRouting:"):]
+	if end := strings.Index(listener, "\ncomponents:"); end > 0 {
+		listener = listener[:end]
+	}
+	if !strings.Contains(listener, fmt.Sprintf("port: %d", llmListenerPort)) {
+		t.Errorf("the llm listener does not carry port %d:\n%s", llmListenerPort, listener)
+	}
+}
+
+// TestLLMRoutingNeedsAgents: the cutover points kagent's default ModelConfig
+// at the listener, so the toggle is meaningless without the runtime and the
+// config refuses it rather than rendering a listener nothing calls.
+func TestLLMRoutingNeedsAgents(t *testing.T) {
+	cfg := config.Default()
+	cfg.Platform.LLMRouting = true
+	cfg.Platform.Agents = false
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatalf("llmRouting without agents must not validate")
+	}
+	if !strings.Contains(err.Error(), "platform.llmRouting needs platform.agents") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestPlatformChartDir: apsPath replaces the vendored checkout as the chart
+// root, and both roots use the same repository layout.
+func TestPlatformChartDir(t *testing.T) {
+	cfg := config.Default()
+	if got, want := platformChartDir(cfg), apsDir+"/helm/agent-platform-standalone"; got != want {
+		t.Errorf("vendored chart dir = %q, want %q", got, want)
+	}
+	cfg.Platform.APSPath = "/tmp/aps"
+	if got, want := platformChartDir(cfg), "/tmp/aps/helm/agent-platform-standalone"; got != want {
+		t.Errorf("local chart dir = %q, want %q", got, want)
+	}
+}
+
+func renderPlatformValues(t *testing.T, cfg *config.Config) string {
+	t.Helper()
+	raw, err := renderTemplate(cfg, "agent-platform-values.yaml.tmpl")
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	return string(raw)
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -16,6 +16,12 @@ import (
 
 const platformNamespace = "agent-platform"
 
+// llmListenerPort is the data-plane Gateway's cluster-internal LLM listener.
+// The chart's own default, restated here because the lab writes the same
+// number into the listener and into the ModelConfig base URL that dials it.
+// Unrelated to platform.agentsPort, which is a HOST port for the kagent UI.
+const llmListenerPort = 8081
+
 // platformRelease is the umbrella's Helm release name. Also the name of the
 // muster installation Backstage surfaces: the chart's app-config derives its
 // gs/kubernetes/muster installation entries from {{ .Release.Name }}.
@@ -33,6 +39,17 @@ const (
 // `vendor/`: the repo is a Go module, and a top-level vendor/ directory would
 // flip the Go toolchain into vendored-build mode and break `go build`.
 const apsDir = ".vendor/agent-platform-standalone"
+
+// platformChartDir is the umbrella chart the install reads: the vendored
+// checkout, or the local one platform.apsPath names. Both are the same
+// repository layout, so only the root differs.
+func platformChartDir(cfg *config.Config) string {
+	root := apsDir
+	if cfg.Platform.APSPath != "" {
+		root = cfg.Platform.APSPath
+	}
+	return filepath.Join(root, "helm", "agent-platform-standalone")
+}
 
 // PlatformUp installs the Giant Swarm agent platform into the lab cluster and
 // wires it to the lab Dex.
@@ -69,7 +86,13 @@ func vendorPlatformChart(cfg *config.Config) <-chan error {
 // builds its chart dependencies. Quiet on purpose: it may run concurrently
 // with other steps' output.
 func ensurePlatformChart(cfg *config.Config) error {
-	chartDir := filepath.Join(apsDir, "helm", "agent-platform-standalone")
+	chartDir := platformChartDir(cfg)
+	if cfg.Platform.APSPath != "" {
+		// A local checkout is the user's working copy: never fetch, never
+		// check out over it. Its dependencies still need building, which the
+		// rest of this function does.
+		return buildChartDependencies(chartDir)
+	}
 	if _, err := os.Stat(filepath.Join(apsDir, ".git")); os.IsNotExist(err) {
 		if err := runQuiet("git", "init", "-q", apsDir); err != nil {
 			return err
@@ -89,7 +112,13 @@ func ensurePlatformChart(cfg *config.Config) error {
 		return err
 	}
 
-	// A `helm dependency build` killed mid-flight (this very function runs in
+	return buildChartDependencies(chartDir)
+}
+
+// buildChartDependencies pulls the umbrella's subcharts into chartDir/charts,
+// skipping the work when they were last built from exactly this Chart.lock.
+func buildChartDependencies(chartDir string) error {
+	// A `helm dependency build` killed mid-flight (the caller runs in
 	// a goroutine that dies with a failed boot) leaves a tmpcharts-<pid>/ dir
 	// inside the chart. Helm's directory loader embeds every file .helmignore
 	// does not exclude into the release record, so that corpse of raw .tgz
@@ -132,7 +161,7 @@ func ensurePlatformChart(cfg *config.Config) error {
 // user reads a single "what to do next" block once everything is verified,
 // the standalone `agentlab platform` entry point passes "Platform is up.".
 func platformUp(cfg *config.Config, chartReady <-chan error, header string) error {
-	chartDir := filepath.Join(apsDir, "helm", "agent-platform-standalone")
+	chartDir := platformChartDir(cfg)
 
 	// Also checked at the very top of `agentlab up`; repeated here for the
 	// standalone `agentlab platform` entry point.
@@ -148,7 +177,11 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 			"run `agentlab platform-down` first, then re-run `agentlab platform`")
 	}
 
-	step("Vendoring agent-platform-standalone @ %.12s (chart + dependencies)", cfg.Platform.APSRef)
+	if cfg.Platform.APSPath != "" {
+		step("Using the local agent-platform-standalone at %s (chart dependencies only)", cfg.Platform.APSPath)
+	} else {
+		step("Vendoring agent-platform-standalone @ %.12s (chart + dependencies)", cfg.Platform.APSRef)
+	}
 	if chartReady != nil {
 		if err := <-chartReady; err != nil {
 			return err

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -58,6 +58,11 @@ type tmplData struct {
 	// name the proofs sign in to and the protected endpoint it points at.
 	OAuthFixtureServer string
 	OAuthFixtureURL    string
+	// PlatformNamespace and LLMListenerPort build the base URL the kagent
+	// ModelConfig dials when llmRouting is on. The port is written into the
+	// listener AND into that URL from this one value, so they cannot drift.
+	PlatformNamespace string
+	LLMListenerPort   int
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -87,6 +92,8 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		AllGroups:                 config.Groups,
 		KubernetesClientSecret:    config.KubernetesClientSecret,
 		AgentPlatformClientSecret: config.AgentPlatformClientSecret,
+		PlatformNamespace:         platformNamespace,
+		LLMListenerPort:           llmListenerPort,
 	}, nil
 }
 

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -62,6 +62,25 @@ gatewayApi:
 # choke point, muster keeps all per-server connection logic and OAuth.
 ingress:
   mode: agentgateway-muster
+{{- if .Platform.LLMRouting }}
+
+# Agent inference through the same data plane, so the gateway observes every
+# model call: one more listener on the edge Gateway (cluster-internal — the
+# route pins itself to it by sectionName and never attaches to the public
+# HTTPS listener), the Anthropic backend, the mandatory client-path -> body-
+# format map, the per-agent metric labels and the USD price catalog the cost
+# counter reads. The gateway holds NO provider credential: the agent pods keep
+# their own key and x-api-key passes through untouched.
+#
+# The metrics land in the lab Prometheus through the data-plane PodMonitor
+# (rendered with platform.observability), so agentgateway_gen_ai_* is
+# queryable through x_mcp-prometheus_* right after an agent turn.
+llmRouting:
+  enabled: true
+  listener:
+    name: llm
+    port: {{ .LLMListenerPort }}
+{{- end }}
 {{- if .ModelManagerEnabled }}
 
 gateway:
@@ -258,6 +277,14 @@ kagent:
         model: {{ .AIModel }}
         apiKeySecretRef: kagent-anthropic
         apiKeySecretKey: ANTHROPIC_API_KEY
+{{- if .Platform.LLMRouting }}
+        # The cutover: the default ModelConfig dials the LLM listener instead
+        # of api.anthropic.com. It lands in each agent's config Secret and the
+        # pod template carries a config hash, so turning this on rolls the
+        # agent pods once. Removing it is the rollback; the listener may stay.
+        config:
+          baseUrl: http://agentgateway.{{ .PlatformNamespace }}.svc:{{ .LLMListenerPort }}
+{{- end }}
     controller:
       auth:
         # The umbrella default is trusted-proxy, which decodes bearer claims

--- a/main.go
+++ b/main.go
@@ -166,7 +166,8 @@ func accessibleMode() bool {
 
 func configureCmd() *cobra.Command {
 	var defaults, accessible bool
-	var platform, agents, observability, backstage, modelManager bool
+	var platform, agents, observability, backstage, modelManager, llmRouting bool
+	var apsPath string
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Ask for the lab configuration interactively and save agentlab.yaml",
@@ -202,6 +203,12 @@ func configureCmd() *cobra.Command {
 					cfg.Backstage.Enabled = backstage
 					cfg.Normalize() // backstage implies the platform
 				}
+				if cmd.Flags().Changed("llm-routing") {
+					cfg.Platform.LLMRouting = llmRouting
+				}
+				if cmd.Flags().Changed("aps-path") {
+					cfg.Platform.APSPath = apsPath
+				}
 				if err := cfg.Validate(); err != nil {
 					return err
 				}
@@ -218,6 +225,12 @@ func configureCmd() *cobra.Command {
 			fmt.Printf("  users      %d\n", len(cfg.Users))
 			fmt.Printf("  platform   %v (agents %v, observability %v)\n", cfg.Platform.Enabled, cfg.Platform.Agents, cfg.Platform.Observability)
 			fmt.Printf("  backstage  %v\n", cfg.Backstage.Enabled)
+			if cfg.Platform.LLMRouting {
+				fmt.Printf("  llm        agent inference routed through agentgateway (GenAI metrics)\n")
+			}
+			if cfg.Platform.APSPath != "" {
+				fmt.Printf("  chart      %s (local checkout; apsRef ignored)\n", cfg.Platform.APSPath)
+			}
 			fmt.Printf("  ai model   %s (key from $%s at deploy time)\n", cfg.AIModel, lab.AnthropicKeyEnv)
 			for _, m := range cfg.Platform.ExtraModels {
 				fmt.Printf("  extra model %s (%s %s)\n", m.Name, m.Provider, m.Model)
@@ -239,6 +252,8 @@ func configureCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&observability, "observability", false, "with --defaults: enable/disable the observability stack (Prometheus + mcp-prometheus)")
 	cmd.Flags().BoolVar(&backstage, "backstage", false, "with --defaults: enable/disable Backstage (implies the platform)")
 	cmd.Flags().BoolVar(&modelManager, "model-manager", false, "with --defaults: enable/disable managed models (the model-manager component with the host Ollama; needs agents)")
+	cmd.Flags().BoolVar(&llmRouting, "llm-routing", false, "with --defaults: enable/disable routing agent inference through agentgateway (needs a chart carrying llmRouting; see --aps-path)")
+	cmd.Flags().StringVar(&apsPath, "aps-path", "", "with --defaults: install the umbrella from this agent-platform-standalone checkout instead of vendoring apsRef (empty string clears it)")
 	cmd.Flags().BoolVar(&accessible, "accessible", false, "prompt-per-question form mode (for screen readers and plain terminals)")
 	return cmd
 }


### PR DESCRIPTION
The lab could not test an unreleased chart change at all. Every hop of the
delivery chain consumes a released artifact: `agent-platform-connectivity` is
published to gsoci, `agent-platform-standalone` generates its whole chart from
that release, and this lab vendors `agent-platform-standalone` from git at
`platform.apsRef`. So the platform change most worth testing — the one not yet
shipped — was the one change the lab could not install.

## `platform.apsPath`

Installs a local `agent-platform-standalone` checkout instead of the pinned
commit: `ensurePlatformChart` skips the fetch and only builds the chart's
dependencies. The checkout is read, never written (helm fills its gitignored
`charts/`). `apsRepo`/`apsRef` are ignored while it is set and the boot says
which chart it used.

```console
$ agentlab configure --defaults --aps-path ~/workspace/agent-platform-standalone
$ agentlab platform
==> Using the local agent-platform-standalone at … (chart dependencies only)
```

`--aps-path ""` clears it. The `agent-platform-standalone` side of the same
gap is `hack/curate.sh -fleet-dir`
(giantswarm/agent-platform-standalone#93); together they are the loop: curate
there, install here.

## `platform.llmRouting`

The first thing tested through that loop. Agent inference stops leaving the
agent pods for `api.anthropic.com` and goes through the platform's own
agentgateway, so the data plane emits GenAI metrics for every model call.

One toggle renders both halves — the cluster-internal `llm` listener on the
edge Gateway, and the base URL kagent's default ModelConfig dials — because a
listener nothing uses and agents pointed at a closed port are both broken
labs. The port is one constant, written into the listener and into that URL,
so the pair cannot drift. It has nothing to do with `platform.agentsPort`, the
HOST port for the kagent UI.

Off by default: the chart change is unreleased
(giantswarm/agent-platform#254), and the released umbrella's
`values.schema.json` rejects an undeclared top-level key outright, so a block
emitted by default would fail every install (HACKS.md U13). It needs
`platform.agents`, since the cutover is a kagent ModelConfig.

## Verified on the lab

The listener answers a real completion, and after one agent turn the lab
Prometheus serves, through the edge:

```
agentgateway_gen_ai_client_token_usage_sum{agent="llmprobe",agent_namespace="kagent",gen_ai_token_type="input"}  712
agentgateway_gen_ai_client_cost_usd_total{agent="llmprobe",gen_ai_response_model="claude-sonnet-4-6"}            0.002226
agentgateway_cost_catalog_lookups_total{status="Exact"}                                                          4
```

`agentlab platform-test` passes with routing on. The same run caught a routing
bug in giantswarm/agent-platform#254 (the `agent-platform-mcps` catch-all
HTTPRoute outranked the LLM route on its own listener, so every inference call
answered `mcp: client must accept both application/json and
text/event-stream`), fixed on that PR — which is what this loop is for.
