### PR TITLE
feat(model-manager): platform.modelManager.backend lemonade — a Lemonade Server (FastFlowLM on AMD Ryzen AI NPUs) on the lab host as the managed-models backend next to Ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ export ANTHROPIC_API_KEY=sk-ant-...   # optional: powers the agents + Backstage 
 ./agentlab configure       # interactive form: cluster, users, components
 ./agentlab up              # certs, kind cluster, Dex, RBAC, the agent platform — verified
 ./agentlab platform-test   # headless proof: Dex -> muster -> mcp-kubernetes -> apiserver, + the per-server OAuth sign-in challenge
-./agentlab models-test     # with an Ollama on the host: pull -> ModelConfig -> agent turn -> delete, through the platform
+./agentlab models-test     # with an Ollama (or Lemonade Server) on the host: pull -> ModelConfig -> agent turn -> delete, through the platform
 ./agentlab agents-test     # agent-manager as the signed-in user: create -> ready -> update -> delete via muster; a viewer's create is Forbidden; the ServiceAccount holds no RBAC
 ```
 
@@ -463,45 +463,53 @@ One Lemonade-specific note: its FastFlowLM models default to a 4096-token
 context, which agent system prompts plus tool schemas outgrow quickly —
 raise it once with `lemonade config set ctx_size=16384`.
 
-#### Managed models: model-manager + host Ollama
+#### Managed models: model-manager + the host's Ollama or Lemonade Server
 
 `extraModels` wires an endpoint and manages nothing: pulling or removing a
 model is CLI-on-host, and nothing shows what is downloaded or loaded. The
 managed mode puts the umbrella's **model-manager** component
 ([giantswarm/model-manager](https://github.com/giantswarm/model-manager),
-the service behind the Model Manager epic) in front of the host's Ollama —
-inventory of downloaded and loaded models, pull with progress, load/unload,
-delete, and every pulled model wired into kagent automatically as a
-`ModelConfig` with the native, keyless `Ollama` provider. One block:
+the service behind the Model Manager epic) in front of the host's model
+server — an Ollama, or a Lemonade Server (FastFlowLM on AMD Ryzen AI NPUs,
+llama.cpp on GPU/CPU) — inventory of downloaded and loaded models, pull with
+progress, load/unload, delete, and every pulled model wired into kagent
+automatically as a `ModelConfig`: the native, keyless `Ollama` provider for
+Ollama, kagent's `OpenAI` provider against Lemonade's `/api/v1` (with a
+placeholder key) for Lemonade. One block:
 
 ```yaml
 platform:
   agents: true                 # required: the ModelConfigs land in kagent
   modelManager:
     enabled: true
-    backend: ollama            # the lab's only backend (kserve needs GPUs + KServe)
-    # endpoint: http://192.168.1.10:11434   # optional; empty autodetects the host
+    backend: ollama            # or lemonade: a Lemonade Server on the host (kserve needs GPUs + KServe)
+    # endpoint: http://192.168.1.10:11434   # optional; empty autodetects the host (11434 ollama, 13305 lemonade)
 ```
 
-`agentlab configure` turns it on for a fresh config when an Ollama answers on
-this machine (`--defaults --model-manager[=false]` forces it either way; the
-interactive form asks). The endpoint is **autodetected at platform time** as
-`http://<kind docker network gateway>:11434` — `docker network inspect kind`,
-the same address the section above documents for `extraModels` — so nobody
-types `172.21.0.1`; set `endpoint` for an Ollama elsewhere on the LAN.
+`agentlab configure` turns it on for a fresh config when an Ollama — else a
+Lemonade Server — answers on this machine (`--defaults --model-manager[=false]`
+forces it either way, `--model-manager-backend ollama|lemonade` picks the
+server; the interactive form asks). The endpoint is **autodetected at
+platform time** as `http://<kind docker network gateway>:<port>` — 11434 for
+Ollama, 13305 for Lemonade; `docker network inspect kind`, the same address
+the section above documents for `extraModels` — so nobody types
+`172.21.0.1`; set `endpoint` for a server elsewhere on the LAN.
 
 What `agentlab platform` (or `up`) does with it:
 
 - **Preflight, not README traps.** Before the install, a short-lived pod in
-  the cluster fetches `<endpoint>/api/version`. If that fails, the boot stops
+  the cluster fetches `<endpoint>/api/version` (Ollama) or
+  `<endpoint>/api/v1/health` (Lemonade). If that fails, the boot stops
   right there with the diagnosis and the two fixes from the section above
