### PR TITLE
feat: agent-manager acts as the signed-in user in the lab — dex-localhost sidecar, requiredAudiences kubernetes, agents-test proof

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -318,12 +318,12 @@ fallback with a Capabilities check like the sibling branches; then the value
 can be dropped (it would render nothing here either way).
 
 ### U13. `postrender.go` patch: `dex-localhost` sidecar on the MCP servers — ACCEPTED
-Since 2026-09-03 the bundled mcp-kubernetes and model-manager and the lab's
-mcp-prometheus validate the user's forwarded Dex id_token themselves (mcp-oauth
-resource servers against `global.identity`), so each of them does OIDC discovery
-and JWKS fetches against the issuer URL — `https://localhost:<dexPort>/dex`, the
+Since 2026-09-03 the bundled mcp-kubernetes, model-manager and agent-manager and
+the lab's mcp-prometheus validate the user's forwarded Dex id_token themselves
+(mcp-oauth resource servers against `global.identity`), so each of them does
+OIDC discovery and JWKS fetches against the issuer URL — `https://localhost:<dexPort>/dex`, the
 one URL the browser, the apiserver and every pod must share (H-issuer, above).
-muster and Backstage reach it through hostNetwork (U1); these three cannot: all
+muster and Backstage reach it through hostNetwork (U1); these four cannot: all
 listen on :8080 and would collide on the single kind node. **Fix:** the
 post-renderer injects a `dex-localhost` sidecar (`alpine/socat`) that listens on
 the pod's own loopback :<dexPort> (IPv6 wildcard, dual-stack) and forwards to the

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ export ANTHROPIC_API_KEY=sk-ant-...   # optional: powers the agents + Backstage 
 ./agentlab up              # certs, kind cluster, Dex, RBAC, the agent platform — verified
 ./agentlab platform-test   # headless proof: Dex -> muster -> mcp-kubernetes -> apiserver, + the per-server OAuth sign-in challenge
 ./agentlab models-test     # with an Ollama on the host: pull -> ModelConfig -> agent turn -> delete, through the platform
