### PR TITLE
feat: the lab's MCP servers act as the signed-in user — forwarded Dex id_tokens, mcp-prometheus OAuth, dex-localhost sidecar, identity proofs

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -317,6 +317,22 @@ guard.
 fallback with a Capabilities check like the sibling branches; then the value
 can be dropped (it would render nothing here either way).
 
+### U13. `postrender.go` patch: `dex-localhost` sidecar on the MCP servers — ACCEPTED
+Since 2026-09-03 the bundled mcp-kubernetes and model-manager and the lab's
+mcp-prometheus validate the user's forwarded Dex id_token themselves (mcp-oauth
+resource servers against `global.identity`), so each of them does OIDC discovery
+and JWKS fetches against the issuer URL — `https://localhost:<dexPort>/dex`, the
+one URL the browser, the apiserver and every pod must share (H-issuer, above).
+muster and Backstage reach it through hostNetwork (U1); these three cannot: all
+listen on :8080 and would collide on the single kind node. **Fix:** the
+post-renderer injects a `dex-localhost` sidecar (`alpine/socat`) that listens on
+the pod's own loopback :<dexPort> (IPv6 wildcard, dual-stack) and forwards to the
+Dex ClusterIP Service, so `localhost` resolves inside the pod exactly as on the
+host; Dex's certificate carries `localhost`, TLS verification against the lab CA
+holds. mcp-prometheus gets it because `installOCIChart` now runs that release
+through the post-renderer too. Lab-only by construction: real installations have
+a routable issuer.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -590,6 +590,18 @@ func (c *Config) FindUser(email string) *User {
 	return nil
 }
 
+// FindUserInGroup returns the first user carrying group, or nil.
+func (c *Config) FindUserInGroup(group string) *User {
+	for i := range c.Users {
+		for _, g := range c.Users[i].Groups {
+			if g == group {
+				return &c.Users[i]
+			}
+		}
+	}
+	return nil
+}
+
 func (c *Config) Issuer() string {
 	return fmt.Sprintf("https://localhost:%d/dex", c.DexPort)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,9 @@ const KagentUINodePort = 30880
 // has a stable node-side port. Host side: Platform.GatewayPort.
 const GatewayNodePort = 30443
 
+// DefaultDexPort is the lab Dex NodePort when agentlab.yaml sets none.
+const DefaultDexPort = 32000
+
 type User struct {
 	Email        string   `yaml:"email"`
 	Username     string   `yaml:"username"`
@@ -280,7 +283,7 @@ type Config struct {
 func Default() *Config {
 	return &Config{
 		ClusterName: "agentlab",
-		DexPort:     32000,
+		DexPort:     DefaultDexPort,
 		// groups on staticPasswords requires Dex >= v2.45.0; see README.
 		DexImage: "ghcr.io/dexidp/dex:v2.45.1",
 		// The agent-platform BOM's own default, and the newest model the

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -59,7 +59,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 
 	step("Logging in to Dex as %s", email)
 	token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
-		user.Email, user.Password, "openid email groups profile")
+		user.Email, user.Password, musterLoginScopes)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	if viewer := cfg.FindUserInGroup("viewers"); viewer != nil {
 		step("Wiring %s as %s — expecting the apiserver's Forbidden (view role, no write in %s)", model, viewer.Email, kagentNamespace)
 		viewerToken, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
-			viewer.Email, viewer.Password, "openid email groups profile")
+			viewer.Email, viewer.Password, musterLoginScopes)
 		if err != nil {
 			return err
 		}

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -130,6 +130,18 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	}
 	note("pulled in %s", time.Since(started).Round(time.Second))
 
+	step("The job is attributed to the caller (requestedBy)")
+	var job struct {
+		RequestedBy string `json:"requestedBy"`
+	}
+	if err := api.getJSON("/jobs/"+pull.Job.ID, &job); err != nil {
+		return err
+	}
+	if job.RequestedBy != user.Email {
+		return fmt.Errorf("job %s carries requestedBy=%q, wanted %q: model-manager did not learn the caller from the forwarded token", pull.Job.ID, job.RequestedBy, user.Email)
+	}
+	note("requestedBy=%s", job.RequestedBy)
+
 	step("Auto-created kagent ModelConfig")
 	mcName := ""
 	found := waitFor(30, 2*time.Second, func() bool {
@@ -163,6 +175,31 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 		return fmt.Errorf("ModelConfig %s is not the native Ollama provider: %s", mcName, spec)
 	}
 	note("ModelConfig %s: %s (keyless native provider)", mcName, strings.TrimSpace(spec))
+
+	// The user's identity, not a ServiceAccount: wiring writes a ModelConfig
+	// into the kagent namespace as the caller (downstream OAuth), so a user
+	// without RBAC there is refused by the apiserver, while the admin who
+	// pulled the model was allowed.
+	if viewer := cfg.FindUserInGroup("viewers"); viewer != nil {
+		step("Wiring %s as %s — expecting the apiserver's Forbidden (view role, no write in %s)", model, viewer.Email, kagentNamespace)
+		viewerToken, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+			viewer.Email, viewer.Password, "openid email groups profile")
+		if err != nil {
+			return err
+		}
+		viewerAPI := modelManagerAPI{client: client, base: api.base, token: viewerToken}
+		status, body, _, err := viewerAPI.do(http.MethodPost, "/models/wire", map[string]any{modelField: model})
+		if err != nil {
+			return err
+		}
+		if status/100 == 2 {
+			return fmt.Errorf("%s wired %s (HTTP %d) although the view role cannot write ModelConfigs — model-manager is not acting as the caller (ServiceAccount fallback?)", viewer.Email, model, status)
+		}
+		if !strings.Contains(strings.ToLower(string(body)), "forbidden") {
+			return fmt.Errorf("POST /models/wire as %s answered %d without the apiserver's Forbidden: %.300s", viewer.Email, status, body)
+		}
+		note("%s: HTTP %d, %s", viewer.Email, status, excerpt(string(body), 120))
+	}
 
 	step("Agent turn on %s (kagent Agent, runtime go -> host Ollama)", mcName)
 	reply, err := agentTurn(client, cfg, mcName, "Reply with exactly the word pong and nothing else.")
@@ -255,6 +292,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	fmt.Println("PASS: no token -> 401 at the gateway; Dex token -> model-manager REST through agentgateway")
 	fmt.Printf("PASS: list -> pull %s (progress) -> ModelConfig %s (Ollama provider) Accepted -> agent turn -> unload -> delete\n", model, mcName)
 	fmt.Printf("PASS: muster aggregates x_%s_* and calls them (get_model, list_models)\n", modelManagerMCPServer)
+	fmt.Printf("PASS: the caller's identity — job requestedBy=%s; a viewer's wire is Forbidden by the apiserver (user RBAC, not the ServiceAccount's)\n", user.Email)
 	return nil
 }
 

