### PR TITLE
fix: pin the lab's kubectl and helm to the kind cluster's exported kubeconfig, never the shell's current-context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,11 @@ with Dex doing the logins.
   `kubectl --kubeconfig kubeconfig.oidc` — that is the OIDC path.
 - The kind admin context (`kind-agentlab`) bypasses the platform and OIDC
   entirely; use it only to debug the lab's own plumbing, never to demonstrate
-  platform behavior.
+  platform behavior. The lab's own `kubectl`/`helm` never read the shell's
+  kubeconfig: every cluster-facing command exports the kind cluster's
+  kubeconfig to `state/kubeconfig` and pins `KUBECONFIG` to it (exec.go), so
+  the proofs are deterministic about the cluster whatever the current-context
+  is — `KUBECONFIG=state/kubeconfig kubectl ...` is the same view from a shell.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -945,6 +945,18 @@ next version lands.
 
 ## Gotchas that cost time
 
+- **The lab never uses your kubeconfig's current-context.** Every command that
+  talks to the cluster first exports the kind cluster's kubeconfig to
+  `state/kubeconfig` and runs its own `kubectl` and `helm` with `KUBECONFIG`
+  pinned to it — so a shell with no current-context (or one pointing at a real
+  cluster) proves the same lab as any other, and a lab that is not running
+  fails by name (`no kubeconfig for kind cluster "agentlab"`) instead of as a
+  kubectl error. Your own kubeconfig is only ever touched by kind itself
+  (`kind create/delete cluster` merge the `kind-<cluster>` admin context in
+  and out); `agentlab` never switches your current-context. The same view from
+  a shell: `KUBECONFIG=state/kubeconfig kubectl -n agent-platform get pods`.
+  A probe that fails reports what kubectl said (`kubectl failed: ... current-context
+  is not set`), never an empty status.
 - **A client certificate beats a bearer token.** `kubectl --token=...` against
   the kind kubeconfig silently keeps authenticating as `kubernetes-admin`. You
   need a kubeconfig with no client cert — that is what `agentlab login` builds
@@ -1068,6 +1080,7 @@ internal/lab/                  everything operational:
   templates/                     every manifest, rendered from agentlab.yaml
 agentlab.yaml                    your configuration (gitignored; `agentlab configure`)
 state/                         rendered manifests, for inspection (gitignored)
+  kubeconfig                     the kind cluster's kubeconfig, exported per run — what the lab's own kubectl/helm use
 .vendor/                       agent-platform-standalone checkout (gitignored)
 .mcp.json                      registers muster as an MCP server for Claude Code
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -609,8 +609,6 @@ func (c *Config) Issuer() string {
 	return fmt.Sprintf("https://localhost:%d/dex", c.DexPort)
 }
 
-func (c *Config) KubeContext() string { return "kind-" + c.ClusterName }
-
 // ControlPlaneNode is the docker container name kind gives the (only) node.
 func (c *Config) ControlPlaneNode() string { return c.ClusterName + "-control-plane" }
 

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -27,6 +27,9 @@ const agentManagerServiceAccount = "system:serviceaccount:" + platformNamespace 
 // agent-manager ServiceAccount holds nothing beyond API discovery. Leaves
 // nothing behind.
 func AgentsTest(cfg *config.Config, email string) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	if !cfg.Platform.Enabled || !cfg.Platform.Agents {
 		return fmt.Errorf("platform.agents is off in %s — enable it and run `agentlab platform` first", config.File)
 	}