-  spelled out — *connection refused* means Ollama listens on `127.0.0.1`
-  only (`OLLAMA_HOST=0.0.0.0`), a *timeout* means the host firewall drops
-  pod→host traffic on the docker bridge (allow TCP 11434 from the bridge
+  spelled out — *connection refused* means the server listens on `127.0.0.1`
+  only (`OLLAMA_HOST=0.0.0.0`; `lemonade config set host=0.0.0.0`), a
+  *timeout* means the host firewall drops pod→host traffic on the docker
+  bridge (allow the server's TCP port, 11434 or 13305, from the bridge
   subnets, inside `172.16.0.0/12`) — instead of a model-manager pod
   reporting an unhealthy backend after Helm's ten-minute wait.
-- **The umbrella's `components.model-manager`** goes on with the Ollama
-  backend (`model-manager.ollama.endpoint` = the detected address), its
+- **The umbrella's `components.model-manager`** goes on with the configured
+  backend (`model-manager.ollama.endpoint` or `model-manager.lemonade.endpoint`
+  = the detected address), its
   agentgateway **route** at `https://agentgateway.<domain>/model-manager`
   and, unlike the lab's kagent route, **JWT validation on**: the gateway
   verifies the caller's Dex token against the lab Dex (JWKS over TLS at
@@ -524,8 +532,12 @@ What `agentlab platform` (or `up`) does with it:
 The proof is `agentlab models-test` (`--model` picks another small,
 **tool-calling capable** model; the default `qwen2.5:0.5b` is ~400 MB —
 `smollm2:135m` pulls fine and then fails every agent turn with "does not
-support tools"). It goes through the platform path only and leaves nothing
-behind:
+support tools"). On the lemonade backend `--model` is required and names a
+Lemonade catalog model whose recipe backend is installed on the host — an
+`*-FLM` model on an AMD NPU host (`lemonade list`) — and the ModelConfig it
+checks is kagent's `OpenAI` provider against `<gateway>:13305/api/v1`; the
+model is deleted at the end, so pick one you can re-pull. It goes through
+the platform path only and leaves nothing behind:
 
 ```
 agentlab models-test

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,8 +142,9 @@ type Platform struct {
 	// CRs by `agentlab platform`; entries removed here are pruned on the next
 	// run. Inert unless agents are enabled.
 	ExtraModels []ExtraModel `yaml:"extraModels,omitempty"`
-	// Managed models: the umbrella's model-manager component with the Ollama
-	// backend, proxying the Ollama that runs on the lab host — pull, load,
+	// Managed models: the umbrella's model-manager component with the ollama
+	// or lemonade backend, proxying the model server that runs on the lab
+	// host (Ollama; Lemonade Server — FastFlowLM on AMD Ryzen AI NPUs) — pull, load,
 	// unload and delete models from the portal (or as x_model-manager_*
 	// tools through muster), each pulled model wired into kagent as a
 	// keyless ModelConfig automatically. Complements extraModels, which
@@ -154,27 +155,59 @@ type Platform struct {
 // ModelManager configures the umbrella's model-manager component in the lab.
 type ModelManager struct {
 	// On, `agentlab platform` enables components.model-manager with the
-	// Ollama backend, its agentgateway route (JWT-validated: the portal
+	// configured backend, its agentgateway route (JWT-validated: the portal
 	// backend forwards the user's Dex token) and the muster registration.
-	// `agentlab configure` turns it on for a fresh config when an Ollama
-	// answers on the host.
+	// `agentlab configure` turns it on for a fresh config when an Ollama (else
+	// a Lemonade Server) answers on the host.
 	Enabled bool `yaml:"enabled"`
-	// The serving backend. The lab supports `ollama` only: kserve needs
-	// GPU nodes and a KServe install this kind cluster does not have.
+	// The serving backend on the lab host: `ollama` (the default) or
+	// `lemonade` (a Lemonade Server — FastFlowLM on AMD Ryzen AI NPUs, llama.cpp
+	// on GPU/CPU). kserve needs GPU nodes and a KServe install this kind
+	// cluster does not have.
 	Backend string `yaml:"backend,omitempty"`
-	// The Ollama API base URL as pods reach it. Empty autodetects
-	// http://<kind docker network gateway>:11434 at platform time — the
-	// same address the README documents for extraModels (`docker network
-	// inspect kind`). Set it for an Ollama elsewhere on the LAN.
+	// The model server's base URL as pods reach it. Empty autodetects
+	// http://<kind docker network gateway>:<port> at platform time — 11434 for
+	// Ollama, 13305 for Lemonade; the same address the README documents for
+	// extraModels (`docker network inspect kind`). Set it for a server
+	// elsewhere on the LAN.
 	Endpoint string `yaml:"endpoint,omitempty"`
 }
 
-// ModelManagerBackendOllama is the one backend the lab runs.
-const ModelManagerBackendOllama = "ollama"
+// The serving backends the lab runs against a server on the host, which
+// model-manager reaches through the kind docker network's gateway.
+const (
+	// ModelManagerBackendOllama is a host Ollama (the default).
+	ModelManagerBackendOllama = "ollama"
+	// ModelManagerBackendLemonade is a host Lemonade Server (lemonade-server.ai):
+	// FastFlowLM on AMD Ryzen AI NPUs, llama.cpp on GPU and CPU.
+	ModelManagerBackendLemonade = "lemonade"
+)
 
-// OllamaPort is Ollama's default API port, the one the autodetected endpoint
-// assumes on the host.
-const OllamaPort = 11434
+// ModelManagerBackends lists the backends the lab accepts, the default first.
+var ModelManagerBackends = []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}
+
+// OllamaPort and LemonadePort are the servers' default API ports, the ones the
+// autodetected endpoint assumes on the host.
+const (
+	OllamaPort   = 11434
+	LemonadePort = 13305
+)
+
+// Port is the default API port of the configured backend's server.
+func (m ModelManager) Port() int {
+	if m.Backend == ModelManagerBackendLemonade {
+		return LemonadePort
+	}
+	return OllamaPort
+}
+
+// ServerName is the configured backend's server as messages name it.
+func (m ModelManager) ServerName() string {
+	if m.Backend == ModelManagerBackendLemonade {
+		return "Lemonade Server"
+	}
+	return "Ollama"
+}
 
 // ExtraModel is one additional kagent ModelConfig. API keys are NOT config:
 // APIKeyEnv only names the host env var read at deploy time — the value lands
