### PR TITLE
fix(backstage): baseUrl follows platform.gatewayPort

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -360,6 +360,21 @@ wiring, its pruning and its agent-turn proof are gone. `models-test --backend
 lemonade` proves the second backend through model-manager instead. The
 `agentlab.yaml` shape did not change.
 
+### U15. Backstage app-config overlay restates `baseUrl`/`cors.origin` with `platform.gatewayPort` — ACCEPTED
+The umbrella's Backstage app-config renders `app.baseUrl`, `backend.baseUrl`
+and `backend.cors.origin` as `https://<hostname>` — no port, because
+`components.backstage.hostname` is also the HTTPRoute hostname and cannot
+carry one. With `platform.gatewayPort != 443` Backstage's OAuth `redirect_uri`
+is port-free while the Dex client (`dex.yaml.tmpl`) registers the ported one,
+and every login fails with "Unregistered redirect_uri". The lab's app-config
+overlay (`backstage-catalog.yaml.tmpl`) restates the three URLs from
+`.BackstageBaseURL`; at 443 the values are identical. Still open on a
+non-443 port: the in-cluster edge Service serves 443 only, so muster cannot
+fetch its own ported OAuth metadata and `platform-test` fails at the
+`lab-oauth-fixture` step. Lab-only by construction: a real installation runs
+its edge on 443, so the umbrella has no reason to carry a ported public URL;
+the overlay is the lab's permanent answer, not an interim.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/README.md
+++ b/README.md
@@ -101,10 +101,14 @@ Applied to the configuration:
   kind port mappings bind. While **no kind node of this configuration
   exists** (a fresh lab, or after `agentlab down`), an occupied port is moved
   to a nearby free one, with a message saying what moved where (443 falls
-  back to 8443). Once the cluster exists its mappings are fixed at node
-  creation, so the ports it publishes never count as occupied and a foreign
-  listener on one of them is **reported**, not renumbered around (free it, or
-  `agentlab down`, re-run `configure`, `agentlab up`).
+  back to 8443). When the edge leaves 443, every public URL in this README
+  gains that port suffix (`https://backstage.127.0.0.1.nip.io:8443`), and
+  `platform-test`'s `lab-oauth-fixture` step fails: in-cluster the edge stays
+  on 443, so muster cannot reach its own ported OAuth metadata URL. Once the
+  cluster exists its mappings are fixed at node creation, so the ports it
+  publishes never count as occupied and a foreign listener on one of them is
+  **reported**, not renumbered around (free it, or `agentlab down`, re-run
+  `configure`, `agentlab up`).
 - **Host model servers**: an Ollama on `:11434` and a Lemonade Server on
   `:13305` (their default ports) are detected with version, whether they
   listen on the kind docker gateway (pods' path to the host — the bind-address

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,9 +122,10 @@ type Platform struct {
 	// the edge Gateway Service.
 	Domain string `yaml:"domain"`
 	// Host-side port of the agentgateway edge (HTTPS). 443 keeps the public
-	// URLs port-free, which the chart's Backstage app-config assumes
-	// (its baseUrl carries no port); change only if 443 is taken, and expect
-	// Backstage to break behind a non-443 edge.
+	// URLs port-free; any other value is only reachable from the host (the
+	// edge Service inside the cluster stays on 443), so in-cluster callers of
+	// a ported public URL — muster fetching its own OAuth metadata for the
+	// lab-oauth-fixture — time out. Change only if 443 is taken.
 	GatewayPort int `yaml:"gatewayPort"`
 	// TLS optionally hands the edge an externally provisioned certificate
 	// pair (PEM) instead of the minted lab-CA wildcard — for users who own a
@@ -776,8 +777,9 @@ func (c *Config) ControlPlaneNode() string { return c.ClusterName + "-control-pl
 func (c *Config) MCPServerName() string { return "mcp-kubernetes" }
 
 // gatewayURL builds the public URL of a platform hostname: through the
-// agentgateway edge, port-free when the edge sits on 443 (the chart's
-// app-config assumes exactly that).
+// agentgateway edge, port-free when the edge sits on 443. The chart's
+// Backstage app-config renders port-free URLs regardless; the lab's overlay
+// restates them from BackstageBaseURL (HACKS.md U15).
 func (c *Config) gatewayURL(prefix string) string {
 	if c.Platform.GatewayPort == 443 {
 		return fmt.Sprintf("https://%s.%s", prefix, c.Platform.Domain)

--- a/internal/config/ports.go
+++ b/internal/config/ports.go
@@ -81,7 +81,7 @@ func (c *Config) ports() []labPort {
 			}
 			return scan(lo, 65535)
 		}, func(to int) string {
-			return fmt.Sprintf("public URLs gain :%d; the chart's Backstage app-config assumes a port-free baseUrl, expect rough edges", to)
+			return fmt.Sprintf("public URLs gain :%d, valid from the host only; platform-test's lab-oauth-fixture step will fail (muster cannot reach its own ported URL in-cluster)", to)
 		}},
 		{"backstage.port", "Backstage's direct debug access", &c.Backstage.Port, func(scan func(int, int) (int, bool)) (int, bool) {
 			return scan(c.Backstage.Port+1, 65535)

--- a/internal/lab/backstage_test.go
+++ b/internal/lab/backstage_test.go
@@ -1,0 +1,141 @@
+package lab
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// backstageOverlayAppConfig renders backstage-catalog.yaml.tmpl and returns
+// the parsed app-config overlay (the agentlab-backstage-app-config
+// ConfigMap's embedded YAML).
+func backstageOverlayAppConfig(t *testing.T, cfg *config.Config) map[string]any {
+	t.Helper()
+	raw, err := renderTemplate(cfg, "backstage-catalog.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var doc map[string]any
+		if err := dec.Decode(&doc); errors.Is(err, io.EOF) {
+			t.Fatalf("overlay ConfigMap agentlab-backstage-app-config not found in:\n%s", raw)
+		} else if err != nil {
+			t.Fatalf("rendered backstage-catalog.yaml is not valid YAML: %v\n%s", err, raw)
+		}
+		meta, _ := doc["metadata"].(map[string]any)
+		if doc["kind"] != "ConfigMap" || meta["name"] != "agentlab-backstage-app-config" {
+			continue
+		}
+		data, _ := doc["data"].(map[string]any)
+		inner, ok := data["app-config.agentlab.yaml"].(string)
+		if !ok {
+			t.Fatalf("overlay ConfigMap has no data[app-config.agentlab.yaml]:\n%s", raw)
+		}
+		var appConfig map[string]any
+		if err := yaml.Unmarshal([]byte(inner), &appConfig); err != nil {
+			t.Fatalf("overlay app-config is not YAML: %v\n%s", err, inner)
+		}
+		return appConfig
+	}
+}
+
+func dig(m map[string]any, path ...string) any {
+	var cur any = m
+	for _, p := range path {
+		mm, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = mm[p]
+	}
+	return cur
+}
+
+// TestBackstageOverlayBaseURLFollowsGatewayPort (HACKS.md U15): the umbrella's
+// app-config has no port in its URLs, so the overlay must carry Backstage's
+// public URL on every gatewayPort — and it must be the very URL the Dex
+// client's redirectURI is built from, or logins fail with "Unregistered
+// redirect_uri".
+func TestBackstageOverlayBaseURLFollowsGatewayPort(t *testing.T) {
+	for _, tc := range []struct {
+		port int
+		want string
+	}{
+		{443, "https://backstage.127.0.0.1.nip.io"},
+		{8443, "https://backstage.127.0.0.1.nip.io:8443"},
+	} {
+		t.Run(fmt.Sprint(tc.port), func(t *testing.T) {
+			cfg := config.Default()
+			cfg.Platform.GatewayPort = tc.port
+			if got := cfg.BackstageBaseURL(); got != tc.want {
+				t.Fatalf("BackstageBaseURL() = %q, want %q", got, tc.want)
+			}
+			appConfig := backstageOverlayAppConfig(t, cfg)
+			for _, path := range [][]string{
+				{"app", "baseUrl"},
+				{"backend", "baseUrl"},
+				{"backend", "cors", "origin"},
+			} {
+				if got := dig(appConfig, path...); got != tc.want {
+					t.Errorf("overlay %s = %v, want %q", strings.Join(path, "."), got, tc.want)
+				}
+			}
+
+			dexRaw, err := renderTemplate(cfg, "dex.yaml.tmpl", nil)
+			if err != nil {
+				t.Fatalf("render dex: %v", err)
+			}
+			redirect := "- " + tc.want + "/api/auth/oidc-agent-platform/handler/frame"
+			if !strings.Contains(string(dexRaw), redirect) {
+				t.Errorf("Dex client redirectURI %q not registered:\n%s", redirect, dexRaw)
+			}
+		})
+	}
+}
+
+// TestBackstageOverlayIsLastAppConfig pins the ordering the override relies
+// on: Backstage gives later app-config files precedence, so the lab's overlay
+// must be listed after the umbrella's file in extraAppConfig — otherwise the
+// umbrella's port-free URLs win and U15 silently regresses.
+func TestBackstageOverlayIsLastAppConfig(t *testing.T) {
+	raw, err := renderTemplate(config.Default(), "agent-platform-values.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	var values struct {
+		Backstage struct {
+			Backstage struct {
+				ExtraAppConfig []struct {
+					Filename     string `yaml:"filename"`
+					ConfigMapRef string `yaml:"configMapRef"`
+				} `yaml:"extraAppConfig"`
+			} `yaml:"backstage"`
+		} `yaml:"backstage"`
+	}
+	if err := yaml.Unmarshal(raw, &values); err != nil {
+		t.Fatalf("values are not YAML: %v\n%s", err, raw)
+	}
+	files := values.Backstage.Backstage.ExtraAppConfig
+	if len(files) < 2 {
+		t.Fatalf("want the umbrella's app-config plus the lab overlay in extraAppConfig, got %+v", files)
+	}
+	last := files[len(files)-1]
+	if last.ConfigMapRef != "agentlab-backstage-app-config" || last.Filename != "app-config.agentlab.yaml" {
+		t.Errorf("lab overlay must be the LAST extraAppConfig entry (later files win the merge), got %+v", files)
+	}
+	var umbrella bool
+	for _, f := range files[:len(files)-1] {
+		umbrella = umbrella || f.ConfigMapRef == "agent-platform-backstage-app-config"
+	}
+	if !umbrella {
+		t.Errorf("umbrella app-config agent-platform-backstage-app-config missing before the overlay: %+v", files)
+	}
+}

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -354,8 +354,10 @@ backstage:
   backstage:
     # Helm replaces lists rather than merging them, so the umbrella's own
     # entries are restated here next to the lab's additions (the catalog
-    # entities + the scaffolder Template behind the agent create flow, and an
-    # in-memory database — see backstage-catalog.yaml.tmpl).
+    # entities + the scaffolder Template behind the agent create flow, an
+    # in-memory database, and the gatewayPort-aware baseUrl — see
+    # backstage-catalog.yaml.tmpl). The lab file must stay LAST: later files
+    # win the deep merge, which is what lets it override the umbrella's URLs.
     extraAppConfig:
       - filename: app-config.agent-platform.yaml
         configMapRef: agent-platform-backstage-app-config

--- a/internal/lab/templates/backstage-catalog.yaml.tmpl
+++ b/internal/lab/templates/backstage-catalog.yaml.tmpl
@@ -56,7 +56,8 @@ data:
 ---
 # App-config overlay on top of the umbrella's own
 # (agent-platform-backstage-app-config): the catalog locations for the files
-# above, and an in-memory database — the lab needs no Postgres for Backstage.
+# above, an in-memory database — the lab needs no Postgres for Backstage —
+# and the gatewayPort-aware public URL.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -64,7 +65,17 @@ metadata:
   namespace: agent-platform
 data:
   app-config.agentlab.yaml: |
+    # Backstage's public URL. The umbrella's app-config renders these three
+    # without a port; Backstage derives its OAuth redirect_uri from them, and
+    # Dex accepts only the redirect URI registered on the agent-platform
+    # client (dex.yaml.tmpl, also .BackstageBaseURL). Both carry
+    # platform.gatewayPort when it is not 443 (HACKS.md U15).
+    app:
+      baseUrl: {{ .BackstageBaseURL }}
     backend:
+      baseUrl: {{ .BackstageBaseURL }}
+      cors:
+        origin: {{ .BackstageBaseURL }}
       database:
         client: better-sqlite3
         connection: ':memory:'


### PR DESCRIPTION
## Problem

With `platform.gatewayPort` set to anything other than 443, every Backstage login fails at Dex with `Bad Request: Unregistered redirect_uri`.

A non-443 port is a supported path: `agentlab configure` moves the edge to 8443 when 443 is busy, and rootless Podman cannot publish 443 at all.

Cause: two renderers disagree on Backstage's public URL.

- The umbrella chart's Backstage app-config renders `app.baseUrl`, `backend.baseUrl` and `backend.cors.origin` as `https://backstage.<domain>` with no port. Its `components.backstage.hostname` value doubles as the HTTPRoute hostname, which cannot carry a port, so the chart has no way to express a ported public URL.
- The lab's Dex client (`dex.yaml.tmpl`) registers the redirect URI from the gatewayPort-aware `Config.BackstageBaseURL`, i.e. with `:8443`.

Backstage derives its OAuth `redirect_uri` from its own baseUrl, so it sends the port-free form and Dex rejects it.

## Fix

The lab already ships an app-config overlay ConfigMap (`backstage-catalog.yaml.tmpl`) that Backstage deep-merges after the umbrella's file. It now restates the three URLs from `.BackstageBaseURL`.

- At 443 the strings are identical to the chart's, so the default lab renders byte-for-byte the same.
- The overlay's existing apply path in `platform.go` already rolls the Backstage pod when the ConfigMap changes.
- No post-render patch and no string surgery on the chart's block scalar.

## Also in this PR

- `agent-platform-values.yaml.tmpl`: comment states the overlay must stay the last `extraAppConfig` entry, because later files win the merge.
- `internal/config/config.go`, `internal/config/ports.go`, README: the gatewayPort comments and the port-move note no longer claim Backstage breaks off 443. They name the gap that remains instead (see below).
- `HACKS.md`: new entry U15, ACCEPTED. A real installation runs its edge on 443, so the umbrella has no reason to carry a ported public URL; the overlay is the lab's permanent answer, not an interim, and there is no upstream ask.

## Tests

- `TestBackstageOverlayBaseURLFollowsGatewayPort` renders the overlay at 443 and 8443, parses the embedded app-config, and asserts the three URLs equal `BackstageBaseURL` and match the redirect URI `dex.yaml.tmpl` registers. Fails on all assertions without the template change.
- `TestBackstageOverlayIsLastAppConfig` parses the rendered values and asserts the lab overlay is the last `extraAppConfig` entry with the umbrella's file before it.
- Live: `./agentlab backstage-test` on `gatewayPort: 8443` passes Dex sign-in, Backstage user resolution and the muster proxy.

## Not in scope

One gap remains on a non-443 port and is now documented rather than hidden: inside the cluster the edge Service serves 443 only, so muster cannot fetch its own ported OAuth metadata URL and `platform-test` fails at the `lab-oauth-fixture` step. A follow-up could add a second port to the lab's edge NodePort Service so ported URLs resolve from every vantage point.