--- a/internal/lab/backstagetest.go
+++ b/internal/lab/backstagetest.go
@@ -22,6 +22,9 @@ var handlerPayloadRe = regexp.MustCompile(`decodeURIComponent\('([^']+)'\)`)
 // user, reports the identity Backstage resolved, and then proves the Giant
 // Swarm muster plugin can reach muster with that user's forwarded token.
 func BackstageTest(cfg *config.Config, emails []string) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	if len(emails) == 0 {
 		for _, u := range cfg.Users {
 			emails = append(emails, u.Email)

--- a/internal/lab/down.go
+++ b/internal/lab/down.go
@@ -15,6 +15,8 @@ func Down(cfg *config.Config) error {
 		return err
 	}
 	_ = os.Remove(".token")
+	// The exported kubeconfig described a cluster that no longer exists.
+	_ = os.Remove(labKubeconfigPath)
 	fmt.Println("Lab destroyed. certs/ kept (agentlab certs --force to regenerate).")
 	return nil
 }
@@ -24,6 +26,9 @@ func Down(cfg *config.Config) error {
 // to serve the platform's MCP tools); their prometheus-operator CRDs stay —
 // helm never removes a chart's crds/, and re-installs are unaffected.
 func PlatformDown(cfg *config.Config) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	_ = runQuiet("helm", "-n", observabilityNamespace, "uninstall", mcpPrometheusRelease)
 	_ = runQuiet("helm", "-n", observabilityNamespace, "uninstall", kpsRelease)
 	_ = runQuiet("kubectl", "delete", "namespace", observabilityNamespace, "--ignore-not-found")

--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -25,9 +25,47 @@ func note(format string, a ...any) {
 	fmt.Printf("    "+format+"\n", a...)
 }
 
+// The two tools whose cluster is pinned by command; every other subprocess
+// (kind, docker, git, helm's plugins) inherits the environment untouched.
+const (
+	kubectlBin = "kubectl"
+	helmBin    = "helm"
+)
+
+// command builds the exec.Cmd behind every helper below. kubectl and helm run
+// with KUBECONFIG pinned to the lab-owned kubeconfig (labKubeconfigPath, the
+// kind cluster's own as exported by useClusterKubeconfig), so which cluster a
+// lab command talks to is decided by agentlab.yaml — never by the shell's
+// kubeconfig or its current-context, which the lab neither reads nor changes.
+// An explicit --kubeconfig flag (the token-only kubeconfigs of test and up)
+// still wins, as kubectl's precedence has it. kind is deliberately not
+// pinned: it manages the user's own kubeconfig (create/delete cluster merge
+// the admin context in and out) and reads the cluster's kubeconfig off the
+// node, not off the host.
+func command(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd.Env = os.Environ()
+	if name == kubectlBin || name == helmBin {
+		// For duplicate keys os/exec keeps the last entry, so an inherited
+		// KUBECONFIG is overridden, not merged with.
+		cmd.Env = append(cmd.Env, "KUBECONFIG="+labKubeconfig())
+	}
+	return cmd
+}
+
+// cmdError wraps a failed command with its invocation and, when captured,
+// what it said on stderr — so a probe's failure reads "current-context is not
+// set" or "NotFound", not just "exit status 1".
+func cmdError(name string, args []string, err error, stderr []byte) error {
+	if msg := strings.TrimSpace(string(stderr)); msg != "" {
+		return fmt.Errorf("%s %s: %w: %s", name, strings.Join(args, " "), err, msg)
+	}
+	return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+}
+
 // run executes a command with output streamed to the terminal.
 func run(name string, args ...string) error {
-	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd := command(name, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -42,13 +80,13 @@ func runQuiet(name string, args ...string) error {
 // appended to the inherited environment.
 func runQuietEnv(extraEnv []string, name string, args ...string) error {
 	var buf bytes.Buffer
-	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
-	cmd.Env = append(os.Environ(), extraEnv...)
+	cmd := command(name, args...)
+	cmd.Env = append(cmd.Env, extraEnv...)
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
 	if err := cmd.Run(); err != nil {
 		_, _ = os.Stderr.Write(buf.Bytes())
-		return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+		return cmdError(name, args, err, nil)
 	}
 	return nil
 }
@@ -56,28 +94,34 @@ func runQuietEnv(extraEnv []string, name string, args ...string) error {
 // output captures a command's stdout (stderr goes to the terminal).
 func output(name string, args ...string) (string, error) {
 	var buf bytes.Buffer
-	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd := command(name, args...)
 	cmd.Stdout = &buf
 	cmd.Stderr = os.Stderr
 	err := cmd.Run()
 	return buf.String(), err
 }
 
-// outputQuiet captures stdout and swallows stderr; for probe-style commands
-// whose failures are expected.
+// outputQuiet captures stdout and keeps stderr off the terminal; for
+// probe-style commands whose failures are expected. The error still carries
+// the command and its stderr, so a caller that does report the failure says
+// what kubectl said — the empty stdout of a failed read is otherwise
+// indistinguishable from "no status yet".
 func outputQuiet(name string, args ...string) (string, error) {
-	var buf bytes.Buffer
-	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
-	cmd.Stdout = &buf
-	err := cmd.Run()
-	return buf.String(), err
+	var stdout, stderr bytes.Buffer
+	cmd := command(name, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), cmdError(name, args, err, stderr.Bytes())
+	}
+	return stdout.String(), nil
 }
 
 // outputAll captures stdout AND stderr together, for probe-style commands
 // whose diagnosis is in the error text (a probe pod's wget message).
 func outputAll(name string, args ...string) (string, error) {
 	var buf bytes.Buffer
-	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd := command(name, args...)
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
 	err := cmd.Run()
@@ -87,13 +131,13 @@ func outputAll(name string, args ...string) (string, error) {
 // pipeInto feeds input to a command's stdin, showing output only on failure.
 func pipeInto(input []byte, name string, args ...string) error {
 	var buf bytes.Buffer
-	cmd := exec.Command(name, args...) // #nosec G204 -- fixed lab tooling (kind/kubectl/helm) with lab-controlled args
+	cmd := command(name, args...)
 	cmd.Stdin = bytes.NewReader(input)
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf
 	if err := cmd.Run(); err != nil {
 		_, _ = os.Stderr.Write(buf.Bytes())
-		return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+		return cmdError(name, args, err, nil)
 	}
 	return nil
 }
@@ -109,6 +153,18 @@ func waitFor(attempts int, interval time.Duration, probe func() bool) bool {
 		time.Sleep(interval)
 	}
 	return false
+}
+
+// notReached words a wait loop's failure. readErr is the last status read's
+// own error: when the read itself failed, the message says so and carries
+// kubectl's words, instead of the empty status a failed read leaves behind —
+// which, on a shell without a kubeconfig current-context, read exactly like a
+// CR the controller had never touched.
+func notReached(subject, want, last string, readErr error, hint string) error {
+	if readErr != nil {
+		return fmt.Errorf("%s: kubectl failed: %w;\n%s", subject, readErr, hint)
+	}
+	return fmt.Errorf("%s never reached %s (last status: %q);\n%s", subject, want, last, hint)
 }
 
 // ensureNamespace idempotently creates a namespace (the dry-run|apply trick,

--- a/internal/lab/exec_test.go
+++ b/internal/lab/exec_test.go
@@ -1,0 +1,92 @@
+package lab
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// lastEnv returns the last KEY=value entry for key — the one os/exec hands the
+// child when a key repeats.
+func lastEnv(env []string, key string) string {
+	last := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, key+"=") {
+			last = kv
+		}
+	}
+	return last
+}
+
+// TestCommandPinsKubeconfig: kubectl and helm run against the lab-owned
+// kubeconfig whatever the shell has — an inherited KUBECONFIG is overridden
+// and a missing current-context is irrelevant — while kind and every other
+// tool inherit the environment untouched, because kind manages the user's own
+// kubeconfig.
+func TestCommandPinsKubeconfig(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/elsewhere/config")
+	if !filepath.IsAbs(labKubeconfig()) || !strings.HasSuffix(labKubeconfig(), filepath.FromSlash(labKubeconfigPath)) {
+		t.Fatalf("labKubeconfig() = %q, want an absolute path ending in %q", labKubeconfig(), labKubeconfigPath)
+	}
+	want := "KUBECONFIG=" + labKubeconfig()
+	for _, name := range []string{"kubectl", "helm"} {
+		if got := lastEnv(command(name, "version").Env, "KUBECONFIG"); got != want {
+			t.Errorf("%s: effective KUBECONFIG %q, want %q", name, got, want)
+		}
+	}
+	for _, name := range []string{"kind", "docker", "git"} {
+		if got := lastEnv(command(name, "version").Env, "KUBECONFIG"); got != "KUBECONFIG=/elsewhere/config" {
+			t.Errorf("%s: effective KUBECONFIG %q, want the inherited one", name, got)
+		}
+	}
+}
+
+// TestOutputQuietErrorCarriesStderr: a failed probe's error says what the
+// command said, not just "exit status 1" — the empty stdout of a failed
+// kubectl read is otherwise indistinguishable from "no status yet". On
+// success stderr stays off both the error and the terminal.
+func TestOutputQuietErrorCarriesStderr(t *testing.T) {
+	out, err := outputQuiet("sh", "-c", "echo partial; echo 'error: current-context is not set' >&2; exit 1")
+	if err == nil {
+		t.Fatal("expected the failing command to error")
+	}
+	if out != "partial\n" {
+		t.Errorf("stdout = %q, want the partial output kept", out)
+	}
+	for _, want := range []string{"sh -c", "exit status 1", "error: current-context is not set"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q lacks %q", err, want)
+		}
+	}
+
+	out, err = outputQuiet("sh", "-c", "echo ok; echo noise >&2")
+	if err != nil || out != "ok\n" {
+		t.Errorf("success: out=%q err=%v, want ok and nil", out, err)
+	}
+}
+
+// TestNotReached: a wait loop whose last status read failed reports the
+// kubectl failure — with kubectl's words — instead of an empty "last status",
+// which is exactly how a shell without a current-context made every proof
+// read as a CR the controller never touched.
+func TestNotReached(t *testing.T) {
+	readErr := errors.New(`kubectl -n kagent get modelconfigs.kagent.dev qwen: exit status 1: error: current-context is not set`)
+	err := notReached("ModelConfig qwen", "Accepted", "", readErr, "check `kubectl -n kagent describe modelconfigs.kagent.dev qwen`")
+	for _, want := range []string{"ModelConfig qwen: kubectl failed:", "current-context is not set", "check `kubectl"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("read failure %q lacks %q", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "last status") {
+		t.Errorf("read failure %q must not pose as a status", err)
+	}
+	if !errors.Is(err, readErr) {
+		t.Errorf("read failure should wrap the kubectl error")
+	}
+
+	err = notReached("ModelConfig qwen", "Accepted", "False", nil, "check it")
+	if want := `ModelConfig qwen never reached Accepted (last status: "False");` + "\ncheck it"; err.Error() != want {
+		t.Errorf("status failure = %q, want %q", err, want)
+	}
+}

--- a/internal/lab/kubeconfig.go
+++ b/internal/lab/kubeconfig.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 
@@ -16,23 +17,72 @@ const (
 	// oidcEntryName names the token kubeconfig's user and context entries
 	// (and its current-context).
 	oidcEntryName = "oidc"
+	// labKubeconfigPath is the lab-owned kubeconfig: the kind cluster's admin
+	// kubeconfig exactly as `kind get kubeconfig` emits it (its
+	// current-context is the kind-<cluster> context), written by
+	// useClusterKubeconfig and set as KUBECONFIG on every kubectl and helm the
+	// lab runs (exec.go). Under StateDir like every other generated artifact;
+	// `KUBECONFIG=state/kubeconfig kubectl ...` is the same view from a shell.
+	labKubeconfigPath = StateDir + "/kubeconfig"
 )
 
-// kindCluster is the cluster entry of the kind kubeconfig, cached per process:
-// `kind get kubeconfig` spawns a subprocess and its output never changes
-// within a run, while Test and the up verification write several kubeconfigs.
-var kindCluster struct {
-	name    string
-	cluster map[string]any
+// labKubeconfig is labKubeconfigPath made absolute, so a child process reads
+// the same file whatever its working directory.
+func labKubeconfig() string {
+	if abs, err := filepath.Abs(labKubeconfigPath); err == nil {
+		return abs
+	}
+	return labKubeconfigPath
 }
 
-func kindClusterEntry(clusterName string) (string, map[string]any, error) {
-	if kindCluster.cluster != nil {
-		return kindCluster.name, kindCluster.cluster, nil
+// kindKubeconfigCache holds `kind get kubeconfig` per process: a docker round
+// trip whose output never changes within a run, while up's verification, test
+// and login all want it.
+var kindKubeconfigCache struct {
+	name string
+	raw  []byte
+}
+
+// kindKubeconfig returns the cluster's admin kubeconfig from kind, which reads
+// it off the control-plane node — independent of any kubeconfig on the host.
+// A cluster that is not running fails here, by name, with kind's message.
+func kindKubeconfig(clusterName string) ([]byte, error) {
+	if kindKubeconfigCache.raw != nil && kindKubeconfigCache.name == clusterName {
+		return kindKubeconfigCache.raw, nil
 	}
-	raw, err := output("kind", "get", "kubeconfig", "--name", clusterName)
+	raw, err := outputQuiet("kind", "get", "kubeconfig", "--name", clusterName)
 	if err != nil {
-		return "", nil, fmt.Errorf("kind get kubeconfig: %w", err)
+		return nil, fmt.Errorf("no kubeconfig for kind cluster %q (is the lab up? `agentlab up`): %w", clusterName, err)
+	}
+	kindKubeconfigCache.name, kindKubeconfigCache.raw = clusterName, []byte(raw)
+	return kindKubeconfigCache.raw, nil
+}
+
+// useClusterKubeconfig exports the kind cluster's kubeconfig to
+// labKubeconfigPath. Every command that talks to the cluster calls it first:
+// from then on its kubectl and helm are deterministic about the cluster (the
+// one agentlab.yaml names), and a lab that is not running fails right here
+// instead of as an opaque kubectl error — or, worse, as a command against
+// whatever cluster the shell's own kubeconfig happens to point at. The user's
+// kubeconfig and current-context are never read or changed.
+func useClusterKubeconfig(cfg *config.Config) error {
+	raw, err := kindKubeconfig(cfg.ClusterName)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(StateDir, 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(labKubeconfigPath, raw, 0o600)
+}
+
+// kindClusterEntry is the cluster entry (name and server/CA) of the kind
+// kubeconfig, for the token-only kubeconfigs that reuse the endpoint without
+// the admin client certificate.
+func kindClusterEntry(clusterName string) (string, map[string]any, error) {
+	raw, err := kindKubeconfig(clusterName)
+	if err != nil {
+		return "", nil, err
 	}
 	var kc struct {
 		Clusters []struct {
@@ -40,14 +90,13 @@ func kindClusterEntry(clusterName string) (string, map[string]any, error) {
 			Cluster map[string]any `yaml:"cluster"`
 		} `yaml:"clusters"`
 	}
-	if err := yaml.Unmarshal([]byte(raw), &kc); err != nil {
+	if err := yaml.Unmarshal(raw, &kc); err != nil {
 		return "", nil, fmt.Errorf("parsing kind kubeconfig: %w", err)
 	}
 	if len(kc.Clusters) == 0 {
 		return "", nil, fmt.Errorf("kind kubeconfig has no clusters")
 	}
-	kindCluster.name, kindCluster.cluster = kc.Clusters[0].Name, kc.Clusters[0].Cluster
-	return kindCluster.name, kindCluster.cluster, nil
+	return kc.Clusters[0].Name, kc.Clusters[0].Cluster, nil
 }
 
 // writeTokenKubeconfig builds a kubeconfig that authenticates ONLY with the

--- a/internal/lab/kubeconfig_test.go
+++ b/internal/lab/kubeconfig_test.go
@@ -1,0 +1,122 @@
+package lab
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// fakeKindKubeconfig is what the stand-in kind emits for `get kubeconfig`:
+// the shape of the real output, with the admin client certificate a token
+// kubeconfig must not inherit.
+const fakeKindKubeconfig = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: Zm9v
+    server: https://127.0.0.1:34547
+  name: kind-agentlab
+contexts:
+- context:
+    cluster: kind-agentlab
+    user: kind-agentlab
+  name: kind-agentlab
+current-context: kind-agentlab
+users:
+- name: kind-agentlab
+  user:
+    client-certificate-data: Zm9v
+    client-key-data: Zm9v
+`
+
+// installFakeKind puts a `kind` on PATH that answers `get kubeconfig --name
+// agentlab` with fakeKindKubeconfig, fails every other cluster the way kind
+// does, and logs each invocation to a file; returns that file.
+func installFakeKind(t *testing.T, dir string) string {
+	t.Helper()
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	calls := filepath.Join(dir, "kind-calls")
+	script := "#!/bin/sh\n" +
+		"echo \"kind $*\" >> \"$KIND_CALLS\"\n" +
+		"if [ \"$1 $2 $3 $4\" != \"get kubeconfig --name agentlab\" ]; then\n" +
+		"  echo \"ERROR: could not locate any control plane nodes for cluster named '$4'\" >&2\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"cat <<'KUBECONFIG'\n" + fakeKindKubeconfig + "KUBECONFIG\n"
+	if err := os.WriteFile(filepath.Join(bin, "kind"), []byte(script), 0o700); err != nil { // #nosec G306 -- an executable stand-in under t.TempDir
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("KIND_CALLS", calls)
+	return calls
+}
+
+func resetKindKubeconfigCache(t *testing.T) {
+	t.Helper()
+	kindKubeconfigCache.name, kindKubeconfigCache.raw = "", nil
+	t.Cleanup(func() { kindKubeconfigCache.name, kindKubeconfigCache.raw = "", nil })
+}
+
+// TestUseClusterKubeconfig drives the export against a stand-in kind: the
+// lab-owned kubeconfig lands under state/ owner-only and byte-identical to
+// what kind emitted, the very file the command constructor pins kubectl to;
+// one kind call serves both it and the cluster entry the token kubeconfigs
+// are built from; and a cluster kind does not know fails by name with kind's
+// message instead of leaving kubectl to the shell's kubeconfig.
+func TestUseClusterKubeconfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	calls := installFakeKind(t, dir)
+	resetKindKubeconfigCache(t)
+
+	cfg := config.Default()
+	if err := useClusterKubeconfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(labKubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("state/kubeconfig mode %v, want owner-only 0600", info.Mode().Perm())
+	}
+	raw, err := os.ReadFile(labKubeconfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != fakeKindKubeconfig {
+		t.Errorf("state/kubeconfig is not kind's output:\n%s", raw)
+	}
+	if got, want := lastEnv(command("kubectl", "get", "pods").Env, "KUBECONFIG"), "KUBECONFIG="+labKubeconfig(); got != want {
+		t.Errorf("kubectl runs with %q, want %q", got, want)
+	}
+
+	name, cluster, err := kindClusterEntry(cfg.ClusterName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "kind-agentlab" || cluster["server"] != "https://127.0.0.1:34547" {
+		t.Errorf("cluster entry = %q %v", name, cluster)
+	}
+	if log, _ := os.ReadFile(calls); strings.Count(string(log), "\n") != 1 { // #nosec G304 -- the call log this test's stand-in wrote under t.TempDir
+		t.Errorf("kind was run %d times for one export + one entry lookup, want 1 (cached):\n%s", strings.Count(string(log), "\n"), log)
+	}
+
+	resetKindKubeconfigCache(t)
+	cfg.ClusterName = "nope"
+	err = useClusterKubeconfig(cfg)
+	if err == nil {
+		t.Fatal("a cluster kind does not know must fail the export")
+	}
+	for _, want := range []string{`"nope"`, "agentlab up", "could not locate any control plane nodes"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("missing-cluster error %q lacks %q", err, want)
+		}
+	}
+}

--- a/internal/lab/logs.go
+++ b/internal/lab/logs.go
@@ -5,6 +5,8 @@ import (
 	"maps"
 	"slices"
 	"strings"
+
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // logCmd is the kubectl subcommand every log target shares.
@@ -24,11 +26,15 @@ var logTargets = map[string][]string{
 // LogComponents lists what Logs accepts, for cobra's ValidArgs.
 func LogComponents() []string { return slices.Sorted(maps.Keys(logTargets)) }
 
-// Logs tails the given component's logs (kubectl logs -f passthrough).
-func Logs(component string) error {
+// Logs tails the given component's logs (kubectl logs -f passthrough, against
+// the lab cluster whatever the shell's kubeconfig says).
+func Logs(cfg *config.Config, component string) error {
 	args, ok := logTargets[component]
 	if !ok {
 		return fmt.Errorf("unknown component %q (%s)", component, strings.Join(LogComponents(), ", "))
+	}
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
 	}
 	return run("kubectl", args...)
 }

--- a/internal/lab/models.go
+++ b/internal/lab/models.go
@@ -156,16 +156,16 @@ func extraModelsHint(cfg *config.Config) string {
 // it — the machine check that the provider/model/Secret combination is one
 // the runtime can mount, before anyone debugs it from a failing agent pod.
 func waitModelConfigAccepted(name string) error {
-	status := ""
+	var status string
+	var readErr error
 	accepted := waitFor(10, 2*time.Second, func() bool {
-		status, _ = outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, name,
+		status, readErr = outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, name,
 			"-o", `jsonpath={.status.conditions[?(@.type=="Accepted")].status}`)
-		return status == "True"
+		return readErr == nil && status == "True"
 	})
 	if !accepted {
-		return fmt.Errorf("ModelConfig %s never reached Accepted (last status: %q);\n"+
-			"check `kubectl -n %s describe %s %s`",
-			name, status, kagentNamespace, modelConfigResource, name)
+		return notReached("ModelConfig "+name, "Accepted", status, readErr,
+			fmt.Sprintf("check `kubectl -n %s describe %s %s`", kagentNamespace, modelConfigResource, name))
 	}
 	note("ModelConfig %s: Accepted", name)
 	return nil

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -33,6 +33,9 @@ const modelField = "model"
 // -> the MCP tools through muster -> unload -> delete (gone from Ollama, the
 // ModelConfig gone). Leaves nothing behind.
 func ModelsTest(cfg *config.Config, email, model string) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	if !cfg.ModelManagerEnabled() {
 		return fmt.Errorf("platform.modelManager is off in %s (needs platform.agents too) — enable it and run `agentlab platform` first", config.File)
 	}

--- a/internal/lab/observability.go
+++ b/internal/lab/observability.go
@@ -85,20 +85,20 @@ func observabilityUp(cfg *config.Config) error {
 	// report an available replica; without it the mcp-prometheus tools connect
 	// fine and then fail every query.
 	step("Waiting for Prometheus to serve (the operator creates it after the install)")
-	replicas := ""
+	var replicas string
+	var readErr error
 	up := waitFor(40, 3*time.Second, func() bool {
 		// Fully qualified on principle (same reason as mcpservers): other
 		// charts may ship colliding kinds.
-		replicas, _ = outputQuiet("kubectl", "-n", observabilityNamespace,
+		replicas, readErr = outputQuiet("kubectl", "-n", observabilityNamespace,
 			"get", "prometheuses.monitoring.coreos.com",
 			"-o", "jsonpath={.items[0].status.availableReplicas}")
 		n, err := strconv.Atoi(strings.TrimSpace(replicas))
-		return err == nil && n >= 1
+		return readErr == nil && err == nil && n >= 1
 	})
 	if !up {
-		return fmt.Errorf("no available Prometheus replica after the install (last status: %q);\n"+
-			"check `kubectl -n %s get prometheus,statefulset,pods`",
-			replicas, observabilityNamespace)
+		return notReached("the Prometheus CR", "an available replica after the install", strings.TrimSpace(replicas), readErr,
+			fmt.Sprintf("check `kubectl -n %s get prometheus,statefulset,pods`", observabilityNamespace))
 	}
 	note("Prometheus is serving (PromQL inside the cluster: http://prometheus-operated.%s:9090)",
 		observabilityNamespace)

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -48,6 +48,9 @@ const apsDir = ".vendor/agent-platform-standalone"
 // it is vendored from git at a pinned SHA and installed from the local path.
 // Once released: swap the vendor step for the OCI ref.
 func PlatformUp(cfg *config.Config) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	// The standalone entry point skips Up's overlapped preload, so join a
 	// synchronous one here: on a live cluster the node filter makes it a
 	// no-op, and after a half-failed boot it heals the missing side-loads
@@ -530,17 +533,17 @@ func waitMCPServerReachable(name string) error {
 // CRD (mcpservers.kagent.dev), so the bare kind resolves to the wrong API
 // group.
 func waitMCPServerState(name string, want ...string) error {
-	state := ""
+	var state string
+	var readErr error
 	reached := waitFor(40, 3*time.Second, func() bool {
-		state, _ = outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io", name,
+		state, readErr = outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io", name,
 			"-o", "jsonpath={.status.state}")
-		return slices.Contains(want, state)
+		return readErr == nil && slices.Contains(want, state)
 	})
 	if !reached {
-		return fmt.Errorf("MCPServer %s never reached %s (last state: %q);\n"+
-			"check `agentlab logs muster`, `kubectl -n %s describe mcpservers.muster.giantswarm.io %s`\n"+
-			"and the server's rollout: `kubectl -n %s get deploy,pods`",
-			name, strings.Join(want, " or "), state, platformNamespace, name, platformNamespace)
+		return notReached("MCPServer "+name, strings.Join(want, " or "), state, readErr,
+			fmt.Sprintf("check `agentlab logs muster`, `kubectl -n %s describe mcpservers.muster.giantswarm.io %s`\n"+
+				"and the server's rollout: `kubectl -n %s get deploy,pods`", platformNamespace, name, platformNamespace))
 	}
 	note("MCPServer %s: %s", name, state)
 	return nil

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -21,6 +21,9 @@ import (
 // oauth.server.trustedAudiences. Claude Code instead does the full browser
 // authorization-code flow; this is the CI-friendly shortcut.
 func PlatformTest(cfg *config.Config, email string) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	user := cfg.FindUser(email)
 	if user == nil {
 		return fmt.Errorf("no user %q in %s", email, config.File)

--- a/internal/lab/test.go
+++ b/internal/lab/test.go
@@ -12,6 +12,9 @@ import (
 // from Dex and a set of `kubectl auth can-i` assertions driven purely by the
 // `groups` claim in the id_token.
 func Test(cfg *config.Config) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	pass, fail := 0, 0
 
 	check := func(kubeconfig, desc, expect string, canIArgs ...string) {

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -55,7 +55,11 @@ func Up(cfg *config.Config) error {
 			return err
 		}
 	}
-	if err := runQuiet("kubectl", "config", "use-context", cfg.KubeContext()); err != nil {
+	// From here on the lab's own kubectl and helm run against the cluster's
+	// exported kubeconfig (exec.go); the user's current-context is left alone
+	// (kind create cluster merges the admin context into their kubeconfig, as
+	// kind always does — that is the `kind-<cluster>` context for debugging).
+	if err := useClusterKubeconfig(cfg); err != nil {
 		return err
 	}
 
@@ -195,6 +199,9 @@ func tryItBlock(cfg *config.Config) string {
 // certs rolls the pod, while an unchanged re-apply is a pure no-op (no
 // throwaway ReplicaSet). Shared by Up and `agentlab reload`.
 func ApplyDex(cfg *config.Config) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
 	stamped, _, err := renderManifest(cfg, "dex.yaml.tmpl")
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -373,7 +373,11 @@ func logsCmd() *cobra.Command {
 		Args:      cobra.ExactArgs(1),
 		ValidArgs: lab.LogComponents(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return lab.Logs(args[0])
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			return lab.Logs(cfg, args[0])
 		},
 	}
 }


### PR DESCRIPTION
## What

Every command that talks to the cluster first exports the kind cluster's kubeconfig (`kind get kubeconfig`, read off the node) to `state/kubeconfig`, and the lab's `kubectl` and `helm` run with `KUBECONFIG` pinned to it (`exec.go`'s `command` constructor). kind itself is not pinned: it keeps managing the user's kubeconfig as it always did (`kind create/delete cluster` merge the `kind-<cluster>` admin context in and out), and `agentlab up` no longer runs `kubectl config use-context` on the user's kubeconfig on re-runs. An explicit `--kubeconfig` flag (the token-only kubeconfigs of `test` and `up`'s verification) still wins, per kubectl's precedence.

Probe failures now carry kubectl's stderr (`outputQuiet` used to swallow it), and the three wait loops (ModelConfig `Accepted`, MCPServer state, Prometheus replicas) report `kubectl failed: …` through one `notReached` helper instead of an empty `last status: ""`. A lab that is not running fails by name (``no kubeconfig for kind cluster "agentlab" (is the lab up? `agentlab up`)``) instead of running against whatever the shell's kubeconfig points at. `agentlab logs` loads the config to know the cluster. `Config.KubeContext` lost its last caller and is removed.

## Why

Found while verifying giantswarm/model-manager#41: in a shell whose kubeconfig has no `current-context`, `agentlab models-test` failed at

```
ModelConfig qwen2-5-0-5b never reached Accepted (last status: "");
```

on the released model-manager and on the build under test alike, while every HTTP step passed and the CR was `Accepted: True` the same second it was created. The bare `kubectl` failed with `error: current-context is not set`, the error was discarded, and the empty stdout read as "no status". A wrong or missing context was indistinguishable from a real regression, and the proofs depended on the shell rather than on `agentlab.yaml`.

## Proof

Unit tests (`go test ./...` green, `golangci-lint -E gosec -E goconst -E govet` clean):

- `TestCommandPinsKubeconfig` — kubectl/helm get the lab file as the effective `KUBECONFIG` even with one inherited; kind/docker/git inherit untouched.
- `TestUseClusterKubeconfig` — against a stand-in `kind` on `PATH`: `state/kubeconfig` is `0600` and byte-identical to kind's output, the command constructor points kubectl at that very file, one cached kind call serves both the export and the cluster entry the token kubeconfigs use, and an unknown cluster fails by name with kind's message.
- `TestOutputQuietErrorCarriesStderr`, `TestNotReached` — the error wording.

Lab, from a shell with **no current-context** (`kubectl config view --raw --flatten` minus `current-context`, `KUBECONFIG` pointed at it; `kubectl config current-context` → `error: current-context is not set`):

- released binary, `agentlab logs muster`: `couldn't get current server API group list: invalid character '<'` (kubectl fell through to localhost:8080), exits.
- this branch, `agentlab logs muster`: streams muster's log.
- this branch, `agentlab models-test`: all four PASS lines in 26 s, including the step that used to fail:

```
==> [00:17] Auto-created kagent ModelConfig
    ModelConfig qwen2-5-0-5b: Accepted
    ModelConfig qwen2-5-0-5b: Ollama qwen2.5:0.5b http://172.21.0.1:11434 managed-by=model-manager (keyless native provider)
…
PASS: no token -> 401 at the gateway; Dex token -> model-manager REST through agentgateway
PASS: list -> pull qwen2.5:0.5b (progress) -> ModelConfig qwen2-5-0-5b (Ollama provider) Accepted -> agent turn -> unload -> delete
PASS: muster aggregates x_model-manager_* and calls them (get_model, list_models)
PASS: the caller's identity — job requestedBy=admin@lab.local; a viewer's wire is Forbidden by the apiserver (user RBAC, not the ServiceAccount's)
```

The user's kubeconfig was not touched by any of it (`current-context` unchanged before/after), `state/kubeconfig` is `-rw-------`, and no ModelConfig or Agent was left behind.

## Behaviour change worth knowing

`agentlab up` on an existing cluster no longer switches your global `current-context` to `kind-<cluster>`. A fresh `kind create cluster` still does, as kind does by default. `KUBECONFIG=state/kubeconfig kubectl …` is the lab's own view from a shell (README "Gotchas", CLAUDE.md).