@@ -556,11 +589,11 @@ var httpURLRe = regexp.MustCompile(`^https?://[^/]+`)
 // Validate checks the model-manager block; agents reports whether the kagent
 // runtime is on (model-manager wires ModelConfigs into it).
 func (m ModelManager) Validate(agents bool) error {
-	if m.Backend != "" && m.Backend != ModelManagerBackendOllama {
-		return fmt.Errorf("backend %q: the lab supports %q only (kserve needs GPU nodes and KServe)", m.Backend, ModelManagerBackendOllama)
+	if m.Backend != "" && m.Backend != ModelManagerBackendOllama && m.Backend != ModelManagerBackendLemonade {
+		return fmt.Errorf("backend %q: the lab supports %q or %q (kserve needs GPU nodes and KServe)", m.Backend, ModelManagerBackendOllama, ModelManagerBackendLemonade)
 	}
 	if m.Endpoint != "" && !httpURLRe.MatchString(m.Endpoint) {
-		return fmt.Errorf("endpoint %q: must be an http(s) URL, e.g. http://172.21.0.1:%d", m.Endpoint, OllamaPort)
+		return fmt.Errorf("endpoint %q: must be an http(s) URL, e.g. http://172.21.0.1:%d", m.Endpoint, m.Port())
 	}
 	if m.Enabled && !agents {
 		return fmt.Errorf("requires platform.agents (model-manager wires pulled models into kagent ModelConfigs)")

--- a/internal/config/models_test.go
+++ b/internal/config/models_test.go
@@ -117,7 +117,8 @@ func TestModelManagerValidate(t *testing.T) {
 		{"on with agents", ModelManager{Enabled: true, Backend: ModelManagerBackendOllama}, true, ""},
 		{"on, endpoint override", ModelManager{Enabled: true, Endpoint: "http://192.168.1.10:11434"}, true, ""},
 		{"on without agents", ModelManager{Enabled: true}, false, "requires platform.agents"},
-		{"kserve", ModelManager{Enabled: true, Backend: "kserve"}, true, "supports \"ollama\" only"},
+		{"lemonade", ModelManager{Enabled: true, Backend: ModelManagerBackendLemonade}, true, ""},
+		{"kserve", ModelManager{Enabled: true, Backend: "kserve"}, true, "supports \"ollama\" or \"lemonade\""},
 		{"bad endpoint", ModelManager{Enabled: true, Endpoint: "172.21.0.1:11434"}, true, "http(s) URL"},
 	}
 	for _, tc := range cases {
@@ -151,5 +152,19 @@ func TestModelManagerEnabledNeedsPlatformAndAgents(t *testing.T) {
 	}
 	if cfg.ModelManagerBaseURL() != "https://agentgateway.127.0.0.1.nip.io/model-manager" {
 		t.Fatalf("unexpected model-manager base URL %q", cfg.ModelManagerBaseURL())
+	}
+}
+
+func TestModelManagerBackendServers(t *testing.T) {
+	ollama := ModelManager{Backend: ModelManagerBackendOllama}
+	if ollama.Port() != OllamaPort || ollama.ServerName() != "Ollama" {
+		t.Fatalf("ollama: port %d server %q", ollama.Port(), ollama.ServerName())
+	}
+	if def := (ModelManager{}); def.Port() != OllamaPort {
+		t.Fatalf("an unset backend must default to Ollama's port, got %d", def.Port())
+	}
+	lemonade := ModelManager{Backend: ModelManagerBackendLemonade}
+	if lemonade.Port() != LemonadePort || lemonade.ServerName() != "Lemonade Server" {
+		t.Fatalf("lemonade: port %d server %q", lemonade.Port(), lemonade.ServerName())
 	}
 }

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -66,6 +66,10 @@ func Run(cfg *config.Config, accessible bool) error {
 	agentsEnabled := cfg.Platform.Agents
 	observabilityEnabled := cfg.Platform.Observability
 	modelManagerEnabled := cfg.Platform.ModelManager.Enabled
+	modelManagerBackend := cfg.Platform.ModelManager.Backend
+	if modelManagerBackend == "" {
+		modelManagerBackend = config.ModelManagerBackendOllama
+	}
 	agentsPort := strconv.Itoa(cfg.Platform.AgentsPort)
 	aiModel := cfg.AIModel
 	customizeModels := false
@@ -161,11 +165,19 @@ func Run(cfg *config.Config, accessible bool) error {
 				Negative("Skip").
 				Value(&observabilityEnabled),
 			huh.NewConfirm().
-				Title("Manage this machine's Ollama models from the platform (model-manager)?").
-				Description("Optional, needs the agents runtime: the umbrella's model-manager component with\nthe Ollama backend — pull, load/unload and delete models from the portal or as\nx_model-manager_* tools, each pulled model wired into kagent as a ModelConfig.\nPods reach the host Ollama through the kind docker gateway (bind it to 0.0.0.0).").
+				Title("Manage this machine's local models from the platform (model-manager)?").
+				Description("Optional, needs the agents runtime: the umbrella's model-manager component in\nfront of the host's Ollama or Lemonade Server — pull, load/unload and delete models\nfrom the portal or as x_model-manager_* tools, each pulled model wired into kagent\nas a ModelConfig. Pods reach the host server through the kind docker gateway\n(bind it to 0.0.0.0).").
 				Affirmative("Manage").
 				Negative("Skip").
 				Value(&modelManagerEnabled),
+			huh.NewSelect[string]().
+				Title("Model server on this machine").
+				Description("What model-manager proxies: Ollama (port 11434), or a Lemonade Server\n(lemonade-server.ai — FastFlowLM on AMD Ryzen AI NPUs, llama.cpp; port 13305).").
+				Options(
+					huh.NewOption("Ollama", config.ModelManagerBackendOllama),
+					huh.NewOption("Lemonade Server", config.ModelManagerBackendLemonade),
+				).
+				Value(&modelManagerBackend),
 			huh.NewInput().
 				Title("Claude model").
 				Description("Used by the platform agents' ModelConfig and Backstage's AI chat.\nThe API key comes from $ANTHROPIC_API_KEY at deploy time, never from this file.").
@@ -209,6 +221,7 @@ func Run(cfg *config.Config, accessible bool) error {
 	// Managed models wire into kagent; without the runtime the confirm has
 	// nothing to manage into.
 	cfg.Platform.ModelManager.Enabled = modelManagerEnabled && agentsEnabled
+	cfg.Platform.ModelManager.Backend = modelManagerBackend
 	cfg.Platform.AgentsPort = mustAtoi(agentsPort)
 	cfg.AIModel = aiModel
 	cfg.Backstage.Port = mustAtoi(backstagePort)

--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -20,9 +20,9 @@ func TestRunTUIDrive(t *testing.T) {
 		"\r", // group 2: customize users? -> keep as is
 		"\r", // group 3: platform + backstage preselected; submit as is
 		// platform group: muster port, aps ref, agents confirm, agents ui
-		// port, observability confirm, model-manager confirm, claude model,
-		// extra models confirm
-		"\r", "\r", "\r", "\r", "\r", "\r", "\r", "\r",
+		// port, observability confirm, model-manager confirm, model server
+		// select, claude model, extra models confirm
+		"\r", "\r", "\r", "\r", "\r", "\r", "\r", "\r", "\r",
 		"\r", // backstage group: port
 	)
 	testOutput = io.Discard
@@ -46,6 +46,9 @@ func TestRunTUIDrive(t *testing.T) {
 	}
 	if cfg.Platform.ModelManager.Enabled {
 		t.Errorf("model-manager enabled (the confirm should keep the default off)")
+	}
+	if cfg.Platform.ModelManager.Backend != config.ModelManagerBackendOllama {
+		t.Errorf("model server select did not keep the default backend: %q", cfg.Platform.ModelManager.Backend)
 	}
 	if !cfg.Backstage.Enabled {
 		t.Errorf("backstage not enabled by multiselect")

--- a/internal/lab/modelmanager.go
+++ b/internal/lab/modelmanager.go
@@ -12,14 +12,16 @@ import (
 )
 
 // The model-manager component (platform.modelManager in agentlab.yaml): the
-// umbrella's `model-manager` dependency with the Ollama backend, proxying the
-// Ollama that runs on the lab host. Pods reach the host only through the kind
-// docker network's gateway — the same address the README documents for
-// extraModels — so the endpoint is detected from `docker network inspect
-// kind` rather than asked for. Everything that can go wrong is host-side
-// plumbing (bind address, firewall), which preflightOllama turns into an
-// early, actionable failure instead of a model-manager pod that reports an
-// unhealthy backend after a ten-minute install.
+// umbrella's `model-manager` dependency in front of the model server that runs
+// on the lab host — an Ollama (backend ollama), or a Lemonade Server (backend
+// lemonade: FastFlowLM on AMD Ryzen AI NPUs, llama.cpp on GPU/CPU). Pods reach
+// the host only through the kind docker network's gateway — the same address
+// the README documents for extraModels — so the endpoint is detected from
+// `docker network inspect kind` and the backend's default port rather than
+// asked for. Everything that can go wrong is host-side plumbing (bind address,
+// firewall), which preflightModelServer turns into an early, actionable
+// failure instead of a model-manager pod that reports an unhealthy backend
+// after a ten-minute install.
 
 // modelManagerMCPServer is the MCPServer CR name the model-manager chart
 // registers with muster (model-manager.muster.mcpServer.name, the chart
@@ -29,21 +31,34 @@ const modelManagerMCPServer = "model-manager"
 // kindDockerNetwork is the docker network kind creates its nodes on.
 const kindDockerNetwork = "kind"
 
-// ollamaProbeImage runs the in-cluster reachability probe: busybox wget in
-// the alpine image the umbrella already ships elsewhere (small, present in
-// the host cache after the first run, side-loaded before the probe pod).
-const ollamaProbeImage = "gsoci.azurecr.io/giantswarm/alpine:3.22.1"
+// probeImage runs the in-cluster reachability probe: busybox wget in the
+// alpine image the umbrella already ships elsewhere (small, present in the
+// host cache after the first run, side-loaded before the probe pod).
+const probeImage = "gsoci.azurecr.io/giantswarm/alpine:3.22.1"
 
-// ollamaVersionRe matches the {"version":"..."} document /api/version answers.
-var ollamaVersionRe = regexp.MustCompile(`\{\s*"version"\s*:\s*"[^"]*"\s*\}`)
+// versionFieldRe matches the "version":"..." field both servers answer with —
+// Ollama's whole /api/version document, one field of Lemonade's /api/v1/health.
+var versionFieldRe = regexp.MustCompile(`"version"\s*:\s*"[^"]*"`)
 
 // DetectHostOllama probes the host's own Ollama on loopback and reports its
 // version. It answers the configure-time question "is there an Ollama on
 // this machine at all?" — reachability from pods (bind address, firewall) is
-// preflightOllama's job at platform time.
+// preflightModelServer's job at platform time.
 func DetectHostOllama() (version string, ok bool) {
+	return detectVersion(fmt.Sprintf("http://127.0.0.1:%d/api/version", config.OllamaPort))
+}
+
+// DetectHostLemonade probes the host's own Lemonade Server on loopback
+// (GET /api/v1/health) and reports its version — the configure-time question
+// for the lemonade backend.
+func DetectHostLemonade() (version string, ok bool) {
+	return detectVersion(fmt.Sprintf("http://127.0.0.1:%d/api/v1/health", config.LemonadePort))
+}
+
+// detectVersion fetches a JSON document with a "version" field.
+func detectVersion(url string) (string, bool) {
 	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/version", config.OllamaPort))
+	resp, err := client.Get(url)
 	if err != nil {
 		return "", false
 	}
@@ -77,67 +92,88 @@ func kindGatewayIP() (string, error) {
 	return "", fmt.Errorf("docker network %q has no IPv4 gateway", kindDockerNetwork)
 }
 
-// resolveModelManagerEndpoint is the Ollama endpoint model-manager dials: the
-// configured override, else http://<kind gateway>:11434. The kind network
-// exists once the cluster does, so callers that render before a boot get an
-// error they may tolerate (render) or must not (platform).
+// resolveModelManagerEndpoint is the endpoint model-manager dials: the
+// configured override, else http://<kind gateway>:<the backend's default port>
+// (11434 for Ollama, 13305 for Lemonade). The kind network exists once the
+// cluster does, so callers that render before a boot get an error they may
+// tolerate (render) or must not (platform).
 func resolveModelManagerEndpoint(cfg *config.Config) (string, error) {
 	if ep := cfg.Platform.ModelManager.Endpoint; ep != "" {
 		return strings.TrimSuffix(ep, "/"), nil
 	}
 	gw, err := kindGatewayIP()
 	if err != nil {
-		return "", fmt.Errorf("autodetecting the Ollama endpoint: %w (set platform.modelManager.endpoint to skip the detection)", err)
+		return "", fmt.Errorf("autodetecting the %s endpoint: %w (set platform.modelManager.endpoint to skip the detection)", cfg.Platform.ModelManager.ServerName(), err)
 	}
-	return fmt.Sprintf("http://%s:%d", gw, config.OllamaPort), nil
+	return fmt.Sprintf("http://%s:%d", gw, cfg.Platform.ModelManager.Port()), nil
 }
 
-// preflightOllama proves host Ollama answers from INSIDE the cluster before
-// the platform install waits ten minutes on a model-manager whose backend is
-// unreachable. A short-lived pod fetches <endpoint>/api/version; the two
-// known host-side failures are spelled out with their fixes: the server
-// bound to 127.0.0.1 (connection refused from the bridge) and a host
-// firewall dropping pod->host traffic on the docker bridge (timeout).
-func preflightOllama(cfg *config.Config, endpoint string) error {
+// healthPath is the version-answering path of the configured backend's
+// server: Ollama's /api/version, Lemonade's /api/v1/health.
+func healthPath(cfg *config.Config) string {
+	if cfg.Platform.ModelManager.Backend == config.ModelManagerBackendLemonade {
+		return "/api/v1/health"
+	}
+	return "/api/version"
+}
+
+// bindFix is the host-side fix for a server listening on loopback only.
+func bindFix(cfg *config.Config) string {
+	if cfg.Platform.ModelManager.Backend == config.ModelManagerBackendLemonade {
+		return "  - bind Lemonade to every interface, not loopback: `lemonade config set host=0.0.0.0`\n" +
+			"    (host in ~/.config/lemonade/config.json), then restart lemond"
+	}
+	return "  - bind Ollama to every interface, not loopback: OLLAMA_HOST=0.0.0.0 (systemd: an\n" +
+		"    Environment= drop-in on ollama.service), then restart it"
+}
+
+// preflightModelServer proves the host model server answers from INSIDE the
+// cluster before the platform install waits ten minutes on a model-manager
+// whose backend is unreachable. A short-lived pod fetches the server's
+// version document; the two known host-side failures are spelled out with
+// their fixes: the server bound to 127.0.0.1 (connection refused from the
+// bridge) and a host firewall dropping pod->host traffic on the docker bridge
+// (timeout).
+func preflightModelServer(cfg *config.Config, endpoint string) error {
+	server := cfg.Platform.ModelManager.ServerName()
 	// The probe image goes host cache -> node like every lab image, so the
 	// pod never waits on an in-node pull (best-effort: a miss falls back to
 	// the kubelet's pull under the pod-running timeout).
-	sideloadImages(cfg, hostPullImages([]string{ollamaProbeImage}))
-	const pod = "ollama-preflight"
+	sideloadImages(cfg, hostPullImages([]string{probeImage}))
+	const pod = "model-server-preflight"
 	// A leftover from an interrupted run would make `kubectl run` refuse.
 	_ = runQuiet("kubectl", "-n", platformNamespace, "delete", "pod", pod, "--ignore-not-found", "--wait=false")
 	out, err := outputAll("kubectl", "-n", platformNamespace, "run", pod,
 		"--rm", "-i", "--quiet", "--restart=Never", "--pod-running-timeout=120s",
-		"--image="+ollamaProbeImage, "--image-pull-policy=IfNotPresent",
-		"--command", "--", "wget", "-qO-", "-T", "5", endpoint+"/api/version")
+		"--image="+probeImage, "--image-pull-policy=IfNotPresent",
+		"--command", "--", "wget", "-qO-", "-T", "5", endpoint+healthPath(cfg))
 	if err == nil && strings.Contains(out, `"version"`) {
 		// The combined output also carries kubectl's own attach chatter
 		// ("warning: couldn't attach to pod ..., falling back to logs"), so
-		// pick the JSON document out of it.
+		// pick the version field out of it.
 		version := strings.TrimSpace(out)
-		if m := ollamaVersionRe.FindString(out); m != "" {
+		if m := versionFieldRe.FindString(out); m != "" {
 			version = m
 		}
-		note("host Ollama answers from inside the cluster: %s", version)
+		note("host %s answers from inside the cluster: %s", server, version)
 		return nil
 	}
 	out = strings.TrimSpace(out)
 	reason := "the probe pod could not fetch it"
-	fixes := "  - bind Ollama to every interface, not loopback: OLLAMA_HOST=0.0.0.0 (systemd: an\n" +
-		"    Environment= drop-in on ollama.service), then restart it\n" +
-		"  - allow TCP " + fmt.Sprint(config.OllamaPort) + " from the docker bridge subnets (they fall inside\n" +
+	fixes := bindFix(cfg) + "\n" +
+		"  - allow TCP " + fmt.Sprint(cfg.Platform.ModelManager.Port()) + " from the docker bridge subnets (they fall inside\n" +
 		"    172.16.0.0/12) through the host firewall — pod->host traffic arrives on the\n" +
 		"    bridge like any other inbound connection"
 	switch {
 	case strings.Contains(out, "refused"):
-		reason = "connection refused — Ollama is not listening on the bridge address (the usual\n  cause: OLLAMA_HOST left at 127.0.0.1)"
+		reason = fmt.Sprintf("connection refused — %s is not listening on the bridge address (the usual\n  cause: it is bound to 127.0.0.1)", server)
 	case strings.Contains(out, "timed out"), strings.Contains(out, "timeout"):
-		reason = "connection timed out — the host firewall drops pod->host traffic on the docker\n  bridge (the request never reaches Ollama)"
+		reason = "connection timed out — the host firewall drops pod->host traffic on the docker\n  bridge (the request never reaches the server)"
 	}
-	return fmt.Errorf("host Ollama is not reachable from pods at %s: %s.\n"+
+	return fmt.Errorf("host %s is not reachable from pods at %s: %s.\n"+
 		"  Fixes (README, \"Local backends on the lab host\"):\n%s\n"+
 		"  Then re-run `agentlab platform`, or set platform.modelManager.enabled: false.\n"+
-		"  Probe output: %.300s", endpoint, reason, fixes, out)
+		"  Probe output: %.300s", server, endpoint, reason, fixes, out)
 }
 
 // modelManagerHint is the platform-up summary line for the component.
@@ -145,7 +181,7 @@ func modelManagerHint(cfg *config.Config, endpoint string) string {
 	if !cfg.ModelManagerEnabled() {
 		return "  Model manager is disabled (platform.modelManager in agentlab.yaml)."
 	}
-	return fmt.Sprintf("  Model manager: Ollama backend at %s; REST %s/api/v1 (Dex token required),\n"+
+	return fmt.Sprintf("  Model manager: %s backend (%s) at %s; REST %s/api/v1 (Dex token required),\n"+
 		"  MCP tools x_model-manager_* through muster; the portal's Models tab manages the same models.",
-		endpoint, cfg.ModelManagerBaseURL())
+		cfg.Platform.ModelManager.Backend, cfg.Platform.ModelManager.ServerName(), endpoint, cfg.ModelManagerBaseURL())
 }

--- a/internal/lab/modelmanager_test.go
+++ b/internal/lab/modelmanager_test.go
@@ -2,9 +2,19 @@ package lab
 
 import "testing"
 
-func TestOllamaVersionRe(t *testing.T) {
-	out := "{\"version\":\"0.33.2\"}warning: couldn't attach to pod/ollama-preflight, falling back to streaming logs"
-	if got := ollamaVersionRe.FindString(out); got != `{"version":"0.33.2"}` {
-		t.Fatalf("got %q", got)
+func TestVersionFieldRe(t *testing.T) {
+	cases := map[string]string{
+		// Ollama's /api/version, followed by kubectl's attach chatter.
+		"{\"version\":\"0.33.2\"}warning: couldn't attach to pod/model-server-preflight, falling back to streaming logs": `"version":"0.33.2"`,
+		// Lemonade's /api/v1/health carries the field among many others.
+		`{"all_models_loaded":[],"status":"ok","telemetry":{"enabled":false},"version":"11.9.0","websocket_port":9000}`: `"version":"11.9.0"`,
+	}
+	for in, want := range cases {
+		if got := versionFieldRe.FindString(in); got != want {
+			t.Fatalf("%q: got %q, want %q", in, got, want)
+		}
+	}
+	if got := versionFieldRe.FindString("wget: can't connect to remote host: Connection refused"); got != "" {
+		t.Fatalf("a failed probe matched %q", got)
 	}
 }

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -43,6 +43,11 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	if user == nil {
 		return fmt.Errorf("no user %q in %s", email, config.File)
 	}
+	backendName := cfg.Platform.ModelManager.Backend
+	server := cfg.Platform.ModelManager.ServerName()
+	if backendName == config.ModelManagerBackendLemonade && model == ModelsTestModel {
+		return fmt.Errorf("the lemonade backend needs --model: a small, tool-calling capable Lemonade catalog model whose recipe backend is installed on this host (an *-FLM model on an AMD NPU host; `lemonade list`) — it is pulled, wired, exercised and DELETED")
+	}
 	// Generous: the first agent turn loads the model into Ollama.
 	client, err := labHTTPClient(180 * time.Second)
 	if err != nil {
@@ -84,8 +89,8 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	if err := api.getJSON("/backend", &backend); err != nil {
 		return err
 	}
-	if backend.Backend != config.ModelManagerBackendOllama || !backend.Healthy {
-		return fmt.Errorf("backend %q healthy=%v, wanted a healthy ollama backend (endpoint %s)", backend.Backend, backend.Healthy, backend.Endpoint)
+	if backend.Backend != backendName || !backend.Healthy {
+		return fmt.Errorf("backend %q healthy=%v, wanted a healthy %s backend (endpoint %s)", backend.Backend, backend.Healthy, backendName, backend.Endpoint)
 	}
 	caps := make([]string, 0, len(backend.Capabilities))
 	for name, on := range backend.Capabilities {
@@ -94,7 +99,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 		}
 	}
 	slices.Sort(caps)
-	note("backend ollama %s at %s, healthy; capabilities: %s", backend.Version, backend.Endpoint, strings.Join(caps, ", "))
+	note("backend %s %s at %s, healthy; capabilities: %s", backendName, backend.Version, backend.Endpoint, strings.Join(caps, ", "))
 	note("wiring: ModelConfigs in %s, autoWire=%v", backend.Wiring.Namespace, backend.Wiring.AutoWire)
 
 	step("Listing models")
@@ -169,15 +174,21 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	if err := waitModelConfigAccepted(mcName); err != nil {
 		return err
 	}
+	// ollama wires kagent's native keyless Ollama provider; lemonade the
+	// OpenAI provider against Lemonade's /api/v1 (with a placeholder key).
+	wantProvider, providerNote := config.ProviderOllama, "keyless native provider"
+	if backendName == config.ModelManagerBackendLemonade {
+		wantProvider, providerNote = config.ProviderOpenAI, "OpenAI-compatible /api/v1, placeholder key"
+	}
 	spec, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName,
-		"-o", `jsonpath={.spec.provider} {.spec.model} {.spec.ollama.host} managed-by={.metadata.labels.app\.kubernetes\.io/managed-by}`)
+		"-o", `jsonpath={.spec.provider} {.spec.model} {.spec.ollama.host}{.spec.openAI.baseUrl} managed-by={.metadata.labels.app\.kubernetes\.io/managed-by}`)
 	if err != nil {
 		return err
 	}
-	if !strings.HasPrefix(spec, config.ProviderOllama+" ") {
-		return fmt.Errorf("ModelConfig %s is not the native Ollama provider: %s", mcName, spec)
+	if !strings.HasPrefix(spec, wantProvider+" ") {
+		return fmt.Errorf("ModelConfig %s is not the %s provider the %s backend wires: %s", mcName, wantProvider, backendName, spec)
 	}
-	note("ModelConfig %s: %s (keyless native provider)", mcName, strings.TrimSpace(spec))
+	note("ModelConfig %s: %s (%s)", mcName, strings.TrimSpace(spec), providerNote)
 
 	// The user's identity, not a ServiceAccount: wiring writes a ModelConfig
 	// into the kagent namespace as the caller (downstream OAuth), so a user
@@ -204,7 +215,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 		note("%s: HTTP %d, %s", viewer.Email, status, excerpt(string(body), 120))
 	}
 
-	step("Agent turn on %s (kagent Agent, runtime go -> host Ollama)", mcName)
+	step("Agent turn on %s (kagent Agent, runtime go -> host %s)", mcName, server)
 	reply, err := agentTurn(client, cfg, mcName, "Reply with exactly the word pong and nothing else.")
 	if err != nil {
 		return err
@@ -274,14 +285,14 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	if err != nil {
 		return err
 	}
-	tags, err := ollamaTags(endpoint)
+	tags, err := hostModels(cfg, endpoint)
 	if err != nil {
-		return fmt.Errorf("reading the host Ollama's tags at %s: %w", endpoint, err)
+		return fmt.Errorf("reading the host %s's models at %s: %w", server, endpoint, err)
 	}
 	if slices.Contains(tags, model) {
-		return fmt.Errorf("host Ollama still has %s after the delete", model)
+		return fmt.Errorf("host %s still has %s after the delete", server, model)
 	}
-	note("host Ollama at %s no longer has it (%d models left)", endpoint, len(tags))
+	note("host %s at %s no longer has it (%d models left)", server, endpoint, len(tags))
 	text, err = session.callServerTool(toolPrefix+"list_models", nil)
 	if err != nil {
 		return err
@@ -293,7 +304,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 
 	fmt.Println()
 	fmt.Println("PASS: no token -> 401 at the gateway; Dex token -> model-manager REST through agentgateway")
-	fmt.Printf("PASS: list -> pull %s (progress) -> ModelConfig %s (Ollama provider) Accepted -> agent turn -> unload -> delete\n", model, mcName)
+	fmt.Printf("PASS: list -> pull %s (progress) -> ModelConfig %s (%s provider) Accepted -> agent turn -> unload -> delete\n", model, mcName, wantProvider)
 	fmt.Printf("PASS: muster aggregates x_%s_* and calls them (get_model, list_models)\n", modelManagerMCPServer)
 	fmt.Printf("PASS: the caller's identity — job requestedBy=%s; a viewer's wire is Forbidden by the apiserver (user RBAC, not the ServiceAccount's)\n", user.Email)
 	return nil
@@ -538,8 +549,42 @@ func collectStrings(node any, key string) []string {
 	return out
 }
 
+// hostModels lists the models the host server has, dialed directly from the
+// lab host — the ground truth the delete is checked against: Ollama's
+// /api/tags, or the downloaded models of Lemonade's /api/v1/models.
+func hostModels(cfg *config.Config, endpoint string) ([]string, error) {
+	if cfg.Platform.ModelManager.Backend == config.ModelManagerBackendLemonade {
+		return lemonadeModels(endpoint)
+	}
+	return ollamaTags(endpoint)
+}
+
+// lemonadeModels lists the downloaded models of the host Lemonade Server
+// (GET /api/v1/models, an OpenAI model list with Lemonade's extensions).
+func lemonadeModels(endpoint string) ([]string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(endpoint + "/api/v1/models")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var list struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := decodeJSONBody(resp, &list); err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(list.Data))
+	for _, m := range list.Data {
+		names = append(names, m.ID)
+	}
+	return names, nil
+}
+
 // ollamaTags lists the models the host Ollama has (its /api/tags), dialed
-// directly from the lab host — the ground truth the delete is checked against.
+// directly from the lab host.
 func ollamaTags(endpoint string) ([]string, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(endpoint + "/api/tags")

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -276,8 +276,9 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		}
 	}
 
-	// Managed models: the Ollama endpoint is detected from the kind docker
-	// network and proven reachable from inside the cluster BEFORE the
+	// Managed models: the host model server's endpoint (Ollama, or a Lemonade
+	// Server) is detected from the kind docker network and proven reachable
+	// from inside the cluster BEFORE the
 	// install, so a host-side misconfiguration (bind address, firewall) fails
 	// here with its fix instead of after helm's ten-minute wait.
 	modelManagerEndpoint := ""
@@ -287,8 +288,8 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 			return err
 		}
 		modelManagerEndpoint = endpoint
-		step("Checking host Ollama is reachable from pods (%s)", endpoint)
-		if err := preflightOllama(cfg, endpoint); err != nil {
+		step("Checking the host %s is reachable from pods (%s)", cfg.Platform.ModelManager.ServerName(), endpoint)
+		if err := preflightModelServer(cfg, endpoint); err != nil {
 			return err
 		}
 	}

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -48,11 +48,13 @@ type tmplData struct {
 	AllGroups           []string
 	KubernetesClientSecret,
 	AgentPlatformClientSecret string
-	// ModelManagerEnabled mirrors cfg.ModelManagerEnabled(); the endpoint is
-	// the Ollama URL model-manager dials (autodetected from the kind docker
+	// ModelManagerEnabled mirrors cfg.ModelManagerEnabled(); the backend is
+	// the host server model-manager proxies (ollama, lemonade) and the endpoint
+	// the URL it dials (autodetected from the kind docker
 	// network — empty when the cluster does not exist yet, which only a
 	// pre-boot `agentlab render` sees; platformUp resolves it strictly).
 	ModelManagerEnabled  bool
+	ModelManagerBackend  string
 	ModelManagerEndpoint string
 	// The per-server OAuth sign-in fixture (oauthfixture.go): the MCPServer
 	// name the proofs sign in to and the protected endpoint it points at.
@@ -75,6 +77,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 	return &tmplData{
 		Config:                    cfg,
 		ModelManagerEnabled:       cfg.ModelManagerEnabled(),
+		ModelManagerBackend:       cfg.Platform.ModelManager.Backend,
 		ModelManagerEndpoint:      endpoint,
 		OAuthFixtureServer:        oauthFixtureServer,
 		OAuthFixtureURL:           oauthFixtureURL,

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -108,7 +108,8 @@ components:
 {{- end }}
 {{- if .ModelManagerEnabled }}
   # Managed models (platform.modelManager): the umbrella's model-manager
-  # dependency with the Ollama backend (its own values are in the
+  # dependency with the configured backend — the host's Ollama, or a Lemonade
+  # Server (its own values are in the
   # `model-manager:` block below). The route exposes its REST API on the
   # edge at https://agentgateway.{{ .Platform.Domain }}/model-manager — the
   # chart's Backstage app-config points the portal backend there
@@ -318,7 +319,8 @@ agent-manager:
 {{- if .ModelManagerEnabled }}
 # The model-manager chart's own values (the umbrella pins the Service name,
 # the kagent namespace, the muster registration and — since the identity
-# change — OAuth against global.identity in its contract). The Ollama backend
+# change — OAuth against global.identity in its contract). The backend (the
+# host's Ollama, or a Lemonade Server — FastFlowLM on AMD Ryzen AI NPUs)
 # dials the host through the kind docker network's gateway — autodetected by
 # `agentlab platform` (platform.modelManager.endpoint overrides). Agent pods
 # dial the same address, so agentHost stays empty. Same audience story as
@@ -326,9 +328,14 @@ agent-manager:
 # audience for model-manager's downstream OAuth (the ModelConfigs it writes
 # as the caller) to pass the kind apiserver.
 model-manager:
-  backend: ollama
+  backend: {{ .ModelManagerBackend }}
+{{- if eq .ModelManagerBackend "lemonade" }}
+  lemonade:
+    endpoint: {{ .ModelManagerEndpoint | printf "%q" }}
+{{- else }}
   ollama:
     endpoint: {{ .ModelManagerEndpoint | printf "%q" }}
+{{- end }}
   muster:
     mcpServer:
       auth:

--- a/main.go
+++ b/main.go
@@ -146,17 +146,26 @@ func reportPortChanges(changes []config.PortChange) {
 }
 
 // detectModelManager turns managed models on for a FRESH configuration when
-// an Ollama answers on this machine: the lab then installs the umbrella's
-// model-manager component with the Ollama backend. Reachability from pods
-// (bind address, firewall) is checked at platform time, with the fixes.
+// an Ollama — else a Lemonade Server — answers on this machine: the lab then
+// installs the umbrella's model-manager component with that backend.
+// Reachability from pods (bind address, firewall) is checked at platform
+// time, with the fixes.
 func detectModelManager(cfg *config.Config) {
-	version, ok := lab.DetectHostOllama()
-	if !ok {
-		return
+	switch version, ok := lab.DetectHostOllama(); {
+	case ok:
+		cfg.Platform.ModelManager.Enabled = true
+		cfg.Platform.ModelManager.Backend = config.ModelManagerBackendOllama
+		fmt.Printf("Found Ollama %s on this machine: managed models (model-manager, ollama backend) enabled.\n", version)
+	default:
+		version, ok := lab.DetectHostLemonade()
+		if !ok {
+			return
+		}
+		cfg.Platform.ModelManager.Enabled = true
+		cfg.Platform.ModelManager.Backend = config.ModelManagerBackendLemonade
+		fmt.Printf("Found Lemonade Server %s on this machine: managed models (model-manager, lemonade backend) enabled.\n", version)
 	}
-	cfg.Platform.ModelManager.Enabled = true
-	fmt.Printf("Found Ollama %s on this machine: managed models (model-manager, Ollama backend) enabled.\n", version)
-	fmt.Printf("Turn it off with `agentlab configure --defaults --model-manager=false`.\n\n")
+	fmt.Printf("Turn it off with `agentlab configure --defaults --model-manager=false`; `--model-manager-backend ollama|lemonade` picks the server.\n\n")
 }
 
 // accessibleMode switches huh to its prompt-per-question accessible mode;
@@ -168,6 +177,7 @@ func accessibleMode() bool {
 func configureCmd() *cobra.Command {
 	var defaults, accessible bool
 	var platform, agents, observability, backstage, modelManager bool
+	var modelManagerBackend string
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Ask for the lab configuration interactively and save agentlab.yaml",
@@ -198,6 +208,9 @@ func configureCmd() *cobra.Command {
 				}
 				if cmd.Flags().Changed("model-manager") {
 					cfg.Platform.ModelManager.Enabled = modelManager
+				}
+				if cmd.Flags().Changed("model-manager-backend") {
+					cfg.Platform.ModelManager.Backend = modelManagerBackend
 				}
 				if cmd.Flags().Changed("backstage") {
 					cfg.Backstage.Enabled = backstage
@@ -239,7 +252,8 @@ func configureCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&agents, "agents", false, "with --defaults: enable/disable the agents runtime (kagent, part of the platform install)")
 	cmd.Flags().BoolVar(&observability, "observability", false, "with --defaults: enable/disable the observability stack (Prometheus + mcp-prometheus)")
 	cmd.Flags().BoolVar(&backstage, "backstage", false, "with --defaults: enable/disable Backstage (implies the platform)")
-	cmd.Flags().BoolVar(&modelManager, "model-manager", false, "with --defaults: enable/disable managed models (the model-manager component with the host Ollama; needs agents)")
+	cmd.Flags().BoolVar(&modelManager, "model-manager", false, "with --defaults: enable/disable managed models (the model-manager component in front of the host's Ollama or Lemonade Server; needs agents)")
+	cmd.Flags().StringVar(&modelManagerBackend, "model-manager-backend", "", "with --defaults: the host model server model-manager proxies, ollama (port 11434) or lemonade (a Lemonade Server, port 13305)")
 	cmd.Flags().BoolVar(&accessible, "accessible", false, "prompt-per-question form mode (for screen readers and plain terminals)")
 	return cmd
 }
@@ -329,7 +343,7 @@ func modelsTestCmd() *cobra.Command {
 			return lab.ModelsTest(cfg, email, model)
 		},
 	}
-	cmd.Flags().StringVar(&model, "model", lab.ModelsTestModel, "the Ollama model to pull and delete (small and tool-calling capable)")
+	cmd.Flags().StringVar(&model, "model", lab.ModelsTestModel, "the model to pull and delete: an Ollama tag on the ollama backend, or a Lemonade catalog name whose recipe backend is installed on the host on the lemonade backend (small and tool-calling capable; `lemonade list`)")
 	return cmd
 }
 


### PR DESCRIPTION
Closes #60.

## What

`platform.modelManager.backend: lemonade` — the umbrella's model-manager in front of a [Lemonade Server](https://lemonade-server.ai) on the lab host (FastFlowLM on AMD Ryzen AI NPUs, llama.cpp on GPU/CPU), the way `ollama` fronts the host Ollama. model-manager 0.16.0 ships the backend ([giantswarm/model-manager#43](https://github.com/giantswarm/model-manager/issues/43)); the umbrella accepts it once its curate regeneration carries [agent-platform#261](https://github.com/giantswarm/agent-platform/pull/261) ([agent-platform-standalone#131](https://github.com/giantswarm/agent-platform-standalone/issues/131)).

- **Config:** `backend` accepts `ollama` (default) and `lemonade`; the endpoint autodetects `http://<kind docker network gateway>:<port>` with the backend's default port (11434 / 13305); `ModelManager.Port()` / `ServerName()`.
- **Preflight per backend:** the probe pod fetches `/api/version` (Ollama) or `/api/v1/health` (Lemonade) — both answer a JSON document with `version` — and the two diagnoses name the server's fixes (`OLLAMA_HOST=0.0.0.0` / `lemonade config set host=0.0.0.0`; allow the server's port from the bridge subnets). `preflightOllama` → `preflightModelServer`, pod `model-server-preflight`.
- **Render:** the umbrella values carry `model-manager.backend` and, for lemonade, `model-manager.lemonade.endpoint` (the ollama shape is unchanged).
- **configure:** `--defaults` detects an Ollama, else a Lemonade Server, and sets the backend; `--model-manager-backend ollama|lemonade` forces it; the interactive form gains a "Model server on this machine" select (the scripted form test drives it).
- **models-test:** backend-aware — the model-manager API is the same; the ModelConfig check expects the `Ollama` provider on ollama and the `OpenAI` provider (`…/api/v1`, placeholder key) on lemonade; the post-delete check reads Lemonade's `/api/v1/models` instead of Ollama's `/api/tags`; on lemonade `--model` is required (a small tool-calling catalog model whose recipe backend is installed on the host — an `*-FLM` model on an NPU host — it is pulled, exercised and deleted).
- README: the managed-models section covers both servers.

## Verification

- `go test ./...` (config validation incl. the new backend, the scripted TUI form with the new select, the preflight regex on both servers' documents).
- **Pending — lab proof with the umbrella that accepts `backend: lemonade`:** this PR stays a draft until `agent-platform-standalone` carries agent-platform 3.6.0 and model-manager 0.16.0; then `apsRef` moves to that commit and `agentlab platform` + `agentlab models-test --model <FLM model>` run against the lab host's Lemonade Server (AMD Ryzen AI 9 HX PRO 370, XDNA2). Until then the lemonade shape fails the umbrella's render guard, exactly as before this PR.