--- a/internal/lab/oauthfixture.go
+++ b/internal/lab/oauthfixture.go
@@ -15,11 +15,11 @@ import (
 // The per-server OAuth sign-in fixture.
 //
 // Every downstream the lab aggregates (mcp-kubernetes, mcp-prometheus,
-// model-manager) is unauthenticated in-cluster, so nothing exercises muster's
-// OAuth *client* role: the proxy behind core_auth_login and the portal's
-// per-server "Sign in" button, which hands the user a challenge URL, walks the
-// browser through the downstream's authorization server and keeps the token
-// per session. The lab turns that role on (muster.muster.oauth.mcpClient in
+// model-manager) authenticates the user through the forwarded Dex id_token
+// (auth.forwardToken), so nothing exercises muster's OAuth *client* role: the
+// proxy behind core_auth_login and the portal's per-server "Sign in" button,
+// which hands the user a challenge URL, walks the browser through the
+// downstream's own authorization server and keeps the token per session. The lab turns that role on (muster.muster.oauth.mcpClient in
 // agent-platform-values.yaml.tmpl — the umbrella leaves it off, real
 // installations turn it on) and ships one downstream that declares auth.type
 // oauth and stays Auth Required, so the path can be driven and proven

--- a/internal/lab/observability.go
+++ b/internal/lab/observability.go
@@ -52,7 +52,7 @@ func observabilityUp(cfg *config.Config) error {
 		kpsChartVersion, mcpPrometheusChartVersion)
 	if err := installOCIChart(cfg, kpsRelease,
 		"oci://gsoci.azurecr.io/charts/giantswarm/kube-prometheus-stack",
-		kpsChartVersion, "kube-prometheus-stack-values.yaml.tmpl"); err != nil {
+		kpsChartVersion, "kube-prometheus-stack-values.yaml.tmpl", false); err != nil {
 		return err
 	}
 	// mcp-prometheus runs as an OAuth resource server against the lab Dex
@@ -67,9 +67,15 @@ func observabilityUp(cfg *config.Config) error {
 	}); err != nil {
 		return err
 	}
+	// Through the lab post-renderer: mcp-prometheus gets the dex-localhost
+	// sidecar that makes the issuer URL (https://localhost:<DexPort>)
+	// reachable from inside the pod (postrender.go, item 4).
+	if res := sideloadImages(cfg, hostPullImages([]string{dexLocalhostImage})); res.n > 0 {
+		note("side-loaded the dex-localhost sidecar image (%s)", res.d)
+	}
 	if err := installOCIChart(cfg, mcpPrometheusRelease,
 		"oci://gsoci.azurecr.io/charts/giantswarm/mcp-prometheus",
-		mcpPrometheusChartVersion, "mcp-prometheus-values.yaml.tmpl"); err != nil {
+		mcpPrometheusChartVersion, "mcp-prometheus-values.yaml.tmpl", true); err != nil {
 		return err
 	}
 