+./agentlab agents-test     # agent-manager as the signed-in user: create -> ready -> update -> delete via muster; a viewer's create is Forbidden; the ServiceAccount holds no RBAC
 ```
 
 Then trust the lab CA once and point Claude Code at the platform (`.mcp.json`

--- a/internal/lab/agentmanager.go
+++ b/internal/lab/agentmanager.go
@@ -1,0 +1,6 @@
+package lab
+
+// agentManagerMCPServer is the MCPServer CR (and Deployment, and tool prefix
+// x_agent-manager_*) the umbrella's agent-manager chart renders; on whenever
+// the kagent component is.
+const agentManagerMCPServer = "agent-manager"

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -103,9 +103,9 @@ func AgentsTest(cfg *config.Config, email string) error {
 	note("using ModelConfig %s", modelConfig)
 
 	// A leftover from an aborted run would make the create a conflict.
-	if _, err := session.callServerTool(toolPrefix+"get_agent", map[string]any{"name": agentsTestAgent}); err == nil {
+	if _, err := session.callServerTool(toolPrefix+"get_agent", map[string]any{nameKey: agentsTestAgent}); err == nil {
 		note("removing the leftover agent %s from an earlier run", agentsTestAgent)
-		if _, err := session.callServerTool(toolPrefix+"delete_agent", map[string]any{"name": agentsTestAgent, "force": true}); err != nil {
+		if _, err := session.callServerTool(toolPrefix+"delete_agent", map[string]any{nameKey: agentsTestAgent, "force": true}); err != nil {
 			return err
 		}
 		if err := waitAgentGone(session, toolPrefix, agentsTestAgent); err != nil {
@@ -158,7 +158,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 	}
 	ready := waitFor(40, 3*time.Second, func() bool {
 		status.Verdict, status.Summary = "", ""
-		if err := session.callServerJSON(toolPrefix+"get_agent_status", map[string]any{"name": agentsTestAgent}, &status); err != nil {
+		if err := session.callServerJSON(toolPrefix+"get_agent_status", map[string]any{nameKey: agentsTestAgent}, &status); err != nil {
 			return false
 		}
 		return status.Verdict == "ready"
@@ -173,7 +173,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 		RequestedBy string   `json:"requestedBy"`
 		Changed     []string `json:"changed"`
 	}
-	if err := session.callServerJSON(toolPrefix+"update_agent", map[string]any{"name": agentsTestAgent, "description": "Updated by agentlab agents-test."}, &updated); err != nil {
+	if err := session.callServerJSON(toolPrefix+"update_agent", map[string]any{nameKey: agentsTestAgent, "description": "Updated by agentlab agents-test."}, &updated); err != nil {
 		return err
 	}
 	if updated.RequestedBy != user.Email || !slices.Contains(updated.Changed, "agent.description") {
@@ -199,7 +199,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 		if err != nil {
 			return err
 		}
-		text, err := viewerSession.callServerTool(toolPrefix+"create_agent", map[string]any{"name": agentsTestAgent + "-viewer", "modelConfig": modelConfig})
+		text, err := viewerSession.callServerTool(toolPrefix+"create_agent", map[string]any{nameKey: agentsTestAgent + "-viewer", "modelConfig": modelConfig})
 		switch {
 		case err == nil:
 			return fmt.Errorf("%s created an agent through agent-manager although the view role cannot write HelmReleases — agent-manager is not acting as the caller (ServiceAccount fallback?): %.200s", viewer.Email, text)
@@ -243,7 +243,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 		HelmReleaseDeleted bool   `json:"helmReleaseDeleted"`
 		OCIRepositoryKept  string `json:"ociRepositoryKept"`
 	}
-	if err := session.callServerJSON(toolPrefix+"delete_agent", map[string]any{"name": agentsTestAgent}, &deleted); err != nil {
+	if err := session.callServerJSON(toolPrefix+"delete_agent", map[string]any{nameKey: agentsTestAgent}, &deleted); err != nil {
 		return err
 	}
 	if !deleted.HelmReleaseDeleted || deleted.RequestedBy != user.Email {

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -122,7 +122,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 		} `json:"created"`
 	}
 	if err := session.callServerJSON(toolPrefix+"create_agent", map[string]any{
-		"name": agentsTestAgent, "modelConfig": modelConfig, "displayName": "agentlab agents-test",
+		nameKey: agentsTestAgent, "modelConfig": modelConfig, "displayName": "agentlab agents-test",
 		"description":   "Throwaway agent of `agentlab agents-test`; deleted by the same run.",
 		"systemMessage": "Reply with exactly the word pong and nothing else.",
 	}, &created); err != nil {

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -1,0 +1,310 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// agentsTestAgent is the throwaway agent the proof creates, updates and
+// deletes through agent-manager.
+const agentsTestAgent = "agentlab-agents-test"
+
+// agentManagerServiceAccount is the ServiceAccount the umbrella's agent-manager
+// Deployment runs with (fullnameOverride: agent-manager).
+const agentManagerServiceAccount = "system:serviceaccount:" + platformNamespace + ":" + agentManagerMCPServer
+
+// AgentsTest is the headless proof that agent-manager acts as the signed-in
+// user, through the platform path only (Dex id_token -> muster -> call_tool
+// x_agent-manager_*): get_info reports identity caller; the admin's create ->
+// ready -> update -> delete round trip succeeds with requestedBy set; a
+// viewers-group user's create is refused by the kind apiserver as
+// User "oidc:viewer@lab.local" (the view role writes no HelmReleases); and the
+// agent-manager ServiceAccount holds nothing beyond API discovery. Leaves
+// nothing behind.
+func AgentsTest(cfg *config.Config, email string) error {
+	if !cfg.Platform.Enabled || !cfg.Platform.Agents {
+		return fmt.Errorf("platform.agents is off in %s — enable it and run `agentlab platform` first", config.File)
+	}
+	user := cfg.FindUser(email)
+	if user == nil {
+		return fmt.Errorf("no user %q in %s", email, config.File)
+	}
+	toolPrefix := "x_" + agentManagerMCPServer + "_"
+
+	step("Logging in to Dex as %s", email)
+	token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+		user.Email, user.Password, musterLoginScopes)
+	if err != nil {
+		return err
+	}
+	note("got an id_token")
+
+	step("MCP tools through muster (%s*)", toolPrefix)
+	session, err := openMusterSession(cfg, token, "agents-test")
+	if err != nil {
+		return err
+	}
+	tools, err := session.listTools()
+	if err != nil {
+		return err
+	}
+	var amTools []string
+	for _, t := range tools {
+		if strings.HasPrefix(t, toolPrefix) {
+			amTools = append(amTools, strings.TrimPrefix(t, toolPrefix))
+		}
+	}
+	if len(amTools) == 0 {
+		return fmt.Errorf("muster aggregates no %s tools; check `kubectl -n %s get mcpservers.muster.giantswarm.io %s` and `agentlab logs muster`", toolPrefix, platformNamespace, agentManagerMCPServer)
+	}
+	slices.Sort(amTools)
+	note("%d tools: %s", len(amTools), strings.Join(amTools, ", "))
+
+	step("%sget_info — expecting identity caller (every Kubernetes call as the user)", toolPrefix)
+	var info struct {
+		Version      string          `json:"version"`
+		Identity     string          `json:"identity"`
+		Capabilities map[string]bool `json:"capabilities"`
+		Namespaces   struct {
+			Default string `json:"default"`
+		} `json:"namespaces"`
+	}
+	if err := session.callServerJSON(toolPrefix+"get_info", nil, &info); err != nil {
+		return err
+	}
+	if info.Identity != "caller" || !info.Capabilities["writesAsCaller"] {
+		return fmt.Errorf("agent-manager reports identity=%q writesAsCaller=%v: it is not running with downstream OAuth (umbrella agent-manager.oauth.downstream)", info.Identity, info.Capabilities["writesAsCaller"])
+	}
+	note("version %s, identity %s, default namespace %s", info.Version, info.Identity, info.Namespaces.Default)
+
+	step("%slist_model_configs", toolPrefix)
+	var configs struct {
+		ModelConfigs []struct {
+			Name string `json:"name"`
+		} `json:"modelConfigs"`
+	}
+	if err := session.callServerJSON(toolPrefix+"list_model_configs", nil, &configs); err != nil {
+		return err
+	}
+	if len(configs.ModelConfigs) == 0 {
+		return fmt.Errorf("no ModelConfig in %s — the kagent subchart's default one is missing", kagentNamespace)
+	}
+	modelConfig := configs.ModelConfigs[0].Name
+	for _, mc := range configs.ModelConfigs {
+		if mc.Name == "default-model-config" {
+			modelConfig = mc.Name
+		}
+	}
+	note("using ModelConfig %s", modelConfig)
+
+	// A leftover from an aborted run would make the create a conflict.
+	if _, err := session.callServerTool(toolPrefix+"get_agent", map[string]any{"name": agentsTestAgent}); err == nil {
+		note("removing the leftover agent %s from an earlier run", agentsTestAgent)
+		if _, err := session.callServerTool(toolPrefix+"delete_agent", map[string]any{"name": agentsTestAgent, "force": true}); err != nil {
+			return err
+		}
+		if err := waitAgentGone(session, toolPrefix, agentsTestAgent); err != nil {
+			return err
+		}
+	}
+
+	step("%screate_agent %s as %s", toolPrefix, agentsTestAgent, user.Email)
+	var created struct {
+		RequestedBy string `json:"requestedBy"`
+		Created     struct {
+			HelmRelease   bool `json:"helmRelease"`
+			OCIRepository bool `json:"ociRepository"`
+		} `json:"created"`
+	}
+	if err := session.callServerJSON(toolPrefix+"create_agent", map[string]any{
+		"name": agentsTestAgent, "modelConfig": modelConfig, "displayName": "agentlab agents-test",
+		"description":   "Throwaway agent of `agentlab agents-test`; deleted by the same run.",
+		"systemMessage": "Reply with exactly the word pong and nothing else.",
+	}, &created); err != nil {
+		return err
+	}
+	if !created.Created.HelmRelease {
+		return fmt.Errorf("create_agent reported no HelmRelease written")
+	}
+	if created.RequestedBy != user.Email {
+		return fmt.Errorf("create_agent carries requestedBy=%q, wanted %q: agent-manager did not learn the caller from the forwarded token", created.RequestedBy, user.Email)
+	}
+	note("HelmRelease written (OCIRepository created: %v), requestedBy=%s", created.Created.OCIRepository, created.RequestedBy)
+
+	step("The HelmRelease belongs to the user, not the ServiceAccount (managedFields)")
+	managers, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", agentsTestAgent,
+		"-o", "jsonpath={range .metadata.managedFields[*]}{.manager}{'\\n'}{end}")
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(managers, "agent-manager") {
+		return fmt.Errorf("HelmRelease %s has no agent-manager field manager: %q", agentsTestAgent, managers)
+	}
+	events, _ := outputQuiet("kubectl", "-n", platformNamespace, "logs", "deploy/"+agentManagerMCPServer, "-c", agentManagerMCPServer, "--since=5m")
+	if !strings.Contains(events, "caller="+user.Email) {
+		return fmt.Errorf("agent-manager's log carries no `caller=%s` line for the create", user.Email)
+	}
+	note("agent-manager logged the write with caller=%s", user.Email)
+
+	step("Waiting for %s to be ready (get_agent_status)", agentsTestAgent)
+	var status struct {
+		Verdict string `json:"verdict"`
+		Summary string `json:"summary"`
+	}
+	ready := waitFor(40, 3*time.Second, func() bool {
+		status.Verdict, status.Summary = "", ""
+		if err := session.callServerJSON(toolPrefix+"get_agent_status", map[string]any{"name": agentsTestAgent}, &status); err != nil {
+			return false
+		}
+		return status.Verdict == "ready"
+	})
+	if !ready {
+		return fmt.Errorf("%s never reached ready (last: %s — %s);\ncheck `kubectl -n %s get helmrelease,agents.kagent.dev,pods`", agentsTestAgent, status.Verdict, status.Summary, kagentNamespace)
+	}
+	note("ready: %s", excerpt(status.Summary, 120))
+
+	step("%supdate_agent as %s", toolPrefix, user.Email)
+	var updated struct {
+		RequestedBy string   `json:"requestedBy"`
+		Changed     []string `json:"changed"`
+	}
+	if err := session.callServerJSON(toolPrefix+"update_agent", map[string]any{"name": agentsTestAgent, "description": "Updated by agentlab agents-test."}, &updated); err != nil {
+		return err
+	}
+	if updated.RequestedBy != user.Email || !slices.Contains(updated.Changed, "agent.description") {
+		return fmt.Errorf("update_agent: requestedBy=%q changed=%v", updated.RequestedBy, updated.Changed)
+	}
+	note("changed %v, requestedBy=%s", updated.Changed, updated.RequestedBy)
+
+	// The user's identity, not a ServiceAccount: a viewer (the view
+	// ClusterRole, no HelmRelease writes anywhere) is refused by the kind
+	// apiserver under the user's own name. A shared ServiceAccount would let
+	// both users through alike.
+	viewer := cfg.FindUserInGroup("viewers")
+	if viewer == nil {
+		note("skipping the viewer proof: %s has no viewers-group user", config.File)
+	} else {
+		step("%screate_agent as %s — expecting the apiserver's Forbidden for User \"oidc:%s\"", toolPrefix, viewer.Email, viewer.Email)
+		viewerToken, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+			viewer.Email, viewer.Password, musterLoginScopes)
+		if err != nil {
+			return err
+		}
+		viewerSession, err := openMusterSession(cfg, viewerToken, "agents-test-viewer")
+		if err != nil {
+			return err
+		}
+		text, err := viewerSession.callServerTool(toolPrefix+"create_agent", map[string]any{"name": agentsTestAgent + "-viewer", "modelConfig": modelConfig})
+		switch {
+		case err == nil:
+			return fmt.Errorf("%s created an agent through agent-manager although the view role cannot write HelmReleases — agent-manager is not acting as the caller (ServiceAccount fallback?): %.200s", viewer.Email, text)
+		case !strings.Contains(strings.ToLower(err.Error()), "forbidden"):
+			return fmt.Errorf("%s: wanted the apiserver's Forbidden, got: %w", viewer.Email, err)
+		case !strings.Contains(err.Error(), `User "oidc:`+viewer.Email+`"`):
+			return fmt.Errorf("%s: Forbidden, but not under the user's own name (the apiserver saw someone else): %w", viewer.Email, err)
+		}
+		note("%s: %s", viewer.Email, excerpt(err.Error(), 200))
+		if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", agentsTestAgent+"-viewer"); err == nil {
+			return fmt.Errorf("HelmRelease %s-viewer exists although the create was refused", agentsTestAgent)
+		}
+	}
+
+	step("The agent-manager ServiceAccount holds no RBAC (kubectl auth can-i --list --as=%s)", agentManagerServiceAccount)
+	rules, err := outputQuiet("kubectl", "auth", "can-i", "--list", "--as="+agentManagerServiceAccount, "-n", kagentNamespace)
+	if err != nil {
+		return err
+	}
+	var granted []string
+	for line := range strings.SplitSeq(rules, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 || fields[0] == "Resources" {
+			continue
+		}
+		// Every authenticated principal has the selfsubject* reviews and the
+		// discovery URLs; anything else is a permission of its own.
+		if strings.HasPrefix(fields[0], "selfsubject") || strings.HasPrefix(fields[0], "[") {
+			continue
+		}
+		granted = append(granted, line)
+	}
+	if len(granted) > 0 {
+		return fmt.Errorf("the agent-manager ServiceAccount still holds permissions in %s:\n%s", kagentNamespace, strings.Join(granted, "\n"))
+	}
+	note("nothing beyond discovery and self-subject reviews")
+
+	step("%sdelete_agent %s as %s", toolPrefix, agentsTestAgent, user.Email)
+	var deleted struct {
+		RequestedBy        string `json:"requestedBy"`
+		HelmReleaseDeleted bool   `json:"helmReleaseDeleted"`
+		OCIRepositoryKept  string `json:"ociRepositoryKept"`
+	}
+	if err := session.callServerJSON(toolPrefix+"delete_agent", map[string]any{"name": agentsTestAgent}, &deleted); err != nil {
+		return err
+	}
+	if !deleted.HelmReleaseDeleted || deleted.RequestedBy != user.Email {
+		return fmt.Errorf("delete_agent: helmReleaseDeleted=%v requestedBy=%q", deleted.HelmReleaseDeleted, deleted.RequestedBy)
+	}
+	note("HelmRelease deleted, requestedBy=%s%s", deleted.RequestedBy, kept(deleted.OCIRepositoryKept))
+	if err := waitAgentGone(session, toolPrefix, agentsTestAgent); err != nil {
+		return err
+	}
+	note("%s is gone", agentsTestAgent)
+
+	fmt.Println()
+	fmt.Printf("PASS: muster aggregates %s* and agent-manager reports identity caller\n", toolPrefix)
+	fmt.Printf("PASS: %s created -> ready -> updated -> deleted %s through call_tool, every write requestedBy=%s and logged with caller=\n", user.Email, agentsTestAgent, user.Email)
+	if viewer != nil {
+		fmt.Printf("PASS: %s's create is Forbidden by the apiserver as User \"oidc:%s\" (user RBAC, not the ServiceAccount's)\n", viewer.Email, viewer.Email)
+	}
+	fmt.Printf("PASS: %s holds no permissions beyond discovery\n", agentManagerServiceAccount)
+	return nil
+}
+
+func kept(reason string) string {
+	if reason == "" {
+		return ", OCIRepository deleted"
+	}
+	return ", OCIRepository kept (" + reason + ")"
+}
+
+// waitAgentGone polls list_agents until name is no longer listed: the
+// HelmRelease uninstall is asynchronous (helm-controller finalizer).
+func waitAgentGone(session *musterSession, toolPrefix, name string) error {
+	gone := waitFor(30, 3*time.Second, func() bool {
+		var list struct {
+			Agents []struct {
+				Name string `json:"name"`
+			} `json:"agents"`
+		}
+		if err := session.callServerJSON(toolPrefix+"list_agents", nil, &list); err != nil {
+			return false
+		}
+		for _, a := range list.Agents {
+			if a.Name == name {
+				return false
+			}
+		}
+		return true
+	})
+	if !gone {
+		return fmt.Errorf("%s is still listed after the delete (helm-controller uninstall pending?)", name)
+	}
+	return nil
+}
+
+// callServerJSON runs an aggregated server tool and decodes its JSON payload.
+func (s *musterSession) callServerJSON(name string, args map[string]any, into any) error {
+	text, err := s.callServerTool(name, args)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(text), into); err != nil {
+		return fmt.Errorf("%s: payload is not the expected JSON: %w\n%.300s", name, err, text)
+	}
+	return nil
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -373,6 +373,14 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 			return err
 		}
 	}
+	if cfg.Platform.Agents {
+		// agent-manager ships with the umbrella whenever kagent is on and
+		// registers itself the same way (forward-token auth block).
+		step("Waiting for muster to reach agent-manager")
+		if err := waitMCPServerReachable(agentManagerMCPServer); err != nil {
+			return err
+		}
+	}
 
 	// The Workflow CRD ships with muster, so this has to land after the
 	// install. A muster with no workflows leaves the Backstage muster plugin's

--- a/internal/lab/postrender.go
+++ b/internal/lab/postrender.go
@@ -111,6 +111,7 @@ var dexLocalhostDeployments = map[string]bool{
 	"mcp-kubernetes":      true,
 	modelManagerMCPServer: true,
 	mcpPrometheusRelease:  true,
+	agentManagerMCPServer: true,
 }
 
 // dexLocalhostImage is the socat image of the sidecar (side-loaded like every

--- a/internal/lab/postrender_test.go
+++ b/internal/lab/postrender_test.go
@@ -211,6 +211,18 @@ spec:
       containers:
         - name: controller
           image: kagent:1.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-manager
+  namespace: agent-platform
+spec:
+  template:
+    spec:
+      containers:
+        - name: agent-manager
+          image: agent-manager:1.0
 `
 
 func TestPostRenderDexLocalhostSidecar(t *testing.T) {
@@ -232,8 +244,8 @@ func TestPostRenderDexLocalhostSidecar(t *testing.T) {
 		}
 		docs = append(docs, d)
 	}
-	if len(docs) != 2 {
-		t.Fatalf("want 2 documents, got %d", len(docs))
+	if len(docs) != 3 {
+		t.Fatalf("want 3 documents, got %d", len(docs))
 	}
 	containersOf := func(d map[string]any) []any {
 		return d["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)["containers"].([]any)
@@ -252,5 +264,10 @@ func TestPostRenderDexLocalhostSidecar(t *testing.T) {
 	}
 	if n := len(containersOf(docs[1])); n != 1 {
 		t.Fatalf("kagent-controller must stay untouched, got %d containers", n)
+	}
+	// agent-manager validates forwarded tokens against the lab issuer too.
+	am := containersOf(docs[2])
+	if len(am) != 2 || am[1].(map[string]any)["name"] != dexLocalhostContainer {
+		t.Fatalf("agent-manager: want the app container + the dex-localhost sidecar, got %v", am)
 	}
 }

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -298,6 +298,23 @@ kagent:
         enabled: false
 {{- end }}
 
+{{- if .Platform.Agents }}
+# The agent-manager chart's own values (the umbrella pins the Service name,
+# the kagent namespace, the muster registration and OAuth against
+# global.identity in its contract; the component is on whenever kagent is).
+# Same audience story as mcp-kubernetes above: agent-manager writes the
+# HelmRelease and OCIRepository of every agent as the caller (downstream
+# OAuth), so the forwarded token must carry the `kubernetes` audience to pass
+# the kind apiserver — the lab Dex lists agent-platform as a trusted peer of
+# that client.
+agent-manager:
+  muster:
+    mcpServer:
+      auth:
+        requiredAudiences:
+          - kubernetes
+{{- end }}
+
 {{- if .ModelManagerEnabled }}
 # The model-manager chart's own values (the umbrella pins the Service name,
 # the kagent namespace, the muster registration and — since the identity

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -174,6 +174,9 @@ func tryItBlock(cfg *config.Config) string {
 	if cfg.ModelManagerEnabled() {
 		cmds = append(cmds, [2]string{"agentlab models-test", "pull -> ModelConfig -> agent turn -> unload -> delete, through the platform"})
 	}
+	if cfg.Platform.Enabled && cfg.Platform.Agents {
+		cmds = append(cmds, [2]string{"agentlab agents-test", "agent-manager as the caller: create -> ready -> update -> delete, a viewer refused, the ServiceAccount without RBAC"})
+	}
 	width := 0
 	for _, c := range cmds {
 		width = max(width, len(c[0]))

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ Then:        claude mcp add --transport http muster https://muster.127.0.0.1.nip
 		labCmd("platform", "Install the Giant Swarm agent platform (muster + Kubernetes MCP)", lab.PlatformUp),
 		platformTestCmd(),
 		modelsTestCmd(),
+		agentsTestCmd(),
 		labCmd("platform-down", "Remove the agent platform (leaves Dex and the cluster alone)", lab.PlatformDown),
 		labCmd("backstage", "Retired: Backstage deploys with the platform now (backstage.enabled + `agentlab up`)", lab.BackstageUp),
 		backstageTestCmd(),
@@ -330,6 +331,25 @@ func modelsTestCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&model, "model", lab.ModelsTestModel, "the Ollama model to pull and delete (small and tool-calling capable)")
 	return cmd
+}
+
+func agentsTestCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "agents-test [email]",
+		Short: "Headless agent-manager proof through muster: get_info (caller) -> create -> ready -> update -> delete as the admin, a viewer's create Forbidden by the apiserver, the ServiceAccount without RBAC",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			email := cfg.AdminUser().Email
+			if len(args) == 1 {
+				email = args[0]
+			}
+			return lab.AgentsTest(cfg, email)
+		},
+	}
 }
 
 func backstageTestCmd() *cobra.Command {


### PR DESCRIPTION
## What

agent-manager 0.2.0 (giantswarm/agent-manager#7) runs mcp-oauth against `global.identity` with downstream OAuth, and agent-platform-standalone#103 turns it on from the contract. The lab needs what mcp-kubernetes and model-manager already have:

- `postrender.go`: the agent-manager Deployment gets the `dex-localhost` socat sidecar (HACKS U13) so the pod validates forwarded tokens against `https://localhost:<dexPort>/dex`.
- `agent-platform-values.yaml.tmpl`: `agent-manager.muster.mcpServer.auth.requiredAudiences: [kubernetes]` — the forwarded token must carry the audience the kind apiserver trusts, because the HelmRelease/OCIRepository writes now run as the caller.
- `agentlab platform` waits for the agent-manager MCPServer CR (Auth Required or Connected) whenever agents are on.
- `agentlab agents-test`: the headless proof through muster.

## Proof (lab on agent-platform-standalone `623beca`, agent-manager 0.2.0, this branch's binary)

```
==> [00:00] Logging in to Dex as admin@lab.local
    got an id_token
==> [00:00] MCP tools through muster (x_agent-manager_*)
    10 tools: create_agent, delete_agent, get_agent, get_agent_status, get_info, list_agents, list_model_configs, list_skills, update_agent, validate_agent
==> [00:01] x_agent-manager_get_info — expecting identity caller (every Kubernetes call as the user)
    version dev, identity caller, default namespace kagent
==> [00:01] x_agent-manager_list_model_configs
    using ModelConfig default-model-config
==> [00:01] x_agent-manager_create_agent agentlab-agents-test as admin@lab.local
    HelmRelease written (OCIRepository created: false), requestedBy=admin@lab.local
==> [00:01] The HelmRelease belongs to the user, not the ServiceAccount (managedFields)
    agent-manager logged the write with caller=admin@lab.local
==> [00:01] Waiting for agentlab-agents-test to be ready (get_agent_status)
    ready: Agent is Ready; 1/1 pods available
==> [00:04] x_agent-manager_update_agent as admin@lab.local
    changed [agent.description], requestedBy=admin@lab.local
==> [00:04] x_agent-manager_create_agent as viewer@lab.local — expecting the apiserver's Forbidden for User "oidc:viewer@lab.local"
    viewer@lab.local: x_agent-manager_create_agent failed: forbidden: forbidden: get agent kagent/agentlab-agents-test-viewer: agents.kagent.dev "agentlab-agents-test-viewer" is forbidden: User "oidc:viewer@lab.local" cann...
==> [00:04] The agent-manager ServiceAccount holds no RBAC (kubectl auth can-i --list --as=system:serviceaccount:agent-platform:agent-manager)
    nothing beyond discovery and self-subject reviews
==> [00:04] x_agent-manager_delete_agent agentlab-agents-test as admin@lab.local
    HelmRelease deleted, requestedBy=admin@lab.local, OCIRepository kept (still referenced by 3 other HelmRelease(s): my-agent, sre-agent, test)
    agentlab-agents-test is gone

PASS: muster aggregates x_agent-manager_* and agent-manager reports identity caller
PASS: admin@lab.local created -> ready -> updated -> deleted agentlab-agents-test through call_tool, every write requestedBy=admin@lab.local and logged with caller=
PASS: viewer@lab.local's create is Forbidden by the apiserver as User "oidc:viewer@lab.local" (user RBAC, not the ServiceAccount's)
PASS: system:serviceaccount:agent-platform:agent-manager holds no permissions beyond discovery
```

The first run right after `agentlab platform` failed with `transport error: authorization required` on every `x_agent-manager_*` call — giantswarm/muster#1135 again (the CR flipped from anonymous to forwardToken while the old 0.1.0 pod still answered muster's probe, so the server was registered globally with a token-less client). `kubectl -n agent-platform rollout restart deploy/muster` fixed it; every CR then reads Auth Required until the first session.