@@ -115,7 +121,8 @@ func observabilityUp(cfg *config.Config) error {
 // chart into the observability namespace, side-loading its images first (the
 // same host-cache -> node rule as the platform; see flux.go for the pattern
 // and preload.go for the rule).
-func installOCIChart(cfg *config.Config, release, chartRef, version, valuesTmpl string) error {
+// postRender routes the release through the lab post-renderer (PostRender).
+func installOCIChart(cfg *config.Config, release, chartRef, version, valuesTmpl string, postRender bool) error {
 	_, valuesPath, err := renderManifest(cfg, valuesTmpl)
 	if err != nil {
 		return err
@@ -131,9 +138,18 @@ func installOCIChart(cfg *config.Config, release, chartRef, version, valuesTmpl 
 			}
 		}
 	}
-	return runQuiet("helm", "upgrade", "--install", release, chartRef,
+	args := []string{"upgrade", "--install", release, chartRef,
 		"--version", version,
 		"-n", observabilityNamespace, "--create-namespace",
 		"-f", valuesPath,
-		"--wait", "--timeout", "5m")
+		"--wait", "--timeout", "5m"}
+	if !postRender {
+		return runQuiet("helm", args...)
+	}
+	pluginsDir, err := ensurePostRenderPlugin()
+	if err != nil {
+		return err
+	}
+	args = append(args, "--post-renderer", postRenderPluginName)
+	return runQuietEnv([]string{"HELM_PLUGINS=" + pluginsDir}, "helm", args...)
 }

--- a/internal/lab/observability.go
+++ b/internal/lab/observability.go
@@ -21,8 +21,10 @@ import (
 // endpoint. The lab installs the constituent directly and re-enables the
 // Prometheus server — see kube-prometheus-stack-values.yaml.tmpl.
 const (
-	kpsChartVersion           = "22.0.0" // wraps upstream kube-prometheus-stack 87.3.0
-	mcpPrometheusChartVersion = "0.7.16"
+	kpsChartVersion = "22.0.0" // wraps upstream kube-prometheus-stack 87.3.0
+	// 0.8.0: OAuth provider switch and tenancy mode `none` (a single-tenant
+	// Prometheus behind muster; the lab's identity proofs need both).
+	mcpPrometheusChartVersion = "0.8.0"
 )
 
 // observabilityNamespace also appears in the templates (the PROMETHEUS_URL in
@@ -42,14 +44,27 @@ const (
 // kube-prometheus-stack (operator + CRDs + kube-state-metrics + node-exporter
 // + a Prometheus scraping kubelet/cAdvisor) and mcp-prometheus, the MCP server
 // muster registers via the umbrella's agent-platform-mcps values (see
-// agent-platform-values.yaml.tmpl). Runs BEFORE the umbrella install so
-// muster's first dial of the MCPServer CR succeeds.
+// agent-platform-values.yaml.tmpl) and forwards the user's Dex id_token to.
+// Runs BEFORE the umbrella install so muster's first dial of the MCPServer CR
+// finds a listener.
 func observabilityUp(cfg *config.Config) error {
 	step("Installing the observability stack (kube-prometheus-stack %s + mcp-prometheus %s)",
 		kpsChartVersion, mcpPrometheusChartVersion)
 	if err := installOCIChart(cfg, kpsRelease,
 		"oci://gsoci.azurecr.io/charts/giantswarm/kube-prometheus-stack",
 		kpsChartVersion, "kube-prometheus-stack-values.yaml.tmpl"); err != nil {
+		return err
+	}
+	// mcp-prometheus runs as an OAuth resource server against the lab Dex
+	// (mcp-prometheus-values.yaml.tmpl): it needs the lab CA in its own
+	// namespace to verify Dex's certificate, so the Secret muster and
+	// Backstage use in agent-platform is mirrored here before the install.
+	if err := ensureNamespace(observabilityNamespace); err != nil {
+		return err
+	}
+	if err := ensureSecretFromFiles(observabilityNamespace, "dex-ca", map[string]string{
+		"ca.crt": caCertPath,
+	}); err != nil {
 		return err
 	}
 	if err := installOCIChart(cfg, mcpPrometheusRelease,

--- a/internal/lab/oidc.go
+++ b/internal/lab/oidc.go
@@ -106,6 +106,16 @@ func labHTTPClient(timeout time.Duration) (*http.Client, error) {
 
 // dexToken POSTs a token request (any grant type, in form) to the lab Dex and
 // returns the raw id_token.
+// musterLoginScopes are the scopes the headless proofs request from Dex for a
+// token they present to muster (and that muster forwards downstream): the
+// standard claims plus the cross-client audience the kind apiserver trusts
+// (Dex client `kubernetes`, which lists agent-platform under trustedPeers).
+// muster's own browser login requests that audience through the MCPServer CRs'
+// requiredAudiences and Backstage through components.backstage.extraScopes;
+// a password-grant token must ask for it itself, or the servers' downstream
+// OAuth presents a token the apiserver answers with 401.
+const musterLoginScopes = "openid email groups profile audience:server:client_id:" + config.KubernetesClientID
+
 func dexToken(cfg *config.Config, clientID, clientSecret string, form url.Values) (string, error) {
 	client, err := labHTTPClient(30 * time.Second)
 	if err != nil {

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -343,21 +344,26 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		return err
 	}
 
-	step("Waiting for muster to connect to the Kubernetes MCP")
-	if err := waitMCPServerConnected(cfg.MCPServerName()); err != nil {
+	// Every downstream forwards the user's token (auth.forwardToken), so muster
+	// connects per session, not at startup: until the first session signs in
+	// the CR reads Auth Required, afterwards Connected. Either proves the
+	// server answers (a dead server reads Failed); platform-test and
+	// models-test then drive the sessions that flip them to Connected.
+	step("Waiting for muster to reach the Kubernetes MCP")
+	if err := waitMCPServerReachable(cfg.MCPServerName()); err != nil {
 		return err
 	}
 	if cfg.Platform.Observability {
-		step("Waiting for muster to connect to the Prometheus MCP")
-		if err := waitMCPServerConnected(mcpPrometheusRelease); err != nil {
+		step("Waiting for muster to reach the Prometheus MCP")
+		if err := waitMCPServerReachable(mcpPrometheusRelease); err != nil {
 			return err
 		}
 	}
 	if cfg.ModelManagerEnabled() {
-		// The model-manager chart renders its own MCPServer CR; Connected
-		// proves the pod serves MCP and muster aggregates x_model-manager_*.
-		step("Waiting for muster to connect to model-manager")
-		if err := waitMCPServerConnected(modelManagerMCPServer); err != nil {
+		// The model-manager chart renders its own MCPServer CR (with the
+		// forward-token auth block); reachable proves the pod serves MCP.
+		step("Waiting for muster to reach model-manager")
+		if err := waitMCPServerReachable(modelManagerMCPServer); err != nil {
 			return err
 		}
 	}
@@ -500,24 +506,32 @@ func waitMCPServerConnected(name string) error {
 	return waitMCPServerState(name, "Connected")
 }
 
-// waitMCPServerState polls the MCPServer CR's status.state until it reads
-// want. The name is fully qualified because kagent ships its own MCPServer
+// waitMCPServerReachable is waitMCPServerConnected for a server muster
+// authenticates to per session (auth.forwardToken): Auth Required means the
+// server answered muster's probe with an OAuth challenge and waits for the
+// first session, Connected that a session already signed in.
+func waitMCPServerReachable(name string) error {
+	return waitMCPServerState(name, "Connected", mcpServerStateAuthRequired)
+}
+
+// waitMCPServerState polls the MCPServer CR's status.state until it reads one
+// of want. The name is fully qualified because kagent ships its own MCPServer
 // CRD (mcpservers.kagent.dev), so the bare kind resolves to the wrong API
 // group.
-func waitMCPServerState(name, want string) error {
+func waitMCPServerState(name string, want ...string) error {
 	state := ""
 	reached := waitFor(40, 3*time.Second, func() bool {
 		state, _ = outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io", name,
 			"-o", "jsonpath={.status.state}")
-		return state == want
+		return slices.Contains(want, state)
 	})
 	if !reached {
 		return fmt.Errorf("MCPServer %s never reached %s (last state: %q);\n"+
 			"check `agentlab logs muster`, `kubectl -n %s describe mcpservers.muster.giantswarm.io %s`\n"+
 			"and the server's rollout: `kubectl -n %s get deploy,pods`",
-			name, want, state, platformNamespace, name, platformNamespace)
+			name, strings.Join(want, " or "), state, platformNamespace, name, platformNamespace)
 	}
-	note("MCPServer %s: %s", name, want)
+	note("MCPServer %s: %s", name, state)
 	return nil
 }
 

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -508,14 +508,11 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 
 // waitMCPServerConnected polls one muster MCPServer CR (in the platform
 // namespace) until muster reports the downstream connection up.
-func waitMCPServerConnected(name string) error {
-	return waitMCPServerState(name, "Connected")
-}
-
-// waitMCPServerReachable is waitMCPServerConnected for a server muster
-// authenticates to per session (auth.forwardToken): Auth Required means the
-// server answered muster's probe with an OAuth challenge and waits for the
-// first session, Connected that a session already signed in.
+// waitMCPServerReachable waits for a server muster authenticates to per
+// session (auth.forwardToken): Auth Required means the server answered
+// muster's probe with an OAuth challenge and waits for the first session,
+// Connected that a session already signed in. Every downstream the lab
+// aggregates is such a server now, so this replaced the plain Connected wait.
 func waitMCPServerReachable(name string) error {
 	return waitMCPServerState(name, "Connected", mcpServerStateAuthRequired)
 }

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -334,6 +334,12 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 	if err != nil {
 		return err
 	}
+	// The post-renderer adds the dex-localhost sidecar to mcp-kubernetes and
+	// model-manager (postrender.go, item 4); its image is not in the chart
+	// render, so it is side-loaded here.
+	if res := sideloadImages(cfg, hostPullImages([]string{dexLocalhostImage})); res.n > 0 {
+		note("side-loaded the dex-localhost sidecar image (%s)", res.d)
+	}
 	if err := runQuietEnv([]string{"HELM_PLUGINS=" + pluginsDir},
 		"helm", "upgrade", "--install", platformRelease, chartDir,
 		"-n", platformNamespace,

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -36,7 +36,7 @@ func PlatformTest(cfg *config.Config, email string) error {
 
 	step("Logging in to Dex as %s", email)
 	token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
-		user.Email, user.Password, "openid email groups profile")
+		user.Email, user.Password, musterLoginScopes)
 	if err != nil {
 		return err
 	}
@@ -299,7 +299,7 @@ func PlatformTest(cfg *config.Config, email string) error {
 func musterTokenProbe(cfg *config.Config) error {
 	admin := cfg.AdminUser()
 	token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
-		admin.Email, admin.Password, "openid email groups profile")
+		admin.Email, admin.Password, musterLoginScopes)
 	if err != nil {
 		return err
 	}
@@ -388,7 +388,7 @@ func proveDownstreamIdentity(cfg *config.Config, toolPrefix string) error {
 	} {
 		step("Listing kube-system Secrets through muster as %s — expecting %s", tc.user.Email, tc.expecting)
 		token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
-			tc.user.Email, tc.user.Password, "openid email groups profile")
+			tc.user.Email, tc.user.Password, musterLoginScopes)
 		if err != nil {
 			return err
 		}

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -147,6 +147,13 @@ func PlatformTest(cfg *config.Config, email string) error {
 
 	verdict := "PASS: Claude Code -> muster (Dex) -> mcp-kubernetes -> kind apiserver"
 
+	// The user's identity, not a ServiceAccount: the same tool as two users
+	// with different RBAC must answer differently.
+	if err := proveDownstreamIdentity(cfg, toolPrefix); err != nil {
+		return err
+	}
+	verdict += "\nPASS: the forwarded Dex id_token reaches the apiserver — kube-system Secrets: platform-admin allowed, viewer forbidden (user RBAC, not the ServiceAccount's)"
+
 	// The per-server sign-in path: muster as OAuth client, challenged by the
 	// lab's Auth Required fixture (oauthfixture.go).
 	if err := proveOAuthSignIn(cfg, token); err != nil {
@@ -353,4 +360,55 @@ func parseMCPResponse(raw []byte) (map[string]any, error) {
 		}
 	}
 	return nil, fmt.Errorf("neither JSON nor SSE data frame")
+}
+
+// proveDownstreamIdentity shows that mcp-kubernetes acts as the signed-in
+// user: muster forwards each session's Dex id_token (auth.forwardToken), the
+// server validates it and presents it to the kind apiserver
+// (enableDownstreamOAuth), so the user's RBAC — not a ServiceAccount's —
+// decides. Listing kube-system Secrets separates the lab's groups cleanly: the
+// `view` ClusterRole bound to oidc:viewers excludes Secrets, cluster-admin
+// (oidc:platform-admins) reads them. A shared ServiceAccount would answer both
+// users alike.
+func proveDownstreamIdentity(cfg *config.Config, toolPrefix string) error {
+	admin := cfg.FindUserInGroup("platform-admins")
+	viewer := cfg.FindUserInGroup("viewers")
+	if admin == nil || viewer == nil {
+		note("skipping the identity proof: %s needs one platform-admins and one viewers user", config.File)
+		return nil
+	}
+	args := map[string]any{"resourceType": "secrets", "namespace": "kube-system"}
+	for _, tc := range []struct {
+		user      *config.User
+		allowed   bool
+		expecting string
+	}{
+		{admin, true, "allowed (cluster-admin via oidc:platform-admins)"},
+		{viewer, false, "forbidden (view role via oidc:viewers excludes Secrets)"},
+	} {
+		step("Listing kube-system Secrets through muster as %s — expecting %s", tc.user.Email, tc.expecting)
+		token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+			tc.user.Email, tc.user.Password, "openid email groups profile")
+		if err != nil {
+			return err
+		}
+		session, err := openMusterSession(cfg, token, "platform-test-identity")
+		if err != nil {
+			return err
+		}
+		text, err := session.callServerTool(toolPrefix+"list", args)
+		switch {
+		case tc.allowed && err != nil:
+			return fmt.Errorf("%s could not list kube-system Secrets through %slist: %w", tc.user.Email, toolPrefix, err)
+		case tc.allowed:
+			note("%s: listed (%s)", tc.user.Email, excerpt(text, 80))
+		case err == nil:
+			return fmt.Errorf("%s listed kube-system Secrets through %slist although the view role excludes them — mcp-kubernetes is not acting as the caller (ServiceAccount fallback?): %.200s", tc.user.Email, toolPrefix, text)
+		case !strings.Contains(strings.ToLower(err.Error()), "forbidden"):
+			return fmt.Errorf("%s: wanted the apiserver's Forbidden for kube-system Secrets, got: %w", tc.user.Email, err)
+		default:
+			note("%s: %s", tc.user.Email, excerpt(err.Error(), 160))
+		}
+	}
+	return nil
 }

--- a/internal/lab/postrender.go
+++ b/internal/lab/postrender.go
@@ -41,7 +41,20 @@ import (
 //     one — useless to kind's fixed extraPortMappings. Pinned to
 //     config.KagentUINodePort, the containerPort side of the mapping that
 //     publishes the UI on the host (HACKS.md U9).
-func PostRender(in io.Reader, out io.Writer) error {
+//
+//  4. A `dex-localhost` sidecar on the MCP servers that validate the user's
+//     forwarded id_token themselves (mcp-kubernetes, model-manager, and
+//     mcp-prometheus through installOCIChart): they too must reach the issuer
+//     URL, https://localhost:<DexPort>, but hostNetwork is not an option —
+//     all three listen on :8080 and would collide on the single kind node.
+//     The sidecar (socat) listens on the pod's own loopback :<DexPort> and
+//     forwards to the Dex Service, so `localhost` resolves inside the pod
+//     exactly as on the host; Dex's certificate carries `localhost`, so TLS
+//     verification against the lab CA holds. Lab only (HACKS.md U10).
+//
+// dexPort is the lab Dex NodePort (agentlab.yaml dexPort), the port of the
+// issuer URL the sidecar answers on.
+func PostRender(in io.Reader, out io.Writer, dexPort int) error {
 	dec := yaml.NewDecoder(in)
 	enc := yaml.NewEncoder(out)
 	enc.SetIndent(2)
@@ -65,6 +78,9 @@ func PostRender(in io.Reader, out io.Writer) error {
 		if kind == "Deployment" && (name == componentMuster || name == componentBackstage) {
 			patchHostNetworkDeployment(root)
 		}
+		if kind == "Deployment" && dexLocalhostDeployments[name] {
+			patchDexLocalhostSidecar(root, dexPort)
+		}
 		if kind == "Service" && name == "kagent-ui" {
 			patchKagentUIService(root)
 		}
@@ -86,6 +102,61 @@ func patchHostNetworkDeployment(root *yaml.Node) {
 	setKey(rolling, "maxUnavailable", intNode(1))
 	setKey(strategy, "rollingUpdate", rolling)
 	setKey(ensureMap(root, "spec"), "strategy", strategy)
+}
+
+// dexLocalhostDeployments are the Deployments that get the dex-localhost
+// sidecar: every MCP server that runs mcp-oauth against the lab issuer without
+// hostNetwork.
+var dexLocalhostDeployments = map[string]bool{
+	"mcp-kubernetes":      true,
+	modelManagerMCPServer: true,
+	mcpPrometheusRelease:  true,
+}
+
+// dexLocalhostImage is the socat image of the sidecar (side-loaded like every
+// other lab image; Docker Hub).
+const dexLocalhostImage = "alpine/socat:1.8.1.3"
+
+// dexLocalhostContainer is the sidecar's name; a re-render replaces it in
+// place instead of appending a second one.
+const dexLocalhostContainer = "dex-localhost"
+
+// dexServiceAddr is the lab Dex behind its ClusterIP Service (dex.yaml.tmpl):
+// the same HTTPS endpoint the NodePort publishes on the host.
+const dexServiceAddr = "dex.dex.svc.cluster.local:5556"
+
+// patchDexLocalhostSidecar adds (or replaces) the dex-localhost sidecar on a
+// Deployment's pod template. The pod keeps its own network namespace; the
+// sidecar just makes 127.0.0.1/::1:<DexPort> answer with Dex.
+func patchDexLocalhostSidecar(root *yaml.Node, dexPort int) {
+	podSpec := ensureMap(ensureMap(ensureMap(root, "spec"), "template"), "spec")
+	containers := mapValue(podSpec, "containers")
+	if containers == nil || containers.Kind != yaml.SequenceNode {
+		return
+	}
+	kept := make([]*yaml.Node, 0, len(containers.Content)+1)
+	for _, c := range containers.Content {
+		if scalarAt(c, nameKey) != dexLocalhostContainer {
+			kept = append(kept, c)
+		}
+	}
+	side := &yaml.Node{Kind: yaml.MappingNode, Tag: yamlTagMap}
+	setKey(side, nameKey, strNode(dexLocalhostContainer))
+	setKey(side, "image", strNode(dexLocalhostImage))
+	args := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	// An IPv6 wildcard listener is dual-stack on Linux (bindv6only=0), so both
+	// [::1] — which Go dials first for localhost — and 127.0.0.1 answer.
+	args.Content = append(args.Content,
+		strNode(fmt.Sprintf("TCP6-LISTEN:%d,fork,reuseaddr", dexPort)),
+		strNode("TCP:"+dexServiceAddr))
+	setKey(side, "args", args)
+	resources := &yaml.Node{Kind: yaml.MappingNode, Tag: yamlTagMap}
+	requests := &yaml.Node{Kind: yaml.MappingNode, Tag: yamlTagMap}
+	setKey(requests, "cpu", strNode("5m"))
+	setKey(requests, "memory", strNode("16Mi"))
+	setKey(resources, "requests", requests)
+	setKey(side, "resources", resources)
+	containers.Content = append(kept, side)
 }
 
 // patchKagentUIService pins the UI port entry to the fixed NodePort the kind

--- a/internal/lab/postrender_test.go
+++ b/internal/lab/postrender_test.go
@@ -97,7 +97,7 @@ spec:
 
 func TestPostRender(t *testing.T) {
 	var out bytes.Buffer
-	if err := PostRender(strings.NewReader(postRenderInput), &out); err != nil {
+	if err := PostRender(strings.NewReader(postRenderInput), &out, 32000); err != nil {
 		t.Fatalf("post-render: %v", err)
 	}
 	rendered := out.String()
@@ -185,5 +185,72 @@ func TestPostRender(t *testing.T) {
 		if cfg["other"].(map[string]any)["keep"] != "value" {
 			t.Errorf("unrelated config lost: %v", cfg["other"])
 		}
+	}
+}
+
+const dexLocalhostInput = `---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: model-manager
+  namespace: agent-platform
+spec:
+  template:
+    spec:
+      containers:
+        - name: model-manager
+          image: model-manager:1.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kagent-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: controller
+          image: kagent:1.0
+`
+
+func TestPostRenderDexLocalhostSidecar(t *testing.T) {
+	var out bytes.Buffer
+	if err := PostRender(strings.NewReader(dexLocalhostInput), &out, 31000); err != nil {
+		t.Fatal(err)
+	}
+	// Re-render the output: the sidecar must be replaced, not appended.
+	var again bytes.Buffer
+	if err := PostRender(bytes.NewReader(out.Bytes()), &again, 31000); err != nil {
+		t.Fatal(err)
+	}
+	dec := yaml.NewDecoder(&again)
+	var docs []map[string]any
+	for {
+		var d map[string]any
+		if err := dec.Decode(&d); err != nil {
+			break
+		}
+		docs = append(docs, d)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("want 2 documents, got %d", len(docs))
+	}
+	containersOf := func(d map[string]any) []any {
+		return d["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)["containers"].([]any)
+	}
+	mm := containersOf(docs[0])
+	if len(mm) != 2 {
+		t.Fatalf("model-manager: want the app container + one sidecar, got %d containers", len(mm))
+	}
+	side := mm[1].(map[string]any)
+	if side["name"] != dexLocalhostContainer || side["image"] != dexLocalhostImage {
+		t.Fatalf("unexpected sidecar: %v", side)
+	}
+	args := side["args"].([]any)
+	if args[0] != "TCP6-LISTEN:31000,fork,reuseaddr" || args[1] != "TCP:"+dexServiceAddr {
+		t.Fatalf("unexpected sidecar args: %v", args)
+	}
+	if n := len(containersOf(docs[1])); n != 1 {
+		t.Fatalf("kagent-controller must stay untouched, got %d containers", n)
 	}
 }

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -82,6 +82,15 @@ components:
   # mcp-kubernetes ships bundled in the umbrella (enabled by default since
   # APS #44): the subchart at the BOM's version plus an MCPServer CR named
   # mcp-kubernetes, so muster's tools surface as x_mcp-kubernetes_<tool>.
+  # The umbrella runs it as an OAuth resource server against global.identity
+  # and muster forwards the user's Dex id_token; enableDownstreamOAuth then
+  # presents that token to the kind apiserver, which trusts the lab Dex with
+  # client id `kubernetes` (kind-config.yaml.tmpl) — so the token must carry
+  # that audience, requested at login through the MCPServer CR. The umbrella
+  # default is dex-k8s-authenticator (Giant Swarm apiservers); the lab Dex
+  # lists agent-platform under the kubernetes client's trustedPeers for this.
+  mcp-kubernetes:
+    kubernetesAudience: kubernetes
   # The agent runtime: the platform's Agent CRs run here, wired to Anthropic
   # through the default ModelConfig (see the kagent block below). Optional in
   # this lab (platform.agents in agentlab.yaml) — on real clusters agent
@@ -291,14 +300,23 @@ kagent:
 
 {{- if .ModelManagerEnabled }}
 # The model-manager chart's own values (the umbrella pins the Service name,
-# the kagent namespace and the muster registration in its contract). The
-# Ollama backend dials the host through the kind docker network's gateway —
-# autodetected by `agentlab platform` (platform.modelManager.endpoint
-# overrides). Agent pods dial the same address, so agentHost stays empty.
+# the kagent namespace, the muster registration and — since the identity
+# change — OAuth against global.identity in its contract). The Ollama backend
+# dials the host through the kind docker network's gateway — autodetected by
+# `agentlab platform` (platform.modelManager.endpoint overrides). Agent pods
+# dial the same address, so agentHost stays empty. Same audience story as
+# mcp-kubernetes above: the forwarded token must carry the `kubernetes`
+# audience for model-manager's downstream OAuth (the ModelConfigs it writes
+# as the caller) to pass the kind apiserver.
 model-manager:
   backend: ollama
   ollama:
     endpoint: {{ .ModelManagerEndpoint | printf "%q" }}
+  muster:
+    mcpServer:
+      auth:
+        requiredAudiences:
+          - kubernetes
 {{- end }}
 
 {{- if .Backstage.Enabled }}
@@ -355,23 +373,24 @@ agent-platform-mcps:
     # pairing with ingress.mode).
     viaMuster: true
   # The Kubernetes MCP server is NOT listed here: it is the umbrella's bundled
-  # mcp-kubernetes component, which registers its own MCPServer CR. The chart's
-  # defaults leave the server unauthenticated in-cluster — muster's own OAuth
-  # guards the front door and mcp-kubernetes talks to the apiserver with its
-  # ServiceAccount.
+  # mcp-kubernetes component, which registers its own MCPServer CR (with the
+  # forward-token auth block, see components.mcp-kubernetes above).
 {{- if .Platform.Observability }}
   # The Prometheus MCP server, a lab-installed release (observability.go);
   # this entry only registers it with muster. `group` must stay OUTSIDE
   # muster.families (kubernetes, prometheus): a family entry would surface the
   # tools as x_prometheus_<tool> with a required management_cluster argument,
   # while this singleton keeps mcp-kubernetes's UX — x_mcp-prometheus_<tool>,
-  # no extra argument. Unauthenticated in-cluster, same stance as
-  # mcp-kubernetes.
+  # no extra argument. auth.mode forward: muster forwards the session's Dex
+  # id_token byte-identical and mcp-prometheus validates it against Dex's
+  # JWKS (mcp-prometheus-values.yaml.tmpl) — the caller's identity reaches
+  # the server. The chart's default audience (dex-k8s-authenticator) rides
+  # along; the lab Dex mints it and nothing downstream needs it.
   mcpServers:
     - name: mcp-prometheus
       cluster: {{ .ClusterName }}
       group: observability
       url: http://mcp-prometheus.monitoring.svc.cluster.local:8080/mcp
       auth:
-        mode: none
+        mode: forward
 {{- end }}

--- a/internal/lab/templates/mcp-prometheus-values.yaml.tmpl
+++ b/internal/lab/templates/mcp-prometheus-values.yaml.tmpl
@@ -2,9 +2,23 @@
 # muster aggregates as x_mcp-prometheus_<tool> (registered via the umbrella's
 # agent-platform-mcps values, see agent-platform-values.yaml.tmpl).
 #
-# Auth stays off (the chart default): like the umbrella's bundled
-# mcp-kubernetes, the server is deliberately unauthenticated on the cluster
-# network — muster is the single auth enforcement point in this lab.
+# The user's identity, not a ServiceAccount: the server runs as an OAuth 2.1
+# resource server (mcp-oauth) against the lab Dex — the same platform client
+# muster and Backstage use. muster forwards the session's Dex id_token
+# (the mcps entry's auth.mode: forward) and mcp-prometheus validates it against
+# Dex's JWKS because its audience, agent-platform, is trusted. The issuer is
+# the lab Dex on the host's loopback (see agent-platform-values.yaml.tmpl:
+# why the issuer is https://localhost), hence allowPrivateURLs; the lab CA
+# (Secret dex-ca, mirrored into this namespace by observability.go) verifies
+# Dex's self-signed certificate. Nothing here is routed on the edge: the
+# issuer/redirect URLs only name this server's own OAuth metadata, which no
+# client uses — muster forwards, nobody logs in to mcp-prometheus directly.
+#
+# The lab Prometheus is single-tenant (no Mimir, no X-Scope-OrgID), so the
+# tenancy resolver is `none`: OAuth authenticates the caller, no tenant header
+# is injected. The client secret and the token-encryption key are lab-only
+# throwaway values (the chart renders them into its Secret), like every other
+# credential in this lab.
 app:
   env:
     # The operator-owned headless Service: name-stable across releases, unlike
@@ -12,6 +26,26 @@ app:
     # observability.go.
     - name: PROMETHEUS_URL
       value: http://prometheus-operated.monitoring.svc.cluster.local:9090
+    - name: MCP_OAUTH_ISSUER
+      value: https://mcp-prometheus.{{ .Platform.Domain }}
+    - name: DEX_ISSUER_URL
+      value: "{{ .Issuer }}"
+    - name: DEX_CLIENT_ID
+      value: agent-platform
+  oauth:
+    enabled: true
+    provider: dex
+    redirectURL: https://mcp-prometheus.{{ .Platform.Domain }}/oauth/callback
+    dexClientSecret: "{{ .AgentPlatformClientSecret }}"
+    encryptionKey: "bGFiLW9ubHktbWNwLXByb21ldGhldXMta2V5LTMyYnk="
+    allowPrivateURLs: true
+    dexCASecret:
+      name: dex-ca
+      key: ca.crt
+    trustedAudiences:
+      - agent-platform
+  tenancy:
+    mode: none
 # No Cilium in kind; the chart default is true and would render a CR without
 # a CRD.
 ciliumNetworkPolicy:

--- a/internal/lab/templates/oauth-fixture.yaml.tmpl
+++ b/internal/lab/templates/oauth-fixture.yaml.tmpl
@@ -1,8 +1,8 @@
 # A test fixture, not a real integration. Every downstream the lab aggregates
-# (mcp-kubernetes, mcp-prometheus, model-manager) is unauthenticated on the
-# cluster network, so nothing would otherwise exercise muster's OAuth *client*
-# role — the proxy behind core_auth_login and the portal's per-server
-# "Sign in" button. This MCPServer declares `auth.type: oauth` and stays
+# (mcp-kubernetes, mcp-prometheus, model-manager) authenticates the user
+# through the Dex id_token muster forwards (auth.forwardToken), so nothing
+# would otherwise exercise muster's OAuth *client* role — the proxy behind
+# core_auth_login and the portal's per-server "Sign in" button. This MCPServer declares `auth.type: oauth` and stays
 # "Auth Required" forever: every core_auth_login against it answers a fresh
 # challenge (a /oauth/proxy/start URL with its own state), which is what
 # `agentlab platform-test` and `agentlab backstage-test` prove.

--- a/main.go
+++ b/main.go
@@ -365,7 +365,13 @@ func postRenderCmd() *cobra.Command {
 		Short:  "Helm post-renderer for the agent-platform install (stdin -> stdout)",
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return lab.PostRender(os.Stdin, os.Stdout)
+			// The Dex NodePort from agentlab.yaml when the lab is configured;
+			// the default otherwise (the plugin runs in the lab's cwd).
+			dexPort := config.DefaultDexPort
+			if cfg, err := config.Load(); err == nil && cfg.DexPort != 0 {
+				dexPort = cfg.DexPort
+			}
+			return lab.PostRender(os.Stdin, os.Stdout, dexPort)
 		},
 	}
 }


### PR DESCRIPTION
## Why

The lab's downstream MCP servers (the umbrella's mcp-kubernetes and model-manager, the lab-installed mcp-prometheus) were anonymous on the cluster network and acted as their ServiceAccounts. With agent-platform-standalone#99 the umbrella runs them as mcp-oauth resource servers against `global.identity` and muster forwards the user's id_token; the lab follows and proves it.

## What

- **mcp-prometheus 0.8.0** as an OAuth resource server against the lab Dex (`tenancy: none` for the single-tenant Prometheus, the lab CA mirrored into ns monitoring as `dex-ca`), registered with `auth.mode: forward`.
- **Audiences:** `components.mcp-kubernetes.kubernetesAudience: kubernetes` and `model-manager.muster.mcpServer.auth.requiredAudiences: [kubernetes]` — the kind apiserver trusts the lab Dex with that client id, so the forwarded token passes downstream OAuth. The headless proofs request that cross-client audience too (`musterLoginScopes`); without it the apiserver answers 401 to the forwarded token.
- **`dex-localhost` sidecar (post-renderer, HACKS U13):** pods without hostNetwork cannot reach the lab issuer `https://localhost:<dexPort>/dex`; hostNetwork is not an option for three servers on :8080. A socat sidecar on the pod's loopback forwards to the Dex Service (Dex's certificate carries `localhost`). `installOCIChart` runs the mcp-prometheus release through the post-renderer for it.
- `agentlab platform` waits for forwardToken servers to be *reachable* (Auth Required until the first session, Connected after).
- **Identity proofs:** `platform-test` lists kube-system Secrets through `x_mcp-kubernetes_list` as the platform-admin (allowed) and the viewer (the apiserver's Forbidden for `User "oidc:viewer@lab.local"`); `models-test` checks the pull job's `requestedBy` and that a viewer's `POST /models/wire` is Forbidden by the apiserver.

## Verification (agentlab against agent-platform-standalone@99ef6b4, model-manager 0.13.0, mcp-kubernetes 1.1.1, mcp-prometheus 0.8.0)

- `agentlab platform` green; MCPServer CRs carry the auth blocks and read Auth Required until a session connects.
- `agentlab platform-test`: PASS ×5 incl. "the forwarded Dex id_token reaches the apiserver — kube-system Secrets: platform-admin allowed, viewer forbidden"; mcp-prometheus tools answer PromQL through the forwarded token.
- `agentlab models-test`: PASS ×4 incl. `requestedBy=admin@lab.local` and the viewer's wire Forbidden (`modelconfigs.kagent.dev is forbidden: User "oidc:viewer@lab.local"`).
- `agentlab test`: 10/10. `agentlab backstage-test`: green (re-run after the fixture flipped back to Auth Required following a muster restart).
- Found on the way (fixed upstream, pinned by the umbrella): mcp-kubernetes ≤ 1.1.0 rejected a localhost issuer under `--allow-private-oauth-urls` (giantswarm/mcp-kubernetes#597); muster keeps a token-less global client when a CR flips from anonymous to forwardToken while the old pod still answers (giantswarm/muster#1135) — restart muster after such an upgrade.
