### PR TITLE
feat(configure): discover the host on every run — tools, ports, Ollama and Lemonade Server; platform.modelManager.backends lists the host servers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,16 +73,32 @@ with Dex doing the logins.
   OpenAI-compatible endpoints, OpenRouter, Gemini, Ollama) with the same
   env-var -> Secret key handling; entries removed from the config are pruned
   on the next run (see README "Extra model configs").
-- `platform.modelManager` (on by default when `agentlab configure` finds an
-  Ollama on the host) installs the umbrella's model-manager component with
-  the Ollama backend: the host Ollama's models become manageable from the
-  portal and as `x_model-manager_<tool>` through muster, every pulled model
-  auto-wired into kagent (native keyless `Ollama` provider). The endpoint is
-  autodetected (`docker network inspect kind` gateway, port 11434) and
+- `agentlab configure` **discovers this machine on every run** (fresh or
+  existing `agentlab.yaml`): the tools `up` shells out to, whether this
+  configuration's kind node exists and which host ports it publishes (never
+  conflicts; while no node exists, occupied ports move to free ones), the
+  host model servers — an Ollama on 11434, a Lemonade Server on 13305 —
+  with their downloaded tool-calling models, a standalone `flm serve`
+  (report-only), and `$ANTHROPIC_API_KEY`. What answers becomes
+  `platform.modelManager.backends` (Ollama first); `--model-manager[=false]`
+  and `--model-manager-backends` pin it. Never hand-edit that list to
+  describe the machine — re-run `configure --defaults`.
+- `platform.modelManager` installs the umbrella's model-manager component
+  with the FIRST backend of the list (model-manager fronts one backend per
+  instance today): that server's models become manageable from the portal
+  and as `x_model-manager_<tool>` through muster, every pulled model
+  auto-wired into kagent (native keyless `Ollama` provider; `OpenAI` on
+  `/api/v1` for Lemonade). Every FURTHER backend is wired statically by
+  `agentlab platform`: its downloaded tool-calling models become
+  lab-labeled ModelConfigs `<backend>-<model>` (hostmodels.go), refreshed and
+  pruned on every run — the interim until model-manager is multi-backend
+  (agentlab#60, HACKS.md U14). Endpoints are autodetected (`docker network
+  inspect kind` gateway + the server's default port) and every server is
   proven reachable from a pod before the install; the API sits behind the
   agentgateway route `https://agentgateway.<domain>/model-manager` with JWT
   validation on (a Dex token is required; 401 without). Proof:
-  `./agentlab models-test` (see README "Managed models").
+  `./agentlab models-test` (see README "Managed models"), which ends with an
+  agent turn on a statically wired model when a further backend is listed.
 - For verifying RBAC as a specific user, use `./agentlab login <email>` and
   `kubectl --kubeconfig kubeconfig.oidc` — that is the OIDC path.
 - The kind admin context (`kind-agentlab`) bypasses the platform and OIDC

--- a/HACKS.md
+++ b/HACKS.md
@@ -333,6 +333,26 @@ holds. mcp-prometheus gets it because `installOCIChart` now runs that release
 through the post-renderer too. Lab-only by construction: real installations have
 a routable issuer.
 
+### U14. `hostmodels.go`: the further host backends are wired as static ModelConfigs
+`platform.modelManager.backends` lists every model server on the lab host
+(`agentlab configure` fills it from what answers: an Ollama, a Lemonade
+Server), but model-manager 0.16.0 fronts ONE backend per instance
+(`backend: ollama|kserve|lemonade`). Timo's direction (agentlab#60,
+2026-09-04) is one multi-backend model-manager, not one release per backend
+(the draft that did that, #61, is closed). Until it lands, the lab installs
+model-manager with the first backend and, for every further one, renders its
+downloaded tool-calling models as lab-labeled ModelConfigs in exactly the
+shape model-manager writes for that backend (`lemonade-<model>`: `OpenAI` on
+`<endpoint>/api/v1`, placeholder key; `ollama-<model>`: the native keyless
+provider), refreshed and pruned on every `agentlab platform` run and proven
+by the agent turn `models-test` ends with. Nothing manages those models
+(pull/delete stay CLI-on-host) and the portal's Models pages show the first
+backend only.
+**Unblocks:** giantswarm/model-manager multi-backend (one instance talking to
+ollama, lemonade and kserve at once) + the umbrella values for it; then
+`platform.go` hands the whole list to `model-manager.backends` and
+`hostmodels.go`'s static wiring is deleted — the `agentlab.yaml` shape stays.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/README.md
+++ b/README.md
@@ -75,13 +75,56 @@ agentgateway edge, Backstage on, three users, Dex on 32000.
 `--backstage=false` skips the portal. On a plain terminal or screen reader,
 `agentlab configure --accessible` runs the form as one prompt per question.
 
-When a **new** configuration is created (interactively or via `--defaults`),
-every host-side port is probed on 127.0.0.1 first — the address all kind port
-mappings bind — and any default that is already occupied is moved to a nearby
-free port, with a message saying what moved where (443 falls back to 8443).
-An existing `agentlab.yaml` is never renumbered: its cluster's port mappings
-are already fixed, and while the lab runs its own ports would probe as
-occupied.
+### `configure` discovers this machine — on every run
+
+Before it asks anything (or, with `--defaults`, writes anything), `agentlab
+configure` probes the machine and prints what it found, then applies it to the
+configuration — a fresh one and an existing `agentlab.yaml` alike, so the file
+follows the host instead of freezing the first run's view of it:
+
+```
+Discovering this machine:
+  tools             docker 29.7.2, kind v0.32.0, kubectl v1.36.4, helm v4.2.2
+  cluster           kind "agentlab" exists — its port mappings are fixed at node creation (`agentlab down && agentlab up` to change them)
+  Ollama            0.33.2 on :11434 — listens on the kind gateway 172.21.0.1: yes; 10 downloaded, 4 tool-calling
+  Lemonade Server   11.9.0 on :13305 — listens on the kind gateway 172.21.0.1: yes; 4 downloaded, 3 tool-calling
+  Anthropic key     $ANTHROPIC_API_KEY is set — the agents' default ModelConfig and Backstage's AI chat get the real key at deploy time
+
+Applied to the configuration:
+  platform.modelManager.backends: [ollama] -> [ollama, lemonade]
+```
+
+- **Tools**: `docker`, `kind`, `kubectl`, `helm` are looked up and their
+  versions shown; a missing one (or a Helm 3) is called out here rather than
+  minutes into `agentlab up`.
+- **Ports**: every host-side port is probed on 127.0.0.1 — the address all
+  kind port mappings bind. While **no kind node of this configuration
+  exists** (a fresh lab, or after `agentlab down`), an occupied port is moved
+  to a nearby free one, with a message saying what moved where (443 falls
+  back to 8443). Once the cluster exists its mappings are fixed at node
+  creation, so the ports it publishes never count as occupied and a foreign
+  listener on one of them is **reported**, not renumbered around (free it, or
+  `agentlab down`, re-run `configure`, `agentlab up`).
+- **Host model servers**: an Ollama on `:11434` and a Lemonade Server on
+  `:13305` (their default ports) are detected with version, whether they
+  listen on the kind docker gateway (pods' path to the host — the bind-address
+  fix is named when they do not) and their downloaded models, counting the
+  tool-calling ones. What answers becomes `platform.modelManager.backends`
+  (Ollama first) and turns managed models on; a server that vanished drops
+  out and, with none left, managed models go off — see [Managed
+  models](#managed-models-model-manager--the-host-model-servers). A
+  standalone `flm serve` (FastFlowLM's own server, default `:52625`) is
+  reported but not wired: it has no management API and lists its catalog
+  rather than what is downloaded — the lab drives FLM through Lemonade.
+- **`$ANTHROPIC_API_KEY`**: whether it is exported, since the agents'
+  default ModelConfig and Backstage's AI chat take it at deploy time.
+
+Pins override the discovery for that run: `--model-manager[=false]` decides
+the flag regardless of what answers, `--model-manager-backends ollama,lemonade`
+sets the list (and its order) outright; `--platform`, `--agents`,
+`--observability` and `--backstage` toggle the components as before, with or
+without `--defaults`. Nothing else in an existing file is touched — users,
+extra models and the pinned chart ref stay as they are.
 
 To exercise the identity itself:
 
@@ -463,52 +506,72 @@ One Lemonade-specific note: its FastFlowLM models default to a 4096-token
 context, which agent system prompts plus tool schemas outgrow quickly —
 raise it once with `lemonade config set ctx_size=16384`.
 
-#### Managed models: model-manager + host Ollama
+#### Managed models: model-manager + the host model servers
 
 `extraModels` wires an endpoint and manages nothing: pulling or removing a
 model is CLI-on-host, and nothing shows what is downloaded or loaded. The
 managed mode puts the umbrella's **model-manager** component
 ([giantswarm/model-manager](https://github.com/giantswarm/model-manager),
-the service behind the Model Manager epic) in front of the host's Ollama —
-inventory of downloaded and loaded models, pull with progress, load/unload,
-delete, and every pulled model wired into kagent automatically as a
-`ModelConfig` with the native, keyless `Ollama` provider. One block:
+the service behind the Model Manager epic) in front of a model server on the
+host — inventory of downloaded and loaded models, pull with progress,
+load/unload, delete, and every pulled model wired into kagent automatically
+as a `ModelConfig`: the native, keyless `Ollama` provider for an Ollama, the
+`OpenAI` provider on `/api/v1` (placeholder key) for a Lemonade Server. One
+block, which `agentlab configure` writes from what answers on the machine:
 
 ```yaml
 platform:
   agents: true                 # required: the ModelConfigs land in kagent
   modelManager:
     enabled: true
-    backend: ollama            # the lab's only backend (kserve needs GPUs + KServe)
-    # endpoint: http://192.168.1.10:11434   # optional; empty autodetects the host
+    backends: [ollama, lemonade]   # the host model servers, Ollama first; kserve needs GPUs + KServe
+    # endpoints:                   # optional; empty autodetects the host
+    #   ollama: http://192.168.1.10:11434
 ```
 
-`agentlab configure` turns it on for a fresh config when an Ollama answers on
-this machine (`--defaults --model-manager[=false]` forces it either way; the
-interactive form asks). The endpoint is **autodetected at platform time** as
-`http://<kind docker network gateway>:11434` — `docker network inspect kind`,
-the same address the section above documents for `extraModels` — so nobody
-types `172.21.0.1`; set `endpoint` for an Ollama elsewhere on the LAN.
+The list has an order because **model-manager fronts one backend per instance
+today**: the first entry is model-manager's backend, and every further one is
+wired **statically** by `agentlab platform` — its downloaded tool-calling
+models become lab-labeled ModelConfigs named `<backend>-<model>` (e.g.
+`lemonade-qwen3-it-4b-flm`), in exactly the shape model-manager would write,
+refreshed on every run and pruned when the model is gone from the server or
+the backend from the list. That is the interim until model-manager talks to
+all of them at once (multi-backend, agentlab#60); the config shape stays.
+A model already wired by hand in `extraModels` (same model on the same
+host:port) is left to that entry. The one-backend form earlier versions wrote
+(`backend:` + `endpoint:`) still reads as the one-item list.
+
+`agentlab configure` detects an Ollama on `:11434` and a Lemonade Server on
+`:13305` on every run (`--model-manager[=false]` pins the flag,
+`--model-manager-backends` the list; the interactive form shows what was
+found). Each endpoint is **autodetected at platform time** as `http://<kind
+docker network gateway>:<default port>` — `docker network inspect kind`, the
+same address the section above documents for `extraModels` — so nobody types
+`172.21.0.1`; set `endpoints.<backend>` for a server elsewhere on the LAN
+(such a backend is kept whether or not one answers locally).
 
 What `agentlab platform` (or `up`) does with it:
 
 - **Preflight, not README traps.** Before the install, a short-lived pod in
-  the cluster fetches `<endpoint>/api/version`. If that fails, the boot stops
-  right there with the diagnosis and the two fixes from the section above
-  spelled out — *connection refused* means Ollama listens on `127.0.0.1`
-  only (`OLLAMA_HOST=0.0.0.0`), a *timeout* means the host firewall drops
-  pod→host traffic on the docker bridge (allow TCP 11434 from the bridge
-  subnets, inside `172.16.0.0/12`) — instead of a model-manager pod
-  reporting an unhealthy backend after Helm's ten-minute wait.
-- **The umbrella's `components.model-manager`** goes on with the Ollama
-  backend (`model-manager.ollama.endpoint` = the detected address), its
-  agentgateway **route** at `https://agentgateway.<domain>/model-manager`
-  and, unlike the lab's kagent route, **JWT validation on**: the gateway
-  verifies the caller's Dex token against the lab Dex (JWKS over TLS at
-  `dex.dex.svc.cluster.local:5556/dex/keys`, trusted through the lab CA)
-  and answers 401 without one. model-manager checks no identity itself —
-  the gateway is the boundary, the same trust model as the kagent
-  controller route on real installations.
+  the cluster fetches each server's version document (`/api/version` on
+  Ollama, `/api/v1/health` on Lemonade). If that fails, the boot stops right
+  there with the diagnosis and the two fixes from the section above spelled
+  out — *connection refused* means the server listens on `127.0.0.1` only
+  (`OLLAMA_HOST=0.0.0.0` / `lemonade config set host=0.0.0.0`), a *timeout*
+  means the host firewall drops pod→host traffic on the docker bridge (allow
+  the server's TCP port from the bridge subnets, inside `172.16.0.0/12`) —
+  instead of a model-manager pod reporting an unhealthy backend after Helm's
+  ten-minute wait, or ModelConfigs pointing at a dead endpoint.
+- **The umbrella's `components.model-manager`** goes on with the first
+  backend (`model-manager.backend` and `model-manager.<backend>.endpoint` =
+  the detected address), its agentgateway **route** at
+  `https://agentgateway.<domain>/model-manager` and, unlike the lab's kagent
+  route, **JWT validation on**: the gateway verifies the caller's Dex token
+  against the lab Dex (JWKS over TLS at
+  `dex.dex.svc.cluster.local:5556/dex/keys`, trusted through the lab CA) and
+  answers 401 without one. model-manager checks no identity itself — the
+  gateway is the boundary, the same trust model as the kagent controller
+  route on real installations.
 - **The portal's service side.** The chart's Backstage app-config gains
   `agentPlatform.modelManager.installations.agent-platform.apiBaseUrl:
   https://agentgateway.<domain>/model-manager`; the portal backend forwards
@@ -524,8 +587,11 @@ What `agentlab platform` (or `up`) does with it:
 The proof is `agentlab models-test` (`--model` picks another small,
 **tool-calling capable** model; the default `qwen2.5:0.5b` is ~400 MB —
 `smollm2:135m` pulls fine and then fails every agent turn with "does not
-support tools"). It goes through the platform path only and leaves nothing
-behind:
+support tools"; on a lemonade-first lab name a Lemonade catalog model whose
+recipe backend is installed on the host). It goes through the platform path
+only and leaves nothing behind, and with a further backend in the list it
+ends with an agent turn on one of that server's statically wired
+ModelConfigs — "discovered" means "usable by agents":
 
 ```
 agentlab models-test
@@ -546,9 +612,10 @@ evict; they do not change how long agent traffic keeps a model resident —
 that is `OLLAMA_KEEP_ALIVE` on the host, see the keep-alive note in the
 section above.
 
-Both modes coexist: the static `extraModels` entries stay as they are
-(labeled `managed-by: agentlab`), model-manager's ModelConfigs carry
-`managed-by: model-manager`, and neither prunes the other's.
+Both modes coexist: the static `extraModels` entries and the wired
+further-backend models stay as they are (labeled `managed-by: agentlab`),
+model-manager's ModelConfigs carry `managed-by: model-manager`, and neither
+prunes the other's.
 
 ### Observability (Prometheus + mcp-prometheus)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
 	"slices"
@@ -142,39 +143,178 @@ type Platform struct {
 	// CRs by `agentlab platform`; entries removed here are pruned on the next
 	// run. Inert unless agents are enabled.
 	ExtraModels []ExtraModel `yaml:"extraModels,omitempty"`
-	// Managed models: the umbrella's model-manager component with the Ollama
-	// backend, proxying the Ollama that runs on the lab host — pull, load,
+	// Managed models: the umbrella's model-manager component in front of the
+	// model servers that run on the lab host — an Ollama, a Lemonade Server
+	// (FastFlowLM on AMD Ryzen AI NPUs, llama.cpp on GPU/CPU) — pull, load,
 	// unload and delete models from the portal (or as x_model-manager_*
 	// tools through muster), each pulled model wired into kagent as a
 	// keyless ModelConfig automatically. Complements extraModels, which
 	// wires endpoints statically and manages nothing. Requires agents.
+	// `agentlab configure` fills the backends from what answers on this
+	// machine, on every run.
 	ModelManager ModelManager `yaml:"modelManager"`
 }
 
 // ModelManager configures the umbrella's model-manager component in the lab.
 type ModelManager struct {
 	// On, `agentlab platform` enables components.model-manager with the
-	// Ollama backend, its agentgateway route (JWT-validated: the portal
+	// first backend, its agentgateway route (JWT-validated: the portal
 	// backend forwards the user's Dex token) and the muster registration.
-	// `agentlab configure` turns it on for a fresh config when an Ollama
-	// answers on the host.
+	// `agentlab configure` turns it on whenever a host model server answers
+	// (and off when none does), unless --model-manager pins it.
 	Enabled bool `yaml:"enabled"`
-	// The serving backend. The lab supports `ollama` only: kserve needs
-	// GPU nodes and a KServe install this kind cluster does not have.
-	Backend string `yaml:"backend,omitempty"`
-	// The Ollama API base URL as pods reach it. Empty autodetects
-	// http://<kind docker network gateway>:11434 at platform time — the
-	// same address the README documents for extraModels (`docker network
-	// inspect kind`). Set it for an Ollama elsewhere on the LAN.
+	// The host model servers, in order: `ollama` (an Ollama) and `lemonade`
+	// (a Lemonade Server). model-manager manages ONE backend per instance
+	// today, so the first entry is its backend; every further one is wired
+	// statically by `agentlab platform` — its downloaded tool-calling models
+	// become lab-labeled ModelConfigs, refreshed on every run — until
+	// model-manager talks to all of them at once (giantswarm/model-manager
+	// multi-backend, agentlab#60). `agentlab configure` fills the list from
+	// what answers on this machine (Ollama first); --model-manager-backends
+	// pins it. kserve is no lab backend: GPU nodes and a KServe install.
+	Backends []string `yaml:"backends,omitempty"`
+	// Per-backend base URL as pods reach it, keyed by backend. Empty
+	// autodetects http://<kind docker network gateway>:<default port> at
+	// platform time (11434 for Ollama, 13305 for Lemonade) — the same
+	// address the README documents for extraModels (`docker network inspect
+	// kind`). Set one for a server elsewhere on the LAN: a backend with an
+	// endpoint here is kept by `agentlab configure` whether or not a server
+	// answers on this machine.
+	Endpoints map[string]string `yaml:"endpoints,omitempty"`
+	// The one-backend form earlier versions wrote (backend + endpoint):
+	// still read, folded into backends/endpoints on load, never written.
+	Backend  string `yaml:"backend,omitempty"`
 	Endpoint string `yaml:"endpoint,omitempty"`
 }
 
-// ModelManagerBackendOllama is the one backend the lab runs.
-const ModelManagerBackendOllama = "ollama"
+// The model servers the lab runs against on the host, which model-manager
+// and agent pods reach through the kind docker network's gateway.
+const (
+	// ModelManagerBackendOllama is a host Ollama.
+	ModelManagerBackendOllama = "ollama"
+	// ModelManagerBackendLemonade is a host Lemonade Server
+	// (lemonade-server.ai): FastFlowLM on AMD Ryzen AI NPUs, llama.cpp on
+	// GPU and CPU, behind one OpenAI-compatible API plus a management API.
+	ModelManagerBackendLemonade = "lemonade"
+)
 
-// OllamaPort is Ollama's default API port, the one the autodetected endpoint
-// assumes on the host.
-const OllamaPort = 11434
+// ModelManagerBackends lists the backends the lab accepts, in the canonical
+// order `agentlab configure` writes them — which is also the preference for
+// the one model-manager fronts.
+var ModelManagerBackends = []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}
+
+// The servers' default API ports, the ones the autodetected endpoints assume.
+const (
+	OllamaPort   = 11434
+	LemonadePort = 13305
+)
+
+// BackendPort is the default API port of a backend's server.
+func BackendPort(backend string) int {
+	if backend == ModelManagerBackendLemonade {
+		return LemonadePort
+	}
+	return OllamaPort
+}
+
+// BackendServerName is a backend's server as messages name it.
+func BackendServerName(backend string) string {
+	if backend == ModelManagerBackendLemonade {
+		return "Lemonade Server"
+	}
+	return "Ollama"
+}
+
+// Primary is the backend model-manager fronts: the first, or the historical
+// default (an Ollama) for an enabled block that names none.
+func (m ModelManager) Primary() string {
+	if len(m.Backends) == 0 {
+		return ModelManagerBackendOllama
+	}
+	return m.Backends[0]
+}
+
+// Secondary lists the further backends — wired statically until
+// model-manager is multi-backend.
+func (m ModelManager) Secondary() []string {
+	if len(m.Backends) < 2 {
+		return nil
+	}
+	return m.Backends[1:]
+}
+
+// EndpointFor is the configured endpoint override of a backend, "" to
+// autodetect.
+func (m ModelManager) EndpointFor(backend string) string {
+	return m.Endpoints[backend]
+}
+
+// normalize folds the legacy one-backend form into the lists, orders the
+// backends canonically and gives an enabled block without backends the
+// historical default (an Ollama), so files written by earlier versions read
+// exactly as before.
+func (m *ModelManager) normalize() {
+	if m.Backend != "" {
+		if !slices.Contains(m.Backends, m.Backend) {
+			m.Backends = append([]string{m.Backend}, m.Backends...)
+		}
+		if m.Endpoint != "" {
+			if m.Endpoints == nil {
+				m.Endpoints = map[string]string{}
+			}
+			if _, set := m.Endpoints[m.Backend]; !set {
+				m.Endpoints[m.Backend] = m.Endpoint
+			}
+		}
+	}
+	m.Backend, m.Endpoint = "", ""
+	if m.Enabled && len(m.Backends) == 0 {
+		m.Backends = []string{ModelManagerBackendOllama}
+	}
+	if len(m.Endpoints) == 0 {
+		m.Endpoints = nil
+	}
+}
+
+// ApplyDiscovered merges what `agentlab configure` found on this machine into
+// the block: the backends are the servers that answer plus every backend kept
+// by an explicit endpoint (a server elsewhere on the LAN), in canonical order;
+// managed models go on when there is at least one and the agents runtime is
+// on, and off otherwise. pinBackends (--model-manager-backends) replaces the
+// list outright; pinEnabled (--model-manager) decides the flag instead of the
+// discovery — a pinned-on block without a backend falls back to the Ollama
+// default, so the platform preflight reports the real reachability error.
+func (m *ModelManager) ApplyDiscovered(found []string, agents bool, pinEnabled *bool, pinBackends []string) {
+	m.normalize()
+	var backends []string
+	switch {
+	case pinBackends != nil:
+		backends = slices.Clone(pinBackends)
+	default:
+		for _, b := range ModelManagerBackends {
+			if slices.Contains(found, b) || m.Endpoints[b] != "" {
+				backends = append(backends, b)
+			}
+		}
+	}
+	m.Backends = backends
+	for b := range m.Endpoints {
+		if !slices.Contains(m.Backends, b) {
+			delete(m.Endpoints, b)
+		}
+	}
+	if len(m.Endpoints) == 0 {
+		m.Endpoints = nil
+	}
+	if pinEnabled != nil {
+		m.Enabled = *pinEnabled
+	} else {
+		m.Enabled = agents && len(m.Backends) > 0
+	}
+	if m.Enabled && len(m.Backends) == 0 {
+		m.Backends = []string{ModelManagerBackendOllama}
+	}
+}
 
 // ExtraModel is one additional kagent ModelConfig. API keys are NOT config:
 // APIKeyEnv only names the host env var read at deploy time — the value lands
@@ -305,9 +445,8 @@ func Default() *Config {
 			MusterPort:    8090,
 			Domain:        "127.0.0.1.nip.io",
 			GatewayPort:   443,
-			ModelManager:  ModelManager{Backend: ModelManagerBackendOllama},
 			APSRepo:       "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:        "203cfe9118e5c25cfa705d725f97396ad4781e2f", // main: the optional model-manager component (#75, chart v0.11.0)
+			APSRef:        "d5a88b07b22785dc2f1032df172b2003773c8176", // main: model-manager 0.16.0 + agent-platform 3.6.0 — the umbrella accepts backend lemonade (#132, #108)
 		},
 		Backstage: Backstage{
 			Enabled: true,
@@ -327,6 +466,9 @@ func Load() (*Config, error) {
 	if err := yaml.Unmarshal(raw, cfg); err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", File, err)
 	}
+	// Earlier versions wrote the one-backend form (backend/endpoint); read
+	// it as the one-item lists so the same lab renders exactly as before.
+	cfg.Platform.ModelManager.normalize()
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("%s: %w", File, err)
 	}
@@ -471,9 +613,7 @@ func (c *Config) Normalize() {
 	if c.Backstage.Enabled {
 		c.Platform.Enabled = true
 	}
-	if c.Platform.ModelManager.Backend == "" {
-		c.Platform.ModelManager.Backend = ModelManagerBackendOllama
-	}
+	c.Platform.ModelManager.normalize()
 }
 
 func (c *Config) Validate() error {
@@ -556,11 +696,29 @@ var httpURLRe = regexp.MustCompile(`^https?://[^/]+`)
 // Validate checks the model-manager block; agents reports whether the kagent
 // runtime is on (model-manager wires ModelConfigs into it).
 func (m ModelManager) Validate(agents bool) error {
-	if m.Backend != "" && m.Backend != ModelManagerBackendOllama {
-		return fmt.Errorf("backend %q: the lab supports %q only (kserve needs GPU nodes and KServe)", m.Backend, ModelManagerBackendOllama)
+	backends := m.Backends
+	if m.Backend != "" && !slices.Contains(backends, m.Backend) {
+		backends = append([]string{m.Backend}, backends...) // the legacy form before normalize
+	}
+	for i, b := range backends {
+		if !slices.Contains(ModelManagerBackends, b) {
+			return fmt.Errorf("backend %q: the lab supports %s (kserve needs GPU nodes and KServe)", b, strings.Join(ModelManagerBackends, ", "))
+		}
+		if slices.Contains(backends[:i], b) {
+			return fmt.Errorf("backends: %q listed twice", b)
+		}
 	}
 	if m.Endpoint != "" && !httpURLRe.MatchString(m.Endpoint) {
 		return fmt.Errorf("endpoint %q: must be an http(s) URL, e.g. http://172.21.0.1:%d", m.Endpoint, OllamaPort)
+	}
+	for _, b := range slices.Sorted(maps.Keys(m.Endpoints)) {
+		ep := m.Endpoints[b]
+		if !slices.Contains(backends, b) {
+			return fmt.Errorf("endpoints.%s: %q is not in backends %v", b, b, backends)
+		}
+		if !httpURLRe.MatchString(ep) {
+			return fmt.Errorf("endpoints.%s %q: must be an http(s) URL, e.g. http://172.21.0.1:%d", b, ep, BackendPort(b))
+		}
 	}
 	if m.Enabled && !agents {
 		return fmt.Errorf("requires platform.agents (model-manager wires pulled models into kagent ModelConfigs)")

--- a/internal/config/discovery_test.go
+++ b/internal/config/discovery_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// Files written before the backends list carried backend/endpoint: they read
+// as the one-item lists and never write the old form again.
+func TestModelManagerNormalizeFoldsLegacyForm(t *testing.T) {
+	mm := ModelManager{Enabled: true, Backend: ModelManagerBackendLemonade, Endpoint: "http://192.168.1.10:13305"}
+	mm.normalize()
+	if !slices.Equal(mm.Backends, []string{ModelManagerBackendLemonade}) || mm.Endpoints[ModelManagerBackendLemonade] != "http://192.168.1.10:13305" {
+		t.Fatalf("legacy form not folded: %+v", mm)
+	}
+	if mm.Backend != "" || mm.Endpoint != "" {
+		t.Fatalf("legacy fields survived normalize: %+v", mm)
+	}
+	if mm.Primary() != ModelManagerBackendLemonade || len(mm.Secondary()) != 0 {
+		t.Fatalf("primary/secondary: %q / %v", mm.Primary(), mm.Secondary())
+	}
+}
+
+// An enabled block without any backend (an old file with `enabled: true`
+// alone) means what it always meant: the host Ollama.
+func TestModelManagerNormalizeEnabledDefaultsToOllama(t *testing.T) {
+	mm := ModelManager{Enabled: true}
+	mm.normalize()
+	if !slices.Equal(mm.Backends, []string{ModelManagerBackendOllama}) {
+		t.Fatalf("backends = %v, want [ollama]", mm.Backends)
+	}
+	off := ModelManager{}
+	off.normalize()
+	if len(off.Backends) != 0 || off.Primary() != ModelManagerBackendOllama {
+		t.Fatalf("disabled block: backends=%v primary=%q", off.Backends, off.Primary())
+	}
+}
+
+func TestApplyDiscovered(t *testing.T) {
+	cases := []struct {
+		name         string
+		start        ModelManager
+		found        []string
+		agents       bool
+		pinEnabled   *bool
+		pinBackends  []string
+		wantBackends []string
+		wantEnabled  bool
+	}{
+		{"both answer", ModelManager{}, []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}, true, nil, nil, []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}, true},
+		{"canonical order whatever the probe order", ModelManager{}, []string{ModelManagerBackendLemonade, ModelManagerBackendOllama}, true, nil, nil, []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}, true},
+		{"only lemonade", ModelManager{}, []string{ModelManagerBackendLemonade}, true, nil, nil, []string{ModelManagerBackendLemonade}, true},
+		{"none answers turns it off", ModelManager{Enabled: true, Backends: []string{ModelManagerBackendOllama}}, nil, true, nil, nil, nil, false},
+		{"a server that vanished drops out", ModelManager{Enabled: true, Backends: []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}}, []string{ModelManagerBackendOllama}, true, nil, nil, []string{ModelManagerBackendOllama}, true},
+		{"an explicit endpoint keeps its backend", ModelManager{Enabled: true, Backends: []string{ModelManagerBackendLemonade}, Endpoints: map[string]string{ModelManagerBackendLemonade: "http://lan:13305"}}, nil, true, nil, nil, []string{ModelManagerBackendLemonade}, true},
+		{"agents off keeps managed models off", ModelManager{}, []string{ModelManagerBackendOllama}, false, nil, nil, []string{ModelManagerBackendOllama}, false},
+		{"pinned off", ModelManager{}, []string{ModelManagerBackendOllama}, true, boolPtr(false), nil, []string{ModelManagerBackendOllama}, false},
+		{"pinned on without a server falls back to ollama", ModelManager{}, nil, true, boolPtr(true), nil, []string{ModelManagerBackendOllama}, true},
+		{"pinned backends replace the discovery", ModelManager{}, []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}, true, nil, []string{ModelManagerBackendLemonade}, []string{ModelManagerBackendLemonade}, true},
+		{"legacy form folds first", ModelManager{Enabled: true, Backend: ModelManagerBackendOllama, Endpoint: "http://lan:11434"}, nil, true, nil, nil, []string{ModelManagerBackendOllama}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mm := tc.start
+			mm.ApplyDiscovered(tc.found, tc.agents, tc.pinEnabled, tc.pinBackends)
+			if !slices.Equal(mm.Backends, tc.wantBackends) {
+				t.Errorf("backends = %v, want %v", mm.Backends, tc.wantBackends)
+			}
+			if mm.Enabled != tc.wantEnabled {
+				t.Errorf("enabled = %v, want %v", mm.Enabled, tc.wantEnabled)
+			}
+			if mm.Backend != "" || mm.Endpoint != "" {
+				t.Errorf("legacy fields set after apply: %+v", mm)
+			}
+			if err := mm.Validate(tc.agents); err != nil {
+				t.Errorf("applied block does not validate: %v", err)
+			}
+		})
+	}
+}
+
+// An endpoint override for a backend the discovery dropped goes with it (it
+// would fail validation otherwise), while the kept one stays.
+func TestApplyDiscoveredPrunesEndpointsOfDroppedBackends(t *testing.T) {
+	mm := ModelManager{Enabled: true, Backends: []string{ModelManagerBackendOllama, ModelManagerBackendLemonade},
+		Endpoints: map[string]string{ModelManagerBackendOllama: "http://lan:11434"}}
+	mm.ApplyDiscovered(nil, true, nil, []string{ModelManagerBackendLemonade})
+	if _, kept := mm.Endpoints[ModelManagerBackendOllama]; kept {
+		t.Fatalf("endpoint of the dropped backend survived: %v", mm.Endpoints)
+	}
+	if err := mm.Validate(true); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestConfigLoadsLegacyModelManagerForm(t *testing.T) {
+	cfg := Default()
+	cfg.Platform.ModelManager = ModelManager{Enabled: true, Backend: ModelManagerBackendOllama}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("legacy form rejected before normalize: %v", err)
+	}
+	cfg.Normalize()
+	if !slices.Equal(cfg.Platform.ModelManager.Backends, []string{ModelManagerBackendOllama}) {
+		t.Fatalf("Normalize did not fold the legacy form: %+v", cfg.Platform.ModelManager)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The lab's own published ports are never conflicts; anything else that
+// listens on a lab port is.
+func TestPortConflictsIgnoreTheClustersOwnPorts(t *testing.T) {
+	cfg := Default()
+	cfg.Platform.MusterPort = 8092
+	ours := map[int]bool{cfg.DexPort: true, cfg.Backstage.Port: true, 8092: true, cfg.Platform.AgentsPort: true, cfg.Platform.GatewayPort: true}
+	// Every lab port "listens" (the kind node holds them) plus a foreign
+	// process on the kagent UI port — the only conflict to report.
+	taken := func(p int) bool { return ours[p] || p == cfg.Platform.AgentsPort }
+	conflicts := cfg.portConflicts(func(p int) bool { return !ours[p] && taken(p) })
+	if len(conflicts) != 0 {
+		t.Fatalf("the cluster's own ports reported as conflicts: %v", conflicts)
+	}
+	// Now the cluster does not publish the kagent UI port (an older node)
+	// and a foreign process holds it.
+	delete(ours, cfg.Platform.AgentsPort)
+	conflicts = cfg.portConflicts(func(p int) bool { return !ours[p] && taken(p) })
+	if len(conflicts) != 1 || conflicts[0].Field != "platform.agentsPort" || conflicts[0].Port != cfg.Platform.AgentsPort {
+		t.Fatalf("conflicts = %v, want exactly platform.agentsPort", conflicts)
+	}
+	if !strings.Contains(conflicts[0].String(), "held by another process") {
+		t.Fatalf("unexpected wording: %s", conflicts[0])
+	}
+}
+
+// With no cluster, ChooseFreePorts moves an existing configuration's ports
+// off foreign listeners like a fresh one's — and leaves the free ones alone.
+func TestChooseFreePortsOnExistingConfigWithoutCluster(t *testing.T) {
+	cfg := Default()
+	cfg.Platform.MusterPort = 8092 // moved by an earlier run; still free
+	changes := cfg.chooseFreePorts(takenSet(cfg.Backstage.Port))
+	if len(changes) != 1 || changes[0].Field != "backstage.port" {
+		t.Fatalf("changes = %v, want exactly backstage.port", changes)
+	}
+	if cfg.Platform.MusterPort != 8092 {
+		t.Fatalf("a free non-default port was renumbered: %d", cfg.Platform.MusterPort)
+	}
+}

--- a/internal/config/models_test.go
+++ b/internal/config/models_test.go
@@ -31,7 +31,7 @@ func TestExtraModelValidate(t *testing.T) {
 			m.Provider = ProviderAnthropic
 			return m
 		}, ""},
-		{"ollama", func(m ExtraModel) ExtraModel {
+		{ModelManagerBackendOllama, func(m ExtraModel) ExtraModel {
 			m.Provider = ProviderOllama
 			m.BaseURL = "http://192.168.1.10:11434"
 			return m
@@ -117,7 +117,12 @@ func TestModelManagerValidate(t *testing.T) {
 		{"on with agents", ModelManager{Enabled: true, Backend: ModelManagerBackendOllama}, true, ""},
 		{"on, endpoint override", ModelManager{Enabled: true, Endpoint: "http://192.168.1.10:11434"}, true, ""},
 		{"on without agents", ModelManager{Enabled: true}, false, "requires platform.agents"},
-		{"kserve", ModelManager{Enabled: true, Backend: "kserve"}, true, "supports \"ollama\" only"},
+		{"kserve", ModelManager{Enabled: true, Backend: "kserve"}, true, "supports ollama, lemonade"},
+		{"lemonade legacy form", ModelManager{Enabled: true, Backend: ModelManagerBackendLemonade, Endpoint: "http://172.21.0.1:13305"}, true, ""},
+		{"both backends", ModelManager{Enabled: true, Backends: []string{ModelManagerBackendOllama, ModelManagerBackendLemonade}}, true, ""},
+		{"duplicate backend", ModelManager{Enabled: true, Backends: []string{ModelManagerBackendOllama, ModelManagerBackendOllama}}, true, "listed twice"},
+		{"endpoint for a backend not listed", ModelManager{Enabled: true, Backends: []string{ModelManagerBackendOllama}, Endpoints: map[string]string{ModelManagerBackendLemonade: "http://h:13305"}}, true, "not in backends"},
+		{"bad per-backend endpoint", ModelManager{Enabled: true, Backends: []string{ModelManagerBackendLemonade}, Endpoints: map[string]string{ModelManagerBackendLemonade: "h:13305"}}, true, "http(s) URL"},
 		{"bad endpoint", ModelManager{Enabled: true, Endpoint: "172.21.0.1:11434"}, true, "http(s) URL"},
 	}
 	for _, tc := range cases {

--- a/internal/config/ports.go
+++ b/internal/config/ports.go
@@ -9,11 +9,11 @@ import (
 	"time"
 )
 
-// PortChange records one port of a freshly created configuration that was
-// moved off its default because something on this machine already listens
-// there. Field is the agentlab.yaml path, What names the component for the
-// human-facing message, Note carries an extra caveat where a non-default
-// port has consequences beyond the number itself.
+// PortChange records one port of the configuration that was moved off its
+// value because something on this machine already listens there. Field is
+// the agentlab.yaml path, What names the component for the human-facing
+// message, Note carries an extra caveat where a non-default port has
+// consequences beyond the number itself.
 type PortChange struct {
 	Field    string
 	What     string
@@ -29,14 +29,94 @@ func (ch PortChange) String() string {
 	return s + ")"
 }
 
-// ChooseFreePorts probes every host-side port of a freshly created
-// configuration on 127.0.0.1 — the address all kind port mappings bind — and
-// moves each occupied one to a nearby free port, returning what changed so
-// the caller can tell the user. Meant for new configs only: an existing
-// agentlab.yaml describes a cluster whose mappings are already fixed, where
-// silently renumbering would only mislead.
-func (c *Config) ChooseFreePorts() []PortChange {
-	return c.chooseFreePorts(portTaken)
+// PortConflict records one port of an existing cluster's configuration that
+// another process on this machine holds — the lab cannot renumber it (the
+// kind mappings are fixed at node creation), so it is reported instead.
+type PortConflict struct {
+	Field string
+	What  string
+	Port  int
+}
+
+func (pc PortConflict) String() string {
+	return fmt.Sprintf("%s: %d is held by another process (%s)", pc.Field, pc.Port, pc.What)
+}
+
+// labPort is one host-side port of the configuration: where it lives, what it
+// serves, and how to pick a replacement when it is occupied.
+type labPort struct {
+	field, what string
+	port        *int
+	// pick chooses a free replacement given the scanner; a nil note means
+	// the move has no caveat beyond the number.
+	pick func(scan func(lo, hi int) (int, bool)) (int, bool)
+	note func(to int) string
+}
+
+// ports lists every host-side port the configuration owns, in the order they
+// are probed and reported.
+func (c *Config) ports() []labPort {
+	return []labPort{
+		// Dex must stay in the NodePort range (host port == NodePort); scan
+		// upward from the current value and wrap around the range.
+		{"dexPort", "the Dex issuer", &c.DexPort, func(scan func(int, int) (int, bool)) (int, bool) {
+			if p, ok := scan(c.DexPort+1, 32767); ok {
+				return p, true
+			}
+			return scan(30000, c.DexPort-1)
+		}, nil},
+		{"platform.musterPort", "muster's direct debug access", &c.Platform.MusterPort, func(scan func(int, int) (int, bool)) (int, bool) {
+			return scan(c.Platform.MusterPort+1, 65535)
+		}, nil},
+		{"platform.agentsPort", "the kagent UI", &c.Platform.AgentsPort, func(scan func(int, int) (int, bool)) (int, bool) {
+			return scan(c.Platform.AgentsPort+1, 65535)
+		}, nil},
+		// The edge prefers 8443 over 444: dodging the whole privileged range
+		// keeps later probes honest (they can bind instead of dial), and
+		// 8443 is the conventional alternate HTTPS port.
+		{"platform.gatewayPort", "the agentgateway edge", &c.Platform.GatewayPort, func(scan func(int, int) (int, bool)) (int, bool) {
+			lo := c.Platform.GatewayPort + 1
+			if c.Platform.GatewayPort < 1024 {
+				lo = 8443
+			}
+			return scan(lo, 65535)
+		}, func(to int) string {
+			return fmt.Sprintf("public URLs gain :%d; the chart's Backstage app-config assumes a port-free baseUrl, expect rough edges", to)
+		}},
+		{"backstage.port", "Backstage's direct debug access", &c.Backstage.Port, func(scan func(int, int) (int, bool)) (int, bool) {
+			return scan(c.Backstage.Port+1, 65535)
+		}, nil},
+	}
+}
+
+// ChooseFreePorts probes every host-side port of the configuration on
+// 127.0.0.1 — the address all kind port mappings bind — and moves each
+// occupied one to a nearby free port, returning what changed so the caller
+// can tell the user. Ports in `ours` are the lab's own (published by an
+// existing kind node of this very configuration) and never count as
+// occupied. Meant for a configuration whose cluster does not exist (yet, or
+// any more): an existing cluster's mappings are fixed at node creation, where
+// renumbering would only mislead — PortConflicts is the read-only check for
+// that case.
+func (c *Config) ChooseFreePorts(ours map[int]bool) []PortChange {
+	return c.chooseFreePorts(func(p int) bool { return !ours[p] && portTaken(p) })
+}
+
+// PortConflicts reports which host-side ports of the configuration another
+// process holds, ignoring the lab's own (`ours`, the ports the existing kind
+// node publishes). Nothing is changed.
+func (c *Config) PortConflicts(ours map[int]bool) []PortConflict {
+	return c.portConflicts(func(p int) bool { return !ours[p] && portTaken(p) })
+}
+
+func (c *Config) portConflicts(taken func(int) bool) []PortConflict {
+	var conflicts []PortConflict
+	for _, lp := range c.ports() {
+		if taken(*lp.port) {
+			conflicts = append(conflicts, PortConflict{Field: lp.field, What: lp.what, Port: *lp.port})
+		}
+	}
+	return conflicts
 }
 
 // chooseFreePorts is ChooseFreePorts with the probe injected, so tests can
@@ -70,60 +150,24 @@ func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
 	}
 
 	var changes []PortChange
-	move := func(field, what string, port *int, pick func() (int, bool), note func(to int) string) {
-		if !taken(*port) {
-			return
+	for _, lp := range c.ports() {
+		if !taken(*lp.port) {
+			continue
 		}
-		to, ok := pick()
+		to, ok := lp.pick(scan)
 		if !ok {
 			// Nowhere to go (the range is exhausted); leave the port alone
 			// and let `agentlab up` fail with the real bind error.
-			return
+			continue
 		}
 		reserved[to] = true
-		ch := PortChange{Field: field, What: what, From: *port, To: to}
-		if note != nil {
-			ch.Note = note(to)
+		ch := PortChange{Field: lp.field, What: lp.what, From: *lp.port, To: to}
+		if lp.note != nil {
+			ch.Note = lp.note(to)
 		}
 		changes = append(changes, ch)
-		*port = to
+		*lp.port = to
 	}
-	noNote := func(int) string { return "" }
-
-	// Dex must stay in the NodePort range (host port == NodePort); scan
-	// upward from the default and wrap around the range.
-	move("dexPort", "the Dex issuer", &c.DexPort, func() (int, bool) {
-		if p, ok := scan(c.DexPort+1, 32767); ok {
-			return p, true
-		}
-		return scan(30000, c.DexPort-1)
-	}, noNote)
-
-	move("platform.musterPort", "muster's direct debug access", &c.Platform.MusterPort, func() (int, bool) {
-		return scan(c.Platform.MusterPort+1, 65535)
-	}, noNote)
-
-	move("platform.agentsPort", "the kagent UI", &c.Platform.AgentsPort, func() (int, bool) {
-		return scan(c.Platform.AgentsPort+1, 65535)
-	}, noNote)
-
-	// The edge prefers 8443 over 444: dodging the whole privileged range
-	// keeps later probes honest (they can bind instead of dial), and 8443 is
-	// the conventional alternate HTTPS port.
-	move("platform.gatewayPort", "the agentgateway edge", &c.Platform.GatewayPort, func() (int, bool) {
-		lo := c.Platform.GatewayPort + 1
-		if c.Platform.GatewayPort < 1024 {
-			lo = 8443
-		}
-		return scan(lo, 65535)
-	}, func(to int) string {
-		return fmt.Sprintf("public URLs gain :%d; the chart's Backstage app-config assumes a port-free baseUrl, expect rough edges", to)
-	})
-
-	move("backstage.port", "Backstage's direct debug access", &c.Backstage.Port, func() (int, bool) {
-		return scan(c.Backstage.Port+1, 65535)
-	}, noNote)
-
 	return changes
 }
 

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -45,10 +45,19 @@ func newForm(groups ...*huh.Group) *huh.Form {
 	return form
 }
 
+// Hints is what `agentlab configure` learned about this machine before the
+// form runs, so the questions can say what the defaults are based on.
+type Hints struct {
+	// ModelServers names the host model servers found (versions and ports),
+	// or says that none answers — shown under the managed-models confirm.
+	ModelServers string
+}
+
 // Run walks the user through the lab configuration and mutates cfg in place.
 // The passed cfg provides the defaults shown in the form (so re-configuring
-// starts from the current answers, not from scratch).
-func Run(cfg *config.Config, accessible bool) error {
+// starts from the current answers, not from scratch); hints carry what the
+// discovery on this machine found.
+func Run(cfg *config.Config, accessible bool, hints Hints) error {
 	clusterName := cfg.ClusterName
 	dexPort := strconv.Itoa(cfg.DexPort)
 	dexImage := cfg.DexImage
@@ -161,8 +170,8 @@ func Run(cfg *config.Config, accessible bool) error {
 				Negative("Skip").
 				Value(&observabilityEnabled),
 			huh.NewConfirm().
-				Title("Manage this machine's Ollama models from the platform (model-manager)?").
-				Description("Optional, needs the agents runtime: the umbrella's model-manager component with\nthe Ollama backend — pull, load/unload and delete models from the portal or as\nx_model-manager_* tools, each pulled model wired into kagent as a ModelConfig.\nPods reach the host Ollama through the kind docker gateway (bind it to 0.0.0.0).").
+				Title("Manage this machine's model servers from the platform (model-manager)?").
+				Description("Optional, needs the agents runtime: the umbrella's model-manager component in\nfront of the host's Ollama or Lemonade Server — pull, load/unload and delete models\nfrom the portal or as x_model-manager_* tools, each pulled model wired into kagent\nas a ModelConfig. Pods reach the host through the kind docker gateway (bind the\nserver to 0.0.0.0). "+modelServersHint(hints)).
 				Affirmative("Manage").
 				Negative("Skip").
 				Value(&modelManagerEnabled),
@@ -395,6 +404,14 @@ func editExtraModels(cfg *config.Config, accessible bool) error {
 
 	cfg.Platform.ExtraModels = kept
 	return nil
+}
+
+// modelServersHint is the discovery's line under the managed-models confirm.
+func modelServersHint(h Hints) string {
+	if h.ModelServers == "" {
+		return "No Ollama or Lemonade Server answers on this machine right now."
+	}
+	return "Found: " + h.ModelServers + "."
 }
 
 func baseURLNote(u string) string {

--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -29,7 +29,7 @@ func TestRunTUIDrive(t *testing.T) {
 	defer func() { testInput, testOutput = nil, nil }()
 
 	cfg := config.Default()
-	if err := Run(cfg, false); err != nil {
+	if err := Run(cfg, false, Hints{ModelServers: "Ollama 0.33.2 (:11434)"}); err != nil {
 		t.Fatalf("form run: %v", err)
 	}
 	if cfg.ClusterName != "agentlab" || cfg.DexPort != 32000 {
@@ -74,7 +74,7 @@ func TestRunTUIDriveEdit(t *testing.T) {
 	defer func() { testInput, testOutput = nil, nil }()
 
 	cfg := config.Default()
-	if err := Run(cfg, false); err != nil {
+	if err := Run(cfg, false, Hints{}); err != nil {
 		t.Fatalf("form run: %v", err)
 	}
 	if cfg.ClusterName != "renamed" {

--- a/internal/lab/discover.go
+++ b/internal/lab/discover.go
@@ -1,0 +1,314 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// Discovery is what `agentlab configure` learns about this machine before it
+// writes agentlab.yaml — on every run, not only the first, so the file
+// follows the host: the tools `agentlab up` shells out to, whether this
+// configuration's kind cluster exists (and which host ports it publishes, so
+// they never count as conflicts), the kind docker network's gateway (the
+// address pods reach the host on), the model servers answering on their
+// default ports with their downloaded models, a standalone FastFlowLM server
+// (report-only), and whether the Anthropic key is in the environment.
+type Discovery struct {
+	Tools         []ToolVersion
+	AnthropicKey  bool
+	ClusterExists bool
+	ClusterPorts  map[int]bool
+	KindGateway   string
+	Servers       []HostServer
+	FLM           *FLMServer
+}
+
+// ToolVersion is one of the CLIs the lab shells out to; Version is empty
+// when the tool is not on PATH (or does not answer).
+type ToolVersion struct {
+	Name    string
+	Version string
+}
+
+// HostServer is a model server found on this machine.
+type HostServer struct {
+	Backend string // config.ModelManagerBackend*
+	Version string
+	Port    int
+	// OnGateway: the server also answers on the kind docker gateway address,
+	// i.e. it is bound to every interface and pods can reach it. nil when
+	// the kind network does not exist yet (nothing to dial).
+	OnGateway *bool
+	Models    []HostModel
+	ModelsErr error
+}
+
+// FLMServer is a standalone `flm serve` (FastFlowLM's own OpenAI-compatible
+// server). The lab does not wire it: it has no management API and lists its
+// whole catalog rather than what is downloaded — Lemonade Server is the
+// supported front for FLM.
+type FLMServer struct {
+	Port   int
+	Models int
+}
+
+// flmDefaultPort is `flm port`, the default of `flm serve`.
+const flmDefaultPort = 52625
+
+// flmOwner is the owned_by FLM's /v1/models reports.
+const flmOwner = "FastFlowLM"
+
+// Discover probes this machine. Nothing here needs the cluster; every probe
+// is loopback or a local CLI and degrades to "not found".
+func Discover(cfg *config.Config) *Discovery {
+	d := &Discovery{AnthropicKey: os.Getenv(AnthropicKeyEnv) != ""}
+	d.Tools = []ToolVersion{
+		{"docker", dockerVersion()},
+		{"kind", kindVersion()},
+		{"kubectl", kubectlVersion()},
+		{"helm", helmVersion()},
+	}
+	d.ClusterExists, d.ClusterPorts = kindNodePublishedPorts(cfg.ControlPlaneNode())
+	if gw, err := kindGatewayIP(); err == nil {
+		d.KindGateway = gw
+	}
+	for _, b := range config.ModelManagerBackends {
+		base := loopbackBase(b)
+		version, ok := detectHostServer(b, base)
+		if !ok {
+			continue
+		}
+		s := HostServer{Backend: b, Version: version, Port: config.BackendPort(b)}
+		if d.KindGateway != "" {
+			answers := tcpAnswers(net.JoinHostPort(d.KindGateway, strconv.Itoa(s.Port)))
+			s.OnGateway = &answers
+		}
+		s.Models, s.ModelsErr = hostModelsFn(b, base)
+		d.Servers = append(d.Servers, s)
+	}
+	d.FLM = detectFLM(fmt.Sprintf("http://127.0.0.1:%d", flmDefaultPort), flmDefaultPort)
+	return d
+}
+
+// Backends lists the backends whose servers answer, in canonical order.
+func (d *Discovery) Backends() []string {
+	var out []string
+	for _, s := range d.Servers {
+		out = append(out, s.Backend)
+	}
+	return out
+}
+
+// ModelServersHint names the servers found for the configure form.
+func (d *Discovery) ModelServersHint() string {
+	parts := make([]string, 0, len(d.Servers))
+	for _, s := range d.Servers {
+		parts = append(parts, fmt.Sprintf("%s %s (:%d)", config.BackendServerName(s.Backend), s.Version, s.Port))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// MissingTools names the CLIs `agentlab up` needs that did not answer.
+func (d *Discovery) MissingTools() []string {
+	var missing []string
+	for _, t := range d.Tools {
+		if t.Version == "" {
+			missing = append(missing, t.Name)
+		}
+	}
+	return missing
+}
+
+// Report is the human-readable account of the discovery, printed by
+// `agentlab configure` before it changes anything.
+func (d *Discovery) Report(cfg *config.Config) string {
+	var b strings.Builder
+	line := func(label, format string, a ...any) {
+		fmt.Fprintf(&b, "  %-18s"+format+"\n", append([]any{label}, a...)...)
+	}
+	b.WriteString("Discovering this machine:\n")
+	tools := make([]string, 0, len(d.Tools))
+	for _, t := range d.Tools {
+		if t.Version == "" {
+			tools = append(tools, t.Name+" MISSING")
+			continue
+		}
+		tools = append(tools, t.Name+" "+t.Version)
+	}
+	line("tools", "%s", strings.Join(tools, ", "))
+	if missing := d.MissingTools(); len(missing) > 0 {
+		line("", "`agentlab up` needs docker, kind, kubectl and helm >= 4 — install: %s", strings.Join(missing, ", "))
+	} else if v := d.toolVersion("helm"); v != "" {
+		if major, err := helmMajor(v); err == nil && major < 4 {
+			line("", "helm %s cannot install the platform: Helm >= 4 is required (agent-platform-standalone#21)", v)
+		}
+	}
+	switch {
+	case d.ClusterExists:
+		line("cluster", "kind %q exists — its port mappings are fixed at node creation (`agentlab down && agentlab up` to change them)", cfg.ClusterName)
+	default:
+		line("cluster", "kind %q does not exist yet — ports are free to move", cfg.ClusterName)
+	}
+	if len(d.Servers) == 0 {
+		line("model servers", "none — no Ollama on :%d, no Lemonade Server on :%d", config.OllamaPort, config.LemonadePort)
+	}
+	for _, s := range d.Servers {
+		reach := "kind gateway not known yet (first `agentlab up` creates the network)"
+		if s.OnGateway != nil && *s.OnGateway {
+			reach = fmt.Sprintf("listens on the kind gateway %s: yes", d.KindGateway)
+		} else if s.OnGateway != nil {
+			reach = fmt.Sprintf("does NOT listen on the kind gateway %s — pods cannot reach it (%s)", d.KindGateway, bindHint(s.Backend))
+		}
+		models := "models not listed"
+		if s.ModelsErr == nil {
+			tools := 0
+			for _, m := range s.Models {
+				if m.Tools {
+					tools++
+				}
+			}
+			models = fmt.Sprintf("%d downloaded, %d tool-calling", len(s.Models), tools)
+		}
+		line(config.BackendServerName(s.Backend), "%s on :%d — %s; %s", s.Version, s.Port, reach, models)
+	}
+	if d.FLM != nil {
+		line("FastFlowLM", "standalone `flm serve` on :%d (%d catalog entries) — no management API and loopback by default; the lab drives FLM through Lemonade Server", d.FLM.Port, d.FLM.Models)
+	}
+	if d.AnthropicKey {
+		line("Anthropic key", "$%s is set — the agents' default ModelConfig and Backstage's AI chat get the real key at deploy time", AnthropicKeyEnv)
+	} else {
+		line("Anthropic key", "$%s is not set — the default ModelConfig and Backstage's AI chat get a placeholder until it is exported and `agentlab platform` re-runs", AnthropicKeyEnv)
+	}
+	return b.String()
+}
+
+func (d *Discovery) toolVersion(name string) string {
+	for _, t := range d.Tools {
+		if t.Name == name {
+			return t.Version
+		}
+	}
+	return ""
+}
+
+// bindHint is the one-line version of the bind fix for the report.
+func bindHint(backend string) string {
+	if backend == config.ModelManagerBackendLemonade {
+		return "`lemonade config set host=0.0.0.0`, restart lemond"
+	}
+	return "OLLAMA_HOST=0.0.0.0, restart Ollama"
+}
+
+// tcpAnswers reports whether something accepts a TCP connection at addr.
+func tcpAnswers(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// detectFLM probes a standalone FastFlowLM server: its OpenAI-compatible
+// /v1/models lists entries owned by FastFlowLM.
+func detectFLM(base string, port int) *FLMServer {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(base + "/v1/models")
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var list struct {
+		Data []struct {
+			OwnedBy string `json:"owned_by"`
+		} `json:"data"`
+	}
+	if err := decodeJSONBody(resp, &list); err != nil || len(list.Data) == 0 {
+		return nil
+	}
+	for _, m := range list.Data {
+		if m.OwnedBy != flmOwner {
+			return nil
+		}
+	}
+	return &FLMServer{Port: port, Models: len(list.Data)}
+}
+
+// kindNodePublishedPorts reads the host ports the kind node container of
+// this configuration publishes (docker's HostConfig.PortBindings — set at
+// creation, present whether the container runs or is stopped). exists is
+// false when there is no such container (or no docker).
+func kindNodePublishedPorts(node string) (exists bool, ports map[int]bool) {
+	out, err := outputQuiet("docker", "inspect", "-f", "{{json .HostConfig.PortBindings}}", node)
+	if err != nil {
+		return false, nil
+	}
+	var bindings map[string][]struct {
+		HostPort string `json:"HostPort"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &bindings); err != nil {
+		return true, nil
+	}
+	ports = map[int]bool{}
+	for _, list := range bindings {
+		for _, b := range list {
+			if p, err := strconv.Atoi(b.HostPort); err == nil {
+				ports[p] = true
+			}
+		}
+	}
+	return true, ports
+}
+
+func dockerVersion() string {
+	out, err := outputQuiet("docker", "version", "-f", "{{.Server.Version}}")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+func kindVersion() string {
+	// "kind v0.32.0 go1.26.4 linux/amd64"
+	out, err := outputQuiet("kind", "version")
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(out)
+	if len(fields) < 2 {
+		return strings.TrimSpace(out)
+	}
+	return fields[1]
+}
+
+func kubectlVersion() string {
+	out, err := outputQuiet("kubectl", "version", "--client", "-o", "json")
+	if err != nil {
+		return ""
+	}
+	var v struct {
+		ClientVersion struct {
+			GitVersion string `json:"gitVersion"`
+		} `json:"clientVersion"`
+	}
+	if err := json.Unmarshal([]byte(out), &v); err != nil {
+		return ""
+	}
+	return v.ClientVersion.GitVersion
+}
+
+func helmVersion() string {
+	out, err := outputQuiet("helm", "version", "--template", "{{.Version}}")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}

--- a/internal/lab/discover_test.go
+++ b/internal/lab/discover_test.go
@@ -29,6 +29,7 @@ const (
 	fieldOwnedBy    = "owned_by"
 	fieldDownloaded = "downloaded"
 	fieldLabels     = "labels"
+	fieldSize       = "size"
 	labelVision     = "vision"
 )
 
@@ -45,9 +46,10 @@ func fakeOllama(t *testing.T) *httptest.Server {
 		_ = json.NewEncoder(w).Encode(map[string]string{"version": ollamaVersion})
 	})
 	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, _ *http.Request) {
-		var models []map[string]string
+		sizes := map[string]int64{modelQwen35: 6_000_000_000, modelGemma270m: 300_000_000, modelSmollm: 270_000_000}
+		var models []map[string]any
 		for _, name := range []string{modelQwen35, modelGemma270m, modelSmollm} {
-			models = append(models, map[string]string{"name": name})
+			models = append(models, map[string]any{"name": name, fieldSize: sizes[name]})
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"models": models})
 	})
@@ -71,10 +73,10 @@ func fakeLemonade(t *testing.T) *httptest.Server {
 	})
 	mux.HandleFunc("/api/v1/models", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"object": "list", fieldData: []map[string]any{
-			{"id": modelQwen3FLM, fieldDownloaded: true, fieldLabels: []string{lemonadeToolsLabel, labelChat}, "recipe": "flm"},
-			{"id": modelGemma4bFLM, fieldDownloaded: true, fieldLabels: []string{labelVision, labelChat}, "recipe": "flm"},
-			{"id": modelMoEFLM, fieldDownloaded: true, fieldLabels: []string{labelVision, "reasoning", lemonadeToolsLabel, labelChat}},
-			{"id": "not-yet", fieldDownloaded: false, fieldLabels: []string{lemonadeToolsLabel}},
+			{"id": modelQwen3FLM, fieldDownloaded: true, fieldLabels: []string{lemonadeToolsLabel, labelChat}, "recipe": "flm", fieldSize: 3.1},
+			{"id": modelGemma4bFLM, fieldDownloaded: true, fieldLabels: []string{labelVision, labelChat}, "recipe": "flm", fieldSize: 4.5},
+			{"id": modelMoEFLM, fieldDownloaded: true, fieldLabels: []string{labelVision, "reasoning", lemonadeToolsLabel, labelChat}, fieldSize: 24.3},
+			{"id": "not-yet", fieldDownloaded: false, fieldLabels: []string{lemonadeToolsLabel}, fieldSize: 1},
 		}})
 	})
 	return httptest.NewServer(mux)
@@ -111,7 +113,7 @@ func TestHostServerModels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []HostModel{{modelQwen35, true}, {modelGemma270m, false}, {modelSmollm, true}}
+	want := []HostModel{{modelQwen35, true, 6_000_000_000}, {modelGemma270m, false, 300_000_000}, {modelSmollm, true, 270_000_000}}
 	if !slices.Equal(got, want) {
 		t.Errorf("ollama models = %v, want %v", got, want)
 	}
@@ -120,9 +122,9 @@ func TestHostServerModels(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = []HostModel{{modelQwen3FLM, true}, {modelGemma4bFLM, false}, {modelMoEFLM, true}}
+	want = []HostModel{{modelQwen3FLM, true, 3_100_000_000}, {modelGemma4bFLM, false, 4_500_000_000}, {modelMoEFLM, true, 24_300_000_000}}
 	if !slices.Equal(got, want) {
-		t.Errorf("lemonade models = %v, want %v (downloaded only)", got, want)
+		t.Errorf("lemonade models = %v, want %v (downloaded only, decimal GB -> bytes)", got, want)
 	}
 }
 
@@ -169,9 +171,10 @@ func TestHostModelConfigName(t *testing.T) {
 // hand are left to that entry; the primary backend contributes nothing (it is
 // model-manager's).
 func TestHostBackendModelConfigs(t *testing.T) {
+	// Listed largest first on purpose: the wiring orders smallest first.
 	inventory := map[string][]HostModel{
-		ollama:   {{modelQwen35, true}},
-		lemonade: {{modelQwen3FLM, true}, {modelGemma4bFLM, false}, {modelQwenVLFLM, true}},
+		ollama:   {{modelQwen35, true, 6_000_000_000}},
+		lemonade: {{modelMoEFLM, true, 24_300_000_000}, {modelQwen3FLM, true, 3_100_000_000}, {modelGemma4bFLM, false, 4_500_000_000}, {modelQwenVLFLM, true, 3_900_000_000}},
 	}
 	orig := hostModelsFn
 	hostModelsFn = func(backend, _ string) ([]HostModel, error) { return inventory[backend], nil }
@@ -190,9 +193,10 @@ func TestHostBackendModelConfigs(t *testing.T) {
 	}
 	want := []config.ExtraModel{
 		{Name: "lemonade-qwen3vl-it-4b-flm", Provider: config.ProviderOpenAI, Model: modelQwenVLFLM, BaseURL: "http://172.21.0.1:13305/api/v1"},
+		{Name: "lemonade-qwen3-6-moe-35b-a3b-flm", Provider: config.ProviderOpenAI, Model: modelMoEFLM, BaseURL: "http://172.21.0.1:13305/api/v1"},
 	}
 	if !slices.Equal(got, want) {
-		t.Fatalf("wired = %+v, want %+v", got, want)
+		t.Fatalf("wired = %+v, want %+v (smallest first, the hand-wired qwen3-it-4b left to its entry)", got, want)
 	}
 	for _, m := range got {
 		if err := m.Validate(); err != nil {

--- a/internal/lab/discover_test.go
+++ b/internal/lab/discover_test.go
@@ -1,0 +1,236 @@
+package lab
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// Fixture vocabulary, hoisted so the linter's constant check stays quiet.
+const (
+	ollama          = config.ModelManagerBackendOllama
+	lemonade        = config.ModelManagerBackendLemonade
+	capCompletion   = "completion"
+	labelChat       = "chat"
+	ollamaVersion   = "0.33.2"
+	lemonadeVersion = "11.9.0"
+	modelQwen35     = "qwen3.5:9b"
+	modelGemma270m  = "gemma3:270m"
+	modelSmollm     = "smollm2:135m"
+	modelQwen3FLM   = "qwen3-it-4b-FLM"
+	modelGemma4bFLM = "gemma3-4b-FLM"
+	modelMoEFLM     = "Qwen3.6-MoE-35B-A3B-FLM"
+	modelQwenVLFLM  = "qwen3vl-it-4b-FLM"
+	fieldData       = "data"
+	fieldOwnedBy    = "owned_by"
+	fieldDownloaded = "downloaded"
+	fieldLabels     = "labels"
+	labelVision     = "vision"
+)
+
+// fakeOllama answers /api/version, /api/tags and /api/show like an Ollama.
+func fakeOllama(t *testing.T) *httptest.Server {
+	t.Helper()
+	caps := map[string][]string{
+		modelQwen35:    {capCompletion, labelVision, "tools", "thinking"},
+		modelGemma270m: {capCompletion},
+		modelSmollm:    {capCompletion, "tools"},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": ollamaVersion})
+	})
+	mux.HandleFunc("/api/tags", func(w http.ResponseWriter, _ *http.Request) {
+		var models []map[string]string
+		for _, name := range []string{modelQwen35, modelGemma270m, modelSmollm} {
+			models = append(models, map[string]string{"name": name})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"models": models})
+	})
+	mux.HandleFunc("/api/show", func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Model string `json:"model"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewEncoder(w).Encode(map[string]any{"capabilities": caps[req.Model]})
+	})
+	return httptest.NewServer(mux)
+}
+
+// fakeLemonade answers /api/v1/health and /api/v1/models like a Lemonade
+// Server (downloaded models only, with labels).
+func fakeLemonade(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/health", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"all_models_loaded": []any{}, "status": "ok", "version": lemonadeVersion})
+	})
+	mux.HandleFunc("/api/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"object": "list", fieldData: []map[string]any{
+			{"id": modelQwen3FLM, fieldDownloaded: true, fieldLabels: []string{lemonadeToolsLabel, labelChat}, "recipe": "flm"},
+			{"id": modelGemma4bFLM, fieldDownloaded: true, fieldLabels: []string{labelVision, labelChat}, "recipe": "flm"},
+			{"id": modelMoEFLM, fieldDownloaded: true, fieldLabels: []string{labelVision, "reasoning", lemonadeToolsLabel, labelChat}},
+			{"id": "not-yet", fieldDownloaded: false, fieldLabels: []string{lemonadeToolsLabel}},
+		}})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestDetectHostServer(t *testing.T) {
+	ollama := fakeOllama(t)
+	defer ollama.Close()
+	lemonade := fakeLemonade(t)
+	defer lemonade.Close()
+
+	if v, ok := detectHostServer(config.ModelManagerBackendOllama, ollama.URL); !ok || v != ollamaVersion {
+		t.Errorf("ollama: %q %v", v, ok)
+	}
+	if v, ok := detectHostServer(config.ModelManagerBackendLemonade, lemonade.URL); !ok || v != lemonadeVersion {
+		t.Errorf("lemonade: %q %v", v, ok)
+	}
+	// The wrong server on a port is not a hit: Ollama's path on Lemonade 404s.
+	if _, ok := detectHostServer(config.ModelManagerBackendOllama, lemonade.URL); ok {
+		t.Errorf("Lemonade detected as Ollama")
+	}
+	if _, ok := detectHostServer(config.ModelManagerBackendOllama, "http://127.0.0.1:1"); ok {
+		t.Errorf("a closed port detected as a server")
+	}
+}
+
+func TestHostServerModels(t *testing.T) {
+	ollama := fakeOllama(t)
+	defer ollama.Close()
+	lemonade := fakeLemonade(t)
+	defer lemonade.Close()
+
+	got, err := hostServerModels(config.ModelManagerBackendOllama, ollama.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []HostModel{{modelQwen35, true}, {modelGemma270m, false}, {modelSmollm, true}}
+	if !slices.Equal(got, want) {
+		t.Errorf("ollama models = %v, want %v", got, want)
+	}
+
+	got, err = hostServerModels(config.ModelManagerBackendLemonade, lemonade.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = []HostModel{{modelQwen3FLM, true}, {modelGemma4bFLM, false}, {modelMoEFLM, true}}
+	if !slices.Equal(got, want) {
+		t.Errorf("lemonade models = %v, want %v (downloaded only)", got, want)
+	}
+}
+
+func TestDetectFLM(t *testing.T) {
+	flm := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{fieldData: []map[string]any{
+			{"id": "qwen3-it:4b", fieldOwnedBy: "FastFlowLM"}, {"id": "gemma3:4b", fieldOwnedBy: "FastFlowLM"},
+		}})
+	}))
+	defer flm.Close()
+	got := detectFLM(flm.URL, 52625)
+	if got == nil || got.Models != 2 || got.Port != 52625 {
+		t.Fatalf("detectFLM = %+v", got)
+	}
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{fieldData: []map[string]any{{"id": "x", fieldOwnedBy: "vllm"}}}) // a vLLM, not FLM
+	}))
+	defer other.Close()
+	if detectFLM(other.URL, 8000) != nil {
+		t.Fatalf("a non-FLM OpenAI-compatible server detected as FLM")
+	}
+}
+
+func TestHostModelConfigName(t *testing.T) {
+	cases := map[[2]string]string{
+		{lemonade, modelQwen3FLM}: "lemonade-qwen3-it-4b-flm",
+		{lemonade, modelMoEFLM}:   "lemonade-qwen3-6-moe-35b-a3b-flm",
+		{ollama, modelQwen35}:     "ollama-qwen3-5-9b",
+		{ollama, "aqualaguna/gemma-3-27b-it-abliterated-GGUF:q4_k_m"}: "ollama-aqualaguna-gemma-3-27b-it-abliterated-gguf-q4-k-m",
+	}
+	for in, want := range cases {
+		got := hostModelConfigName(in[0], in[1])
+		if got != want {
+			t.Errorf("hostModelConfigName(%q, %q) = %q, want %q", in[0], in[1], got, want)
+		}
+		if err := config.ValidateModelName(got); err != nil {
+			t.Errorf("%q is not a valid model name: %v", got, err)
+		}
+	}
+}
+
+// The secondary backends' tool-calling models become ModelConfig entries in
+// model-manager's shape for that backend; models the user already wired by
+// hand are left to that entry; the primary backend contributes nothing (it is
+// model-manager's).
+func TestHostBackendModelConfigs(t *testing.T) {
+	inventory := map[string][]HostModel{
+		ollama:   {{modelQwen35, true}},
+		lemonade: {{modelQwen3FLM, true}, {modelGemma4bFLM, false}, {modelQwenVLFLM, true}},
+	}
+	orig := hostModelsFn
+	hostModelsFn = func(backend, _ string) ([]HostModel, error) { return inventory[backend], nil }
+	defer func() { hostModelsFn = orig }()
+
+	cfg := config.Default()
+	cfg.Platform.ModelManager = config.ModelManager{Enabled: true, Backends: []string{ollama, lemonade}}
+	cfg.Platform.ExtraModels = []config.ExtraModel{
+		// Timo's hand-wired entry for the same model on the same host:port, on /v1 instead of /api/v1.
+		{Name: "lemonade-npu", Provider: config.ProviderOpenAI, Model: modelQwen3FLM, BaseURL: "http://172.21.0.1:13305/v1"},
+	}
+	endpoints := map[string]string{ollama: "http://172.21.0.1:11434", lemonade: "http://172.21.0.1:13305"}
+	got, err := hostBackendModelConfigs(cfg, endpoints)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []config.ExtraModel{
+		{Name: "lemonade-qwen3vl-it-4b-flm", Provider: config.ProviderOpenAI, Model: modelQwenVLFLM, BaseURL: "http://172.21.0.1:13305/api/v1"},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("wired = %+v, want %+v", got, want)
+	}
+	for _, m := range got {
+		if err := m.Validate(); err != nil {
+			t.Errorf("%s: %v", m.Name, err)
+		}
+	}
+
+	// Ollama as the further backend: the native keyless provider on the endpoint itself.
+	cfg.Platform.ModelManager.Backends = []string{lemonade, ollama}
+	cfg.Platform.ExtraModels = nil
+	got, err = hostBackendModelConfigs(cfg, endpoints)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = []config.ExtraModel{{Name: "ollama-qwen3-5-9b", Provider: config.ProviderOllama, Model: modelQwen35, BaseURL: "http://172.21.0.1:11434"}}
+	if !slices.Equal(got, want) {
+		t.Fatalf("wired = %+v, want %+v", got, want)
+	}
+
+	// Managed models off: nothing is wired, whatever the list says.
+	cfg.Platform.ModelManager.Enabled = false
+	if got, _ := hostBackendModelConfigs(cfg, endpoints); len(got) != 0 {
+		t.Fatalf("wired with managed models off: %+v", got)
+	}
+}
+
+func TestDiscoveryBackendsAndHint(t *testing.T) {
+	d := &Discovery{Servers: []HostServer{
+		{Backend: ollama, Version: ollamaVersion, Port: 11434},
+		{Backend: lemonade, Version: lemonadeVersion, Port: 13305},
+	}}
+	if !slices.Equal(d.Backends(), []string{ollama, lemonade}) {
+		t.Fatalf("backends = %v", d.Backends())
+	}
+	if d.ModelServersHint() != "Ollama 0.33.2 (:11434), Lemonade Server 11.9.0 (:13305)" {
+		t.Fatalf("hint = %q", d.ModelServersHint())
+	}
+	if (&Discovery{}).ModelServersHint() != "" {
+		t.Fatalf("empty discovery should hint nothing")
+	}
+}

--- a/internal/lab/hostmodels.go
+++ b/internal/lab/hostmodels.go
@@ -2,6 +2,7 @@ package lab
 
 import (
 	"bytes"
+	"cmp"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,7 +31,15 @@ type HostModel struct {
 	// send tool schemas with every turn (a model without it fails each turn
 	// with "does not support tools").
 	Tools bool
+	// Size on disk in bytes (Lemonade reports decimal GB; converted). The
+	// wired list is ordered by it, smallest first, so a proof that takes the
+	// first entry loads the cheapest model.
+	Size int64
 }
+
+// lemonadeModelField is the request field Lemonade's management API takes
+// the model name in.
+const lemonadeModelField = "model_name"
 
 // The capability names the servers use for tool calling.
 const (
@@ -63,6 +72,7 @@ func ollamaModels(base string) ([]HostModel, error) {
 	var tags struct {
 		Models []struct {
 			Name string `json:"name"`
+			Size int64  `json:"size"`
 		} `json:"models"`
 	}
 	if err := decodeJSONBody(resp, &tags); err != nil {
@@ -70,7 +80,7 @@ func ollamaModels(base string) ([]HostModel, error) {
 	}
 	models := make([]HostModel, 0, len(tags.Models))
 	for _, m := range tags.Models {
-		body, _ := json.Marshal(map[string]string{"model": m.Name})
+		body, _ := json.Marshal(map[string]string{modelField: m.Name})
 		show, err := client.Post(base+"/api/show", "application/json", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
@@ -83,7 +93,7 @@ func ollamaModels(base string) ([]HostModel, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading %s/api/show for %s: %w", base, m.Name, err)
 		}
-		models = append(models, HostModel{ID: m.Name, Tools: slices.Contains(info.Capabilities, ollamaToolsCapability)})
+		models = append(models, HostModel{ID: m.Name, Tools: slices.Contains(info.Capabilities, ollamaToolsCapability), Size: m.Size})
 	}
 	return models, nil
 }
@@ -102,6 +112,7 @@ func lemonadeModels(base string) ([]HostModel, error) {
 			ID         string   `json:"id"`
 			Downloaded bool     `json:"downloaded"`
 			Labels     []string `json:"labels"`
+			Size       float64  `json:"size"` // decimal GB
 		} `json:"data"`
 	}
 	if err := decodeJSONBody(resp, &list); err != nil {
@@ -112,9 +123,34 @@ func lemonadeModels(base string) ([]HostModel, error) {
 		if !m.Downloaded {
 			continue
 		}
-		models = append(models, HostModel{ID: m.ID, Tools: slices.Contains(m.Labels, lemonadeToolsLabel)})
+		models = append(models, HostModel{ID: m.ID, Tools: slices.Contains(m.Labels, lemonadeToolsLabel), Size: int64(m.Size * 1e9)})
 	}
 	return models, nil
+}
+
+// unloadHostModel evicts a model from a host server after a proof used it —
+// Lemonade has no idle eviction (POST /api/v1/unload), Ollama's keep-alive
+// is re-armed by every request (a zero keep_alive generate unloads now).
+func unloadHostModel(backend, endpoint, model string) error {
+	client := &http.Client{Timeout: 30 * time.Second}
+	var path string
+	var body []byte
+	if backend == config.ModelManagerBackendLemonade {
+		path = lemonadeAPIBasePath + "/unload"
+		body, _ = json.Marshal(map[string]string{lemonadeModelField: model})
+	} else {
+		path = "/api/generate"
+		body, _ = json.Marshal(map[string]any{modelField: model, "keep_alive": 0})
+	}
+	resp, err := client.Post(endpoint+path, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("%s answered %s", path, resp.Status)
+	}
+	return nil
 }
 
 // hostBackendModelConfigs synthesizes the ModelConfig entries for the
@@ -137,6 +173,15 @@ func hostBackendModelConfigs(cfg *config.Config, endpoints map[string]string) ([
 		if err != nil {
 			return nil, fmt.Errorf("listing %s's models at %s: %w", config.BackendServerName(b), endpoint, err)
 		}
+		// Smallest first: the proof takes the first entry, and the summary
+		// reads the same whatever order the server lists them in.
+		models = slices.Clone(models)
+		slices.SortStableFunc(models, func(a, b HostModel) int {
+			if c := cmp.Compare(a.Size, b.Size); c != 0 {
+				return c
+			}
+			return strings.Compare(a.ID, b.ID)
+		})
 		for _, m := range models {
 			if !m.Tools {
 				continue

--- a/internal/lab/hostmodels.go
+++ b/internal/lab/hostmodels.go
@@ -1,0 +1,205 @@
+package lab
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The inventories of the host model servers, and the static wiring of the
+// backends model-manager does not front. model-manager manages one backend
+// per instance today; until it is multi-backend (giantswarm/model-manager,
+// agentlab#60), every further entry of platform.modelManager.backends gets
+// its downloaded tool-calling models rendered as lab-labeled ModelConfigs —
+// the shape model-manager itself writes for that backend (Ollama: the native
+// keyless provider; Lemonade: the OpenAI provider on its /api/v1) — refreshed
+// on every `agentlab platform` run and pruned like extraModels entries.
+
+// HostModel is one model a host model server has downloaded.
+type HostModel struct {
+	ID string
+	// Tools: the model supports tool calling — what agents need, since they
+	// send tool schemas with every turn (a model without it fails each turn
+	// with "does not support tools").
+	Tools bool
+}
+
+// The capability names the servers use for tool calling.
+const (
+	ollamaToolsCapability = "tools"
+	lemonadeToolsLabel    = "tool-calling"
+)
+
+// hostModelsFn lists a server's downloaded models; a variable so tests can
+// substitute an inventory.
+var hostModelsFn = hostServerModels
+
+// hostServerModels lists the downloaded models of a backend's server at base
+// and whether each one can call tools.
+func hostServerModels(backend, base string) ([]HostModel, error) {
+	if backend == config.ModelManagerBackendLemonade {
+		return lemonadeModels(base)
+	}
+	return ollamaModels(base)
+}
+
+// ollamaModels reads /api/tags and asks /api/show for each model's
+// capabilities (Ollama reports `tools` per model, not in the tag list).
+func ollamaModels(base string) ([]HostModel, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(base + "/api/tags")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var tags struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := decodeJSONBody(resp, &tags); err != nil {
+		return nil, fmt.Errorf("reading %s/api/tags: %w", base, err)
+	}
+	models := make([]HostModel, 0, len(tags.Models))
+	for _, m := range tags.Models {
+		body, _ := json.Marshal(map[string]string{"model": m.Name})
+		show, err := client.Post(base+"/api/show", "application/json", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		var info struct {
+			Capabilities []string `json:"capabilities"`
+		}
+		err = decodeJSONBody(show, &info)
+		_ = show.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading %s/api/show for %s: %w", base, m.Name, err)
+		}
+		models = append(models, HostModel{ID: m.Name, Tools: slices.Contains(info.Capabilities, ollamaToolsCapability)})
+	}
+	return models, nil
+}
+
+// lemonadeModels reads Lemonade's /api/v1/models — the downloaded models with
+// their labels (the catalog needs ?show_all=true, which this does not ask).
+func lemonadeModels(base string) ([]HostModel, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(base + lemonadeModelsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var list struct {
+		Data []struct {
+			ID         string   `json:"id"`
+			Downloaded bool     `json:"downloaded"`
+			Labels     []string `json:"labels"`
+		} `json:"data"`
+	}
+	if err := decodeJSONBody(resp, &list); err != nil {
+		return nil, fmt.Errorf("reading %s%s: %w", base, lemonadeModelsPath, err)
+	}
+	var models []HostModel
+	for _, m := range list.Data {
+		if !m.Downloaded {
+			continue
+		}
+		models = append(models, HostModel{ID: m.ID, Tools: slices.Contains(m.Labels, lemonadeToolsLabel)})
+	}
+	return models, nil
+}
+
+// hostBackendModelConfigs synthesizes the ModelConfig entries for the
+// backends model-manager does not front: every tool-calling model each
+// further host server has downloaded, as the entry model-manager would write
+// for it. Entries the user already wired by hand (a platform.extraModels
+// entry for the same model on the same host:port, or the same name) are left
+// to that entry. Inert when managed models are off.
+func hostBackendModelConfigs(cfg *config.Config, endpoints map[string]string) ([]config.ExtraModel, error) {
+	if !cfg.ModelManagerEnabled() {
+		return nil, nil
+	}
+	var out []config.ExtraModel
+	for _, b := range cfg.Platform.ModelManager.Secondary() {
+		endpoint := endpoints[b]
+		if endpoint == "" {
+			return nil, fmt.Errorf("no endpoint resolved for backend %s", b)
+		}
+		models, err := hostModelsFn(b, endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("listing %s's models at %s: %w", config.BackendServerName(b), endpoint, err)
+		}
+		for _, m := range models {
+			if !m.Tools {
+				continue
+			}
+			entry := hostModelConfig(b, endpoint, m.ID)
+			if manualEntryCovers(cfg.Platform.ExtraModels, entry) {
+				continue
+			}
+			out = append(out, entry)
+		}
+	}
+	return out, nil
+}
+
+// hostModelConfig is the ModelConfig entry for one model of a host backend,
+// in the shape model-manager writes for that backend.
+func hostModelConfig(backend, endpoint, model string) config.ExtraModel {
+	entry := config.ExtraModel{Name: hostModelConfigName(backend, model), Model: model}
+	if backend == config.ModelManagerBackendLemonade {
+		entry.Provider = config.ProviderOpenAI
+		entry.BaseURL = endpoint + lemonadeAPIBasePath
+	} else {
+		entry.Provider = config.ProviderOllama
+		entry.BaseURL = endpoint
+	}
+	return entry
+}
+
+// manualEntryCovers reports whether a platform.extraModels entry already
+// wires this model on this server (same model id and host:port, whatever the
+// path — Lemonade answers on /v1 and /api/v1 alike) or takes the name.
+func manualEntryCovers(manual []config.ExtraModel, entry config.ExtraModel) bool {
+	for _, m := range manual {
+		if m.Name == entry.Name {
+			return true
+		}
+		if m.Model == entry.Model && urlHost(m.BaseURL) == urlHost(entry.BaseURL) {
+			return true
+		}
+	}
+	return false
+}
+
+func urlHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return u.Host
+}
+
+var nonNameRunRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// hostModelConfigName derives the ModelConfig name for a host backend's model:
+// <backend>-<model id sanitized to lowercase alphanumerics and dashes>, e.g.
+// lemonade-qwen3-it-4b-flm, ollama-qwen3-5-9b. Prefixed so the entries of
+// several servers never collide with each other or with model-manager's own
+// (which uses the bare sanitized name).
+func hostModelConfigName(backend, model string) string {
+	s := nonNameRunRe.ReplaceAllString(strings.ToLower(model), "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "model"
+	}
+	return backend + "-" + s
+}

--- a/internal/lab/modelmanager.go
+++ b/internal/lab/modelmanager.go
@@ -12,14 +12,19 @@ import (
 )
 
 // The model-manager component (platform.modelManager in agentlab.yaml): the
-// umbrella's `model-manager` dependency with the Ollama backend, proxying the
-// Ollama that runs on the lab host. Pods reach the host only through the kind
-// docker network's gateway — the same address the README documents for
-// extraModels — so the endpoint is detected from `docker network inspect
-// kind` rather than asked for. Everything that can go wrong is host-side
-// plumbing (bind address, firewall), which preflightOllama turns into an
-// early, actionable failure instead of a model-manager pod that reports an
-// unhealthy backend after a ten-minute install.
+// umbrella's `model-manager` dependency in front of the model servers that
+// run on the lab host — an Ollama (backend ollama), a Lemonade Server
+// (backend lemonade: FastFlowLM on AMD Ryzen AI NPUs, llama.cpp on GPU/CPU).
+// model-manager fronts ONE backend per instance today, the first of
+// platform.modelManager.backends; the further ones are wired statically
+// (hostmodels.go) until it is multi-backend. Pods reach the host only through
+// the kind docker network's gateway — the same address the README documents
+// for extraModels — so every endpoint is detected from `docker network
+// inspect kind` plus the server's default port rather than asked for.
+// Everything that can go wrong is host-side plumbing (bind address,
+// firewall), which preflightHostServer turns into an early, actionable
+// failure instead of a model-manager pod that reports an unhealthy backend
+// after a ten-minute install.
 
 // modelManagerMCPServer is the MCPServer CR name the model-manager chart
 // registers with muster (model-manager.muster.mcpServer.name, the chart
@@ -29,21 +34,38 @@ const modelManagerMCPServer = "model-manager"
 // kindDockerNetwork is the docker network kind creates its nodes on.
 const kindDockerNetwork = "kind"
 
-// ollamaProbeImage runs the in-cluster reachability probe: busybox wget in
-// the alpine image the umbrella already ships elsewhere (small, present in
-// the host cache after the first run, side-loaded before the probe pod).
-const ollamaProbeImage = "gsoci.azurecr.io/giantswarm/alpine:3.22.1"
+// probeImage runs the in-cluster reachability probe: busybox wget in the
+// alpine image the umbrella already ships elsewhere (small, present in the
+// host cache after the first run, side-loaded before the probe pod).
+const probeImage = "gsoci.azurecr.io/giantswarm/alpine:3.22.1"
 
-// ollamaVersionRe matches the {"version":"..."} document /api/version answers.
-var ollamaVersionRe = regexp.MustCompile(`\{\s*"version"\s*:\s*"[^"]*"\s*\}`)
+// The version-answering paths of the servers: Ollama's whole document is
+// {"version":"..."}, Lemonade's health document carries a version field.
+const (
+	ollamaVersionPath   = "/api/version"
+	lemonadeHealthPath  = "/api/v1/health"
+	lemonadeModelsPath  = "/api/v1/models"
+	lemonadeAPIBasePath = "/api/v1"
+)
 
-// DetectHostOllama probes the host's own Ollama on loopback and reports its
-// version. It answers the configure-time question "is there an Ollama on
-// this machine at all?" — reachability from pods (bind address, firewall) is
-// preflightOllama's job at platform time.
-func DetectHostOllama() (version string, ok bool) {
+// versionFieldRe matches the "version":"..." field both servers answer with.
+var versionFieldRe = regexp.MustCompile(`"version"\s*:\s*"[^"]*"`)
+
+// healthPath is the version-answering path of a backend's server.
+func healthPath(backend string) string {
+	if backend == config.ModelManagerBackendLemonade {
+		return lemonadeHealthPath
+	}
+	return ollamaVersionPath
+}
+
+// detectHostServer asks a model server at base for its version — the
+// configure-time question "is there one on this machine at all?" —
+// reachability from pods (bind address, firewall) is preflightHostServer's
+// job at platform time.
+func detectHostServer(backend, base string) (version string, ok bool) {
 	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/api/version", config.OllamaPort))
+	resp, err := client.Get(base + healthPath(backend))
 	if err != nil {
 		return "", false
 	}
@@ -54,10 +76,15 @@ func DetectHostOllama() (version string, ok bool) {
 	var v struct {
 		Version string `json:"version"`
 	}
-	if err := decodeJSONBody(resp, &v); err != nil {
+	if err := decodeJSONBody(resp, &v); err != nil || v.Version == "" {
 		return "", false
 	}
 	return v.Version, true
+}
+
+// loopbackBase is where a server on this machine answers on its default port.
+func loopbackBase(backend string) string {
+	return fmt.Sprintf("http://127.0.0.1:%d", config.BackendPort(backend))
 }
 
 // kindGatewayIP returns the IPv4 gateway of the kind docker network — the
@@ -77,75 +104,117 @@ func kindGatewayIP() (string, error) {
 	return "", fmt.Errorf("docker network %q has no IPv4 gateway", kindDockerNetwork)
 }
 
-// resolveModelManagerEndpoint is the Ollama endpoint model-manager dials: the
-// configured override, else http://<kind gateway>:11434. The kind network
-// exists once the cluster does, so callers that render before a boot get an
-// error they may tolerate (render) or must not (platform).
-func resolveModelManagerEndpoint(cfg *config.Config) (string, error) {
-	if ep := cfg.Platform.ModelManager.Endpoint; ep != "" {
+// resolveBackendEndpoint is the URL model-manager (or an agent pod) dials for
+// a backend: the configured override, else http://<kind gateway>:<the
+// server's default port>. The kind network exists once the cluster does, so
+// callers that render before a boot get an error they may tolerate (render)
+// or must not (platform).
+func resolveBackendEndpoint(cfg *config.Config, backend string) (string, error) {
+	if ep := cfg.Platform.ModelManager.EndpointFor(backend); ep != "" {
 		return strings.TrimSuffix(ep, "/"), nil
 	}
 	gw, err := kindGatewayIP()
 	if err != nil {
-		return "", fmt.Errorf("autodetecting the Ollama endpoint: %w (set platform.modelManager.endpoint to skip the detection)", err)
+		return "", fmt.Errorf("autodetecting the %s endpoint: %w (set platform.modelManager.endpoints.%s to skip the detection)",
+			config.BackendServerName(backend), err, backend)
 	}
-	return fmt.Sprintf("http://%s:%d", gw, config.OllamaPort), nil
+	return fmt.Sprintf("http://%s:%d", gw, config.BackendPort(backend)), nil
 }
 
-// preflightOllama proves host Ollama answers from INSIDE the cluster before
-// the platform install waits ten minutes on a model-manager whose backend is
-// unreachable. A short-lived pod fetches <endpoint>/api/version; the two
-// known host-side failures are spelled out with their fixes: the server
-// bound to 127.0.0.1 (connection refused from the bridge) and a host
-// firewall dropping pod->host traffic on the docker bridge (timeout).
-func preflightOllama(cfg *config.Config, endpoint string) error {
+// resolveBackendEndpoints resolves every configured backend's endpoint.
+func resolveBackendEndpoints(cfg *config.Config) (map[string]string, error) {
+	endpoints := map[string]string{}
+	for _, b := range cfg.Platform.ModelManager.Backends {
+		ep, err := resolveBackendEndpoint(cfg, b)
+		if err != nil {
+			return nil, err
+		}
+		endpoints[b] = ep
+	}
+	return endpoints, nil
+}
+
+// bindFix is the host-side fix for a server listening on loopback only.
+func bindFix(backend string) string {
+	if backend == config.ModelManagerBackendLemonade {
+		return "  - bind Lemonade to every interface, not loopback: `lemonade config set host=0.0.0.0`\n" +
+			"    (host in ~/.config/lemonade/config.json), then restart lemond"
+	}
+	return "  - bind Ollama to every interface, not loopback: OLLAMA_HOST=0.0.0.0 (systemd: an\n" +
+		"    Environment= drop-in on ollama.service), then restart it"
+}
+
+// preflightHostServer proves a host model server answers from INSIDE the
+// cluster before the platform install waits ten minutes on a model-manager
+// whose backend is unreachable (or wires ModelConfigs to a dead endpoint). A
+// short-lived pod fetches the server's version document; the two known
+// host-side failures are spelled out with their fixes: the server bound to
+// 127.0.0.1 (connection refused from the bridge) and a host firewall
+// dropping pod->host traffic on the docker bridge (timeout).
+func preflightHostServer(cfg *config.Config, backend, endpoint string) error {
+	server := config.BackendServerName(backend)
 	// The probe image goes host cache -> node like every lab image, so the
 	// pod never waits on an in-node pull (best-effort: a miss falls back to
 	// the kubelet's pull under the pod-running timeout).
-	sideloadImages(cfg, hostPullImages([]string{ollamaProbeImage}))
-	const pod = "ollama-preflight"
+	sideloadImages(cfg, hostPullImages([]string{probeImage}))
+	pod := backend + "-preflight"
 	// A leftover from an interrupted run would make `kubectl run` refuse.
 	_ = runQuiet("kubectl", "-n", platformNamespace, "delete", "pod", pod, "--ignore-not-found", "--wait=false")
 	out, err := outputAll("kubectl", "-n", platformNamespace, "run", pod,
 		"--rm", "-i", "--quiet", "--restart=Never", "--pod-running-timeout=120s",
-		"--image="+ollamaProbeImage, "--image-pull-policy=IfNotPresent",
-		"--command", "--", "wget", "-qO-", "-T", "5", endpoint+"/api/version")
+		"--image="+probeImage, "--image-pull-policy=IfNotPresent",
+		"--command", "--", "wget", "-qO-", "-T", "5", endpoint+healthPath(backend))
 	if err == nil && strings.Contains(out, `"version"`) {
 		// The combined output also carries kubectl's own attach chatter
 		// ("warning: couldn't attach to pod ..., falling back to logs"), so
-		// pick the JSON document out of it.
+		// pick the version field out of it.
 		version := strings.TrimSpace(out)
-		if m := ollamaVersionRe.FindString(out); m != "" {
+		if m := versionFieldRe.FindString(out); m != "" {
 			version = m
 		}
-		note("host Ollama answers from inside the cluster: %s", version)
+		note("host %s answers from inside the cluster: %s", server, version)
 		return nil
 	}
 	out = strings.TrimSpace(out)
 	reason := "the probe pod could not fetch it"
-	fixes := "  - bind Ollama to every interface, not loopback: OLLAMA_HOST=0.0.0.0 (systemd: an\n" +
-		"    Environment= drop-in on ollama.service), then restart it\n" +
-		"  - allow TCP " + fmt.Sprint(config.OllamaPort) + " from the docker bridge subnets (they fall inside\n" +
+	fixes := bindFix(backend) + "\n" +
+		"  - allow TCP " + fmt.Sprint(config.BackendPort(backend)) + " from the docker bridge subnets (they fall inside\n" +
 		"    172.16.0.0/12) through the host firewall — pod->host traffic arrives on the\n" +
 		"    bridge like any other inbound connection"
 	switch {
 	case strings.Contains(out, "refused"):
-		reason = "connection refused — Ollama is not listening on the bridge address (the usual\n  cause: OLLAMA_HOST left at 127.0.0.1)"
+		reason = fmt.Sprintf("connection refused — %s is not listening on the bridge address (the usual\n  cause: it is bound to 127.0.0.1)", server)
 	case strings.Contains(out, "timed out"), strings.Contains(out, "timeout"):
-		reason = "connection timed out — the host firewall drops pod->host traffic on the docker\n  bridge (the request never reaches Ollama)"
+		reason = "connection timed out — the host firewall drops pod->host traffic on the docker\n  bridge (the request never reaches the server)"
 	}
-	return fmt.Errorf("host Ollama is not reachable from pods at %s: %s.\n"+
+	return fmt.Errorf("host %s is not reachable from pods at %s: %s.\n"+
 		"  Fixes (README, \"Local backends on the lab host\"):\n%s\n"+
-		"  Then re-run `agentlab platform`, or set platform.modelManager.enabled: false.\n"+
-		"  Probe output: %.300s", endpoint, reason, fixes, out)
+		"  Then re-run `agentlab platform`, or drop %s from platform.modelManager.backends\n"+
+		"  (`agentlab configure --defaults` rewrites the list from what answers on this machine).\n"+
+		"  Probe output: %.300s", server, endpoint, reason, fixes, backend, out)
 }
 
-// modelManagerHint is the platform-up summary line for the component.
-func modelManagerHint(cfg *config.Config, endpoint string) string {
+// modelManagerHint is the platform-up summary for managed models: the backend
+// model-manager fronts, and the further host servers wired statically.
+func modelManagerHint(cfg *config.Config, endpoints map[string]string, wired []config.ExtraModel) string {
 	if !cfg.ModelManagerEnabled() {
 		return "  Model manager is disabled (platform.modelManager in agentlab.yaml)."
 	}
-	return fmt.Sprintf("  Model manager: Ollama backend at %s; REST %s/api/v1 (Dex token required),\n"+
+	mm := cfg.Platform.ModelManager
+	primary := mm.Primary()
+	s := fmt.Sprintf("  Model manager: %s backend (%s) at %s; REST %s/api/v1 (Dex token required),\n"+
 		"  MCP tools x_model-manager_* through muster; the portal's Models tab manages the same models.",
-		endpoint, cfg.ModelManagerBaseURL())
+		primary, config.BackendServerName(primary), endpoints[primary], cfg.ModelManagerBaseURL())
+	for _, b := range mm.Secondary() {
+		names := make([]string, 0, len(wired))
+		for _, m := range wired {
+			if strings.HasPrefix(m.Name, b+"-") {
+				names = append(names, m.Name)
+			}
+		}
+		s += fmt.Sprintf("\n  %s at %s: %d tool-calling model(s) wired as ModelConfigs (%s) — statically,\n"+
+			"  model-manager fronts one backend per instance today (agentlab#60).",
+			config.BackendServerName(b), endpoints[b], len(names), strings.Join(names, ", "))
+	}
+	return s
 }

--- a/internal/lab/modelmanager_test.go
+++ b/internal/lab/modelmanager_test.go
@@ -2,9 +2,23 @@ package lab
 
 import "testing"
 
-func TestOllamaVersionRe(t *testing.T) {
-	out := "{\"version\":\"0.33.2\"}warning: couldn't attach to pod/ollama-preflight, falling back to streaming logs"
-	if got := ollamaVersionRe.FindString(out); got != `{"version":"0.33.2"}` {
-		t.Fatalf("got %q", got)
+// The preflight picks the version field out of kubectl's combined output for
+// both servers' documents: Ollama's {"version":...} and Lemonade's health
+// document, where version is one field among many.
+func TestVersionFieldRe(t *testing.T) {
+	cases := map[string]string{
+		"{\"version\":\"0.33.2\"}warning: couldn't attach to pod/ollama-preflight, falling back to streaming logs":      `"version":"0.33.2"`,
+		`{"all_models_loaded":[],"status":"ok","telemetry":{"enabled":false},"version":"11.9.0","websocket_port":9000}`: `"version":"11.9.0"`,
+	}
+	for in, want := range cases {
+		if got := versionFieldRe.FindString(in); got != want {
+			t.Errorf("FindString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHealthPath(t *testing.T) {
+	if healthPath("ollama") != "/api/version" || healthPath("lemonade") != "/api/v1/health" {
+		t.Fatalf("health paths: ollama=%s lemonade=%s", healthPath("ollama"), healthPath("lemonade"))
 	}
 }

--- a/internal/lab/models.go
+++ b/internal/lab/models.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -30,40 +31,82 @@ const modelConfigResource = "modelconfigs.kagent.dev"
 // lab-owned CRs — the chart-rendered default ModelConfig is never touched.
 const managedByAgentlab = "app.kubernetes.io/managed-by=agentlab"
 
-// ensureExtraModels reconciles the platform.extraModels entries into kagent
-// ModelConfig CRs plus their key Secrets, and prunes lab-labeled CRs whose
-// entry is gone from agentlab.yaml. Only called with the agents runtime
-// installed (the ModelConfig CRD ships with the kagent chart).
-func ensureExtraModels(cfg *config.Config) error {
-	_, path, err := renderManifest(cfg, "extra-models.yaml.tmpl")
+// extraModelsTemplate renders the lab-owned ModelConfigs.
+const extraModelsTemplate = "extra-models.yaml.tmpl"
+
+// allExtraModels is everything the lab renders as its own ModelConfigs: the
+// platform.extraModels entries plus the tool-calling models of the host
+// backends model-manager does not front (wired, returned separately for the
+// summary). endpoints may be nil, in which case they are resolved here.
+func allExtraModels(cfg *config.Config, endpoints map[string]string) (all, wired []config.ExtraModel, err error) {
+	manual := cfg.Platform.ExtraModels
+	if cfg.ModelManagerEnabled() && len(cfg.Platform.ModelManager.Secondary()) > 0 {
+		if endpoints == nil {
+			if endpoints, err = resolveBackendEndpoints(cfg); err != nil {
+				return nil, nil, err
+			}
+		}
+		if wired, err = hostBackendModelConfigs(cfg, endpoints); err != nil {
+			return nil, nil, err
+		}
+	}
+	return append(slices.Clone(manual), wired...), wired, nil
+}
+
+// ensureExtraModels reconciles the platform.extraModels entries — and the
+// statically wired models of the host backends model-manager does not front
+// — into kagent ModelConfig CRs plus their key Secrets, and prunes
+// lab-labeled CRs whose entry is gone (from agentlab.yaml, or from the host
+// server). Only called with the agents runtime installed (the ModelConfig
+// CRD ships with the kagent chart). Returns the wired host models for the
+// summary.
+func ensureExtraModels(cfg *config.Config, endpoints map[string]string) ([]config.ExtraModel, error) {
+	models, wired, err := allExtraModels(cfg, endpoints)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	_, path, err := renderManifestWith(cfg, extraModelsTemplate, func(d *tmplData) { d.ExtraModels = models })
+	if err != nil {
+		return nil, err
 	}
 	if len(cfg.Platform.ExtraModels) > 0 {
 		step("Adding extra model configs (%d beyond the default %s)", len(cfg.Platform.ExtraModels), cfg.AIModel)
 	}
+	for _, b := range cfg.Platform.ModelManager.Secondary() {
+		var names []string
+		for _, m := range wired {
+			if strings.HasPrefix(m.Name, b+"-") {
+				names = append(names, m.Name)
+			}
+		}
+		step("Wiring %s's tool-calling models as ModelConfigs (%d; model-manager fronts %s only, agentlab#60)",
+			config.BackendServerName(b), len(names), cfg.Platform.ModelManager.Primary())
+		if len(names) > 0 {
+			note("%s", strings.Join(names, ", "))
+		}
+	}
 	// Secrets before the CRs: the controller hashes the referenced Secret
 	// into the ModelConfig status, so the reference should resolve on the
 	// controller's first look.
-	for _, m := range cfg.Platform.ExtraModels {
+	for _, m := range models {
 		if err := ensureModelKeySecret(m); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	if len(cfg.Platform.ExtraModels) > 0 {
+	if len(models) > 0 {
 		if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	if err := pruneExtraModels(cfg); err != nil {
-		return err
+	if err := pruneExtraModels(models); err != nil {
+		return nil, err
 	}
-	for _, m := range cfg.Platform.ExtraModels {
+	for _, m := range models {
 		if err := waitModelConfigAccepted(m.Name); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return wired, nil
 }
 
 // ensureModelKeySecret creates the model's key Secret from the host env var
@@ -109,24 +152,25 @@ stringData:
 	return nil
 }
 
-// pruneExtraModels deletes lab-labeled ModelConfigs (and their Secrets) whose
-// entry no longer exists in agentlab.yaml, so removing a model from the
-// config is a real removal on the next run.
-func pruneExtraModels(cfg *config.Config) error {
+// pruneExtraModels deletes lab-labeled ModelConfigs (and their Secrets) that
+// are not among the wanted entries any more — removed from agentlab.yaml, or
+// gone from the host server they were wired from — so a removal is a real
+// removal on the next run.
+func pruneExtraModels(want []config.ExtraModel) error {
 	out, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource,
 		"-l", managedByAgentlab, "-o", "jsonpath={.items[*].metadata.name}")
 	if err != nil {
 		return nil // no CRD / no namespace: nothing lab-owned to prune
 	}
-	want := map[string]bool{}
-	for _, m := range cfg.Platform.ExtraModels {
-		want[m.Name] = true
+	keep := map[string]bool{}
+	for _, m := range want {
+		keep[m.Name] = true
 	}
 	for _, name := range strings.Fields(out) {
-		if want[name] {
+		if keep[name] {
 			continue
 		}
-		note("pruning model config %s (removed from %s)", name, config.File)
+		note("pruning model config %s (removed from %s or gone from its host server)", name, config.File)
 		if err := runQuiet("kubectl", "-n", kagentNamespace, "delete", modelConfigResource, name); err != nil {
 			return err
 		}
@@ -139,14 +183,14 @@ func pruneExtraModels(cfg *config.Config) error {
 	return nil
 }
 
-// extraModelsHint names the extra ModelConfigs in the platform-up summary,
+// extraModelsHint names the lab's ModelConfigs in the platform-up summary,
 // e.g. " (+ qwen3-8-27b, gemini-flash)"; empty when there are none.
-func extraModelsHint(cfg *config.Config) string {
-	if len(cfg.Platform.ExtraModels) == 0 {
+func extraModelsHint(models []config.ExtraModel) string {
+	if len(models) == 0 {
 		return ""
 	}
-	names := make([]string, 0, len(cfg.Platform.ExtraModels))
-	for _, m := range cfg.Platform.ExtraModels {
+	names := make([]string, 0, len(models))
+	for _, m := range models {
 		names = append(names, m.Name)
 	}
 	return " (+ " + strings.Join(names, ", ") + ")"

--- a/internal/lab/models_test.go
+++ b/internal/lab/models_test.go
@@ -22,7 +22,7 @@ func TestExtraModelsTemplate(t *testing.T) {
 		{Name: "local-llama", Provider: "Ollama", Model: "llama3.3", BaseURL: "http://192.168.1.10:11434"},
 		{Name: "claude-proxy", Provider: "Anthropic", Model: "claude-haiku-4-5", BaseURL: "https://proxy.example.com"},
 	}
-	raw, err := renderTemplate(cfg, "extra-models.yaml.tmpl")
+	raw, err := renderTemplate(cfg, "extra-models.yaml.tmpl", nil)
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
@@ -58,7 +58,7 @@ func TestExtraModelsTemplate(t *testing.T) {
 	// No extras -> comments only, nothing to apply (the lifecycle skips
 	// kubectl apply on an empty list).
 	cfg.Platform.ExtraModels = nil
-	raw, err = renderTemplate(cfg, "extra-models.yaml.tmpl")
+	raw, err = renderTemplate(cfg, "extra-models.yaml.tmpl", nil)
 	if err != nil {
 		t.Fatalf("render empty: %v", err)
 	}

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -84,8 +84,9 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	if err := api.getJSON("/backend", &backend); err != nil {
 		return err
 	}
-	if backend.Backend != config.ModelManagerBackendOllama || !backend.Healthy {
-		return fmt.Errorf("backend %q healthy=%v, wanted a healthy ollama backend (endpoint %s)", backend.Backend, backend.Healthy, backend.Endpoint)
+	primary := cfg.Platform.ModelManager.Primary()
+	if backend.Backend != primary || !backend.Healthy {
+		return fmt.Errorf("backend %q healthy=%v, wanted a healthy %s backend (endpoint %s)", backend.Backend, backend.Healthy, primary, backend.Endpoint)
 	}
 	caps := make([]string, 0, len(backend.Capabilities))
 	for name, on := range backend.Capabilities {
@@ -94,7 +95,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 		}
 	}
 	slices.Sort(caps)
-	note("backend ollama %s at %s, healthy; capabilities: %s", backend.Version, backend.Endpoint, strings.Join(caps, ", "))
+	note("backend %s %s at %s, healthy; capabilities: %s", primary, backend.Version, backend.Endpoint, strings.Join(caps, ", "))
 	note("wiring: ModelConfigs in %s, autoWire=%v", backend.Wiring.Namespace, backend.Wiring.AutoWire)
 
 	step("Listing models")
@@ -170,14 +171,20 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 		return err
 	}
 	spec, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName,
-		"-o", `jsonpath={.spec.provider} {.spec.model} {.spec.ollama.host} managed-by={.metadata.labels.app\.kubernetes\.io/managed-by}`)
+		"-o", `jsonpath={.spec.provider} {.spec.model} {.spec.ollama.host}{.spec.openAI.baseUrl} managed-by={.metadata.labels.app\.kubernetes\.io/managed-by}`)
 	if err != nil {
 		return err
 	}
-	if !strings.HasPrefix(spec, config.ProviderOllama+" ") {
-		return fmt.Errorf("ModelConfig %s is not the native Ollama provider: %s", mcName, spec)
+	// model-manager writes the native keyless Ollama provider for ollama and
+	// the OpenAI provider on /api/v1 (placeholder key) for lemonade.
+	wantProvider := config.ProviderOllama
+	if primary == config.ModelManagerBackendLemonade {
+		wantProvider = config.ProviderOpenAI
 	}
-	note("ModelConfig %s: %s (keyless native provider)", mcName, strings.TrimSpace(spec))
+	if !strings.HasPrefix(spec, wantProvider+" ") {
+		return fmt.Errorf("ModelConfig %s is not the %s provider model-manager writes for %s: %s", mcName, wantProvider, primary, spec)
+	}
+	note("ModelConfig %s: %s (keyless)", mcName, strings.TrimSpace(spec))
 
 	// The user's identity, not a ServiceAccount: wiring writes a ModelConfig
 	// into the kagent namespace as the caller (downstream OAuth), so a user
@@ -204,7 +211,7 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 		note("%s: HTTP %d, %s", viewer.Email, status, excerpt(string(body), 120))
 	}
 
-	step("Agent turn on %s (kagent Agent, runtime go -> host Ollama)", mcName)
+	step("Agent turn on %s (kagent Agent, runtime go -> host %s)", mcName, config.BackendServerName(primary))
 	reply, err := agentTurn(client, cfg, mcName, "Reply with exactly the word pong and nothing else.")
 	if err != nil {
 		return err
@@ -270,18 +277,19 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 		}
 	}
 	note("ModelConfig %s is gone", mcName)
-	endpoint, err := resolveModelManagerEndpoint(cfg)
+	endpoint, err := resolveBackendEndpoint(cfg, primary)
 	if err != nil {
 		return err
 	}
-	tags, err := ollamaTags(endpoint)
+	server := config.BackendServerName(primary)
+	remaining, err := hostServerModels(primary, endpoint)
 	if err != nil {
-		return fmt.Errorf("reading the host Ollama's tags at %s: %w", endpoint, err)
+		return fmt.Errorf("reading the host %s's models at %s: %w", server, endpoint, err)
 	}
-	if slices.Contains(tags, model) {
-		return fmt.Errorf("host Ollama still has %s after the delete", model)
+	if slices.ContainsFunc(remaining, func(m HostModel) bool { return m.ID == model }) {
+		return fmt.Errorf("host %s still has %s after the delete", server, model)
 	}
-	note("host Ollama at %s no longer has it (%d models left)", endpoint, len(tags))
+	note("host %s at %s no longer has it (%d models left)", server, endpoint, len(remaining))
 	text, err = session.callServerTool(toolPrefix+"list_models", nil)
 	if err != nil {
 		return err
@@ -291,9 +299,41 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 	}
 	note("%slist_models agrees", toolPrefix)
 
+	// The backends model-manager does not front are wired statically by the
+	// platform run (hostmodels.go): prove one of those ModelConfigs answers
+	// an agent turn too, so "discovered" means "usable by agents".
+	wiredProof := ""
+	if secondary := cfg.Platform.ModelManager.Secondary(); len(secondary) > 0 {
+		endpoints, err := resolveBackendEndpoints(cfg)
+		if err != nil {
+			return err
+		}
+		wired, err := hostBackendModelConfigs(cfg, endpoints)
+		if err != nil {
+			return err
+		}
+		if len(wired) == 0 {
+			note("no tool-calling model downloaded on %s — nothing to prove for the static wiring", strings.Join(secondary, ", "))
+		} else {
+			w := wired[0]
+			step("Agent turn on %s (%s %s, wired statically — model-manager fronts %s only)", w.Name, config.BackendServerName(secondary[0]), w.Model, primary)
+			if err := waitModelConfigAccepted(w.Name); err != nil {
+				return err
+			}
+			reply, err := agentTurn(client, cfg, w.Name, "Reply with exactly the word pong and nothing else.")
+			if err != nil {
+				return err
+			}
+			note("agent replied: %q", excerpt(reply, 120))
+			wiredProof = fmt.Sprintf("PASS: %s's %s, wired statically as ModelConfig %s, answered an agent turn (%d wired)\n",
+				config.BackendServerName(secondary[0]), w.Model, w.Name, len(wired))
+		}
+	}
+
 	fmt.Println()
 	fmt.Println("PASS: no token -> 401 at the gateway; Dex token -> model-manager REST through agentgateway")
-	fmt.Printf("PASS: list -> pull %s (progress) -> ModelConfig %s (Ollama provider) Accepted -> agent turn -> unload -> delete\n", model, mcName)
+	fmt.Printf("PASS: list -> pull %s (progress) -> ModelConfig %s (%s provider) Accepted -> agent turn -> unload -> delete\n", model, mcName, wantProvider)
+	fmt.Print(wiredProof)
 	fmt.Printf("PASS: muster aggregates x_%s_* and calls them (get_model, list_models)\n", modelManagerMCPServer)
 	fmt.Printf("PASS: the caller's identity — job requestedBy=%s; a viewer's wire is Forbidden by the apiserver (user RBAC, not the ServiceAccount's)\n", user.Email)
 	return nil
@@ -536,30 +576,6 @@ func collectStrings(node any, key string) []string {
 	}
 	walk(node)
 	return out
-}
-
-// ollamaTags lists the models the host Ollama has (its /api/tags), dialed
-// directly from the lab host — the ground truth the delete is checked against.
-func ollamaTags(endpoint string) ([]string, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(endpoint + "/api/tags")
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	var tags struct {
-		Models []struct {
-			Name string `json:"name"`
-		} `json:"models"`
-	}
-	if err := decodeJSONBody(resp, &tags); err != nil {
-		return nil, err
-	}
-	names := make([]string, 0, len(tags.Models))
-	for _, m := range tags.Models {
-		names = append(names, m.Name)
-	}
-	return names, nil
 }
 
 func decodeJSONBody(resp *http.Response, out any) error {

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -325,6 +325,12 @@ func ModelsTest(cfg *config.Config, email, model string) error {
 				return err
 			}
 			note("agent replied: %q", excerpt(reply, 120))
+			// Leave the host as found: the turn loaded the model there.
+			if err := unloadHostModel(secondary[0], endpoints[secondary[0]], w.Model); err != nil {
+				note("could not unload %s from the host %s: %v", w.Model, config.BackendServerName(secondary[0]), err)
+			} else {
+				note("unloaded %s from the host %s", w.Model, config.BackendServerName(secondary[0]))
+			}
 			wiredProof = fmt.Sprintf("PASS: %s's %s, wired statically as ModelConfig %s, answered an agent turn (%d wired)\n",
 				config.BackendServerName(secondary[0]), w.Model, w.Name, len(wired))
 		}

--- a/internal/lab/oauthfixture_test.go
+++ b/internal/lab/oauthfixture_test.go
@@ -13,7 +13,7 @@ import (
 // exchange — either would make core_auth_login refuse the manual login), and
 // its purpose spelled out on the object.
 func TestOAuthFixtureTemplate(t *testing.T) {
-	raw, err := renderTemplate(config.Default(), "oauth-fixture.yaml.tmpl")
+	raw, err := renderTemplate(config.Default(), "oauth-fixture.yaml.tmpl", nil)
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestOAuthFixtureTemplate(t *testing.T) {
 // public URL every sign-in challenge must carry.
 func TestPlatformValuesEnableOAuthClient(t *testing.T) {
 	cfg := config.Default()
-	raw, err := renderTemplate(cfg, "agent-platform-values.yaml.tmpl")
+	raw, err := renderTemplate(cfg, "agent-platform-values.yaml.tmpl", nil)
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -276,20 +276,25 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		}
 	}
 
-	// Managed models: the Ollama endpoint is detected from the kind docker
-	// network and proven reachable from inside the cluster BEFORE the
-	// install, so a host-side misconfiguration (bind address, firewall) fails
-	// here with its fix instead of after helm's ten-minute wait.
-	modelManagerEndpoint := ""
+	// Managed models: every host model server's endpoint is detected from
+	// the kind docker network and proven reachable from inside the cluster
+	// BEFORE the install, so a host-side misconfiguration (bind address,
+	// firewall) fails here with its fix instead of after helm's ten-minute
+	// wait — for the backend model-manager fronts and for the ones wired
+	// statically alike.
+	var backendEndpoints map[string]string
+	var wiredModels []config.ExtraModel
 	if cfg.ModelManagerEnabled() {
-		endpoint, err := resolveModelManagerEndpoint(cfg)
+		endpoints, err := resolveBackendEndpoints(cfg)
 		if err != nil {
 			return err
 		}
-		modelManagerEndpoint = endpoint
-		step("Checking host Ollama is reachable from pods (%s)", endpoint)
-		if err := preflightOllama(cfg, endpoint); err != nil {
-			return err
+		backendEndpoints = endpoints
+		for _, b := range cfg.Platform.ModelManager.Backends {
+			step("Checking host %s is reachable from pods (%s)", config.BackendServerName(b), endpoints[b])
+			if err := preflightHostServer(cfg, b, endpoints[b]); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -409,12 +414,15 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 			return err
 		}
 		// The extra ModelConfigs from platform.extraModels (self-hosted
-		// endpoints, OpenRouter, Gemini, ...) — after the install for the same
-		// reason as the Secret above: the chart owns the kagent namespace and
-		// the ModelConfig CRD.
-		if err := ensureExtraModels(cfg); err != nil {
+		// endpoints, OpenRouter, Gemini, ...) and the statically wired models
+		// of the host backends model-manager does not front — after the
+		// install for the same reason as the Secret above: the chart owns the
+		// kagent namespace and the ModelConfig CRD.
+		wired, err := ensureExtraModels(cfg, backendEndpoints)
+		if err != nil {
 			return err
 		}
+		wiredModels = wired
 		// Agent pods need the golang-adk runtime image at kagent's own tag,
 		// which upstream has been observed not to publish (HACKS.md U8).
 		step("Ensuring the agents' ADK runtime images are on the node")
@@ -484,7 +492,7 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		})
 		if uiUp {
 			agentsHint = fmt.Sprintf("  Agents (kagent) run with model %s%s; UI: %s",
-				cfg.AIModel, extraModelsHint(cfg), cfg.KagentUIBaseURL())
+				cfg.AIModel, extraModelsHint(append(slices.Clone(cfg.Platform.ExtraModels), wiredModels...)), cfg.KagentUIBaseURL())
 		} else {
 			agentsHint = fmt.Sprintf(`  Agents (kagent) run with model %s, but the UI is NOT reachable on %s.
   If 'docker port %s' shows no %d line, this cluster
@@ -510,7 +518,7 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 %s
 %s
 %s
-%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, modelManagerHint(cfg, modelManagerEndpoint), obsHint, tryItBlock(cfg))
+%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, modelManagerHint(cfg, backendEndpoints, wiredModels), obsHint, tryItBlock(cfg))
 	// Everything the platform runs is in the node now — record it so the next
 	// boot side-loads instead of pulling.
 	snapshotPreloadImages(cfg)

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -48,12 +48,19 @@ type tmplData struct {
 	AllGroups           []string
 	KubernetesClientSecret,
 	AgentPlatformClientSecret string
-	// ModelManagerEnabled mirrors cfg.ModelManagerEnabled(); the endpoint is
-	// the Ollama URL model-manager dials (autodetected from the kind docker
-	// network — empty when the cluster does not exist yet, which only a
-	// pre-boot `agentlab render` sees; platformUp resolves it strictly).
+	// ModelManagerEnabled mirrors cfg.ModelManagerEnabled(); the backend is
+	// the first of platform.modelManager.backends and the endpoint the URL
+	// model-manager dials for it (autodetected from the kind docker network
+	// — empty when the cluster does not exist yet, which only a pre-boot
+	// `agentlab render` sees; platformUp resolves it strictly).
 	ModelManagerEnabled  bool
+	ModelManagerBackend  string
 	ModelManagerEndpoint string
+	// ExtraModels is what extra-models.yaml.tmpl renders: the
+	// platform.extraModels entries, plus — when the platform run computes
+	// them — the tool-calling models of the host backends model-manager does
+	// not front (hostmodels.go).
+	ExtraModels []config.ExtraModel
 	// The per-server OAuth sign-in fixture (oauthfixture.go): the MCPServer
 	// name the proofs sign in to and the protected endpoint it points at.
 	OAuthFixtureServer string
@@ -67,7 +74,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 	}
 	endpoint := ""
 	if cfg.ModelManagerEnabled() {
-		if endpoint, err = resolveModelManagerEndpoint(cfg); err != nil {
+		if endpoint, err = resolveBackendEndpoint(cfg, cfg.Platform.ModelManager.Primary()); err != nil {
 			note("model-manager endpoint left empty in the render: %v", err)
 			endpoint = ""
 		}
@@ -75,7 +82,9 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 	return &tmplData{
 		Config:                    cfg,
 		ModelManagerEnabled:       cfg.ModelManagerEnabled(),
+		ModelManagerBackend:       cfg.Platform.ModelManager.Primary(),
 		ModelManagerEndpoint:      endpoint,
+		ExtraModels:               cfg.Platform.ExtraModels,
 		OAuthFixtureServer:        oauthFixtureServer,
 		OAuthFixtureURL:           oauthFixtureURL,
 		CertsDir:                  certsDir,
@@ -121,11 +130,16 @@ var tmplFuncs = template.FuncMap{
 	},
 }
 
-// renderTemplate renders one embedded template with the config.
-func renderTemplate(cfg *config.Config, name string) ([]byte, error) {
+// renderTemplate renders one embedded template with the config; mutate, when
+// given, adjusts the template data first (the platform run hands
+// extra-models.yaml.tmpl the statically wired host models this way).
+func renderTemplate(cfg *config.Config, name string, mutate func(*tmplData)) ([]byte, error) {
 	data, err := newTmplData(cfg)
 	if err != nil {
 		return nil, err
+	}
+	if mutate != nil {
+		mutate(data)
 	}
 	t, err := template.New(name).Funcs(tmplFuncs).Option("missingkey=error").
 		ParseFS(templatesFS, "templates/"+name)
@@ -171,11 +185,16 @@ var manifests = map[string]struct {
 // exactly when config or certs change and an unchanged re-apply is a pure
 // no-op.
 func renderManifest(cfg *config.Config, tmplName string) ([]byte, string, error) {
+	return renderManifestWith(cfg, tmplName, nil)
+}
+
+// renderManifestWith is renderManifest with a template-data mutator.
+func renderManifestWith(cfg *config.Config, tmplName string, mutate func(*tmplData)) ([]byte, string, error) {
 	spec, ok := manifests[tmplName]
 	if !ok {
 		return nil, "", fmt.Errorf("template %s is not in the manifests table", tmplName)
 	}
-	content, err := renderTemplate(cfg, tmplName)
+	content, err := renderTemplate(cfg, tmplName, mutate)
 	if err != nil {
 		return nil, "", err
 	}
@@ -204,12 +223,24 @@ func renderManifest(cfg *config.Config, tmplName string) ([]byte, string, error)
 
 // RenderAll renders every manifest into state/ for inspection. The stamped
 // manifest (dex) needs the certs, so they are generated first if missing.
+// The extra models include the statically wired host models when the host
+// servers answer (best effort: the platform run is where a failure counts).
 func RenderAll(cfg *config.Config) error {
 	if err := GenCerts(cfg.Platform.Domain, false); err != nil {
 		return err
 	}
+	extraModels := cfg.Platform.ExtraModels
+	if models, _, err := allExtraModels(cfg, nil); err == nil {
+		extraModels = models
+	} else {
+		note("extra-models.yaml rendered without the host backends' models: %v", err)
+	}
 	for _, tmpl := range slices.Sorted(maps.Keys(manifests)) {
-		if _, _, err := renderManifest(cfg, tmpl); err != nil {
+		var mutate func(*tmplData)
+		if tmpl == extraModelsTemplate {
+			mutate = func(d *tmplData) { d.ExtraModels = extraModels }
+		}
+		if _, _, err := renderManifestWith(cfg, tmpl, mutate); err != nil {
 			return err
 		}
 	}

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -318,16 +318,19 @@ agent-manager:
 {{- if .ModelManagerEnabled }}
 # The model-manager chart's own values (the umbrella pins the Service name,
 # the kagent namespace, the muster registration and — since the identity
-# change — OAuth against global.identity in its contract). The Ollama backend
-# dials the host through the kind docker network's gateway — autodetected by
-# `agentlab platform` (platform.modelManager.endpoint overrides). Agent pods
-# dial the same address, so agentHost stays empty. Same audience story as
+# change — OAuth against global.identity in its contract). The backend is the
+# first of platform.modelManager.backends (an Ollama, or a Lemonade Server);
+# it dials the host through the kind docker network's gateway — autodetected
+# by `agentlab platform` (platform.modelManager.endpoints.<backend>
+# overrides). Agent pods dial the same address, so agentHost stays empty.
+# Further backends are wired statically (extra-models.yaml.tmpl) until
+# model-manager is multi-backend. Same audience story as
 # mcp-kubernetes above: the forwarded token must carry the `kubernetes`
 # audience for model-manager's downstream OAuth (the ModelConfigs it writes
 # as the caller) to pass the kind apiserver.
 model-manager:
-  backend: ollama
-  ollama:
+  backend: {{ .ModelManagerBackend }}
+  {{ .ModelManagerBackend }}:
     endpoint: {{ .ModelManagerEndpoint | printf "%q" }}
   muster:
     mcpServer:

--- a/internal/lab/templates/extra-models.yaml.tmpl
+++ b/internal/lab/templates/extra-models.yaml.tmpl
@@ -1,5 +1,8 @@
 # Extra kagent ModelConfigs beyond the chart-rendered default: one CR per
-# platform.extraModels entry in agentlab.yaml. Key material never renders
+# platform.extraModels entry in agentlab.yaml, plus one per downloaded
+# tool-calling model of every host model server model-manager does not front
+# (platform.modelManager.backends beyond the first — wired statically until
+# model-manager is multi-backend). Key material never renders
 # here — each CR references the Secret kagent-<name>, which `agentlab
 # platform` creates from the entry's apiKeyEnv on the host (or with a
 # placeholder for keyless endpoints: the kagent ADK runtime requires the
@@ -7,7 +10,7 @@
 # The managed-by label scopes pruning: entries removed from agentlab.yaml
 # are deleted on the next run; the chart's default ModelConfig is never
 # touched.
-{{- range .Platform.ExtraModels }}
+{{- range .ExtraModels }}
 ---
 apiVersion: kagent.dev/v1alpha2
 kind: ModelConfig

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -118,9 +119,8 @@ func loadOrCreateConfig() (*config.Config, error) {
 	}
 	fmt.Printf("No %s yet — let's create one.\n\n", config.File)
 	cfg = config.Default()
-	reportPortChanges(cfg.ChooseFreePorts())
-	detectModelManager(cfg)
-	if err := forms.Run(cfg, accessibleMode()); err != nil {
+	disc := discoverInto(cfg, nil, nil)
+	if err := forms.Run(cfg, accessibleMode(), forms.Hints{ModelServers: disc.ModelServersHint()}); err != nil {
 		return nil, err
 	}
 	if err := cfg.Save(); err != nil {
@@ -130,33 +130,97 @@ func loadOrCreateConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-// reportPortChanges tells the user which default ports were already occupied
-// on this machine and what the fresh configuration uses instead. The form (or
-// the saved file) shows the adjusted numbers, but only this message explains
-// why they differ from the documented defaults.
+// discoverInto probes this machine (lab.Discover), prints what it found, and
+// applies it to cfg — on EVERY `agentlab configure` run, so agentlab.yaml
+// follows the host: the ports move off foreign listeners while no cluster
+// holds them (an existing cluster's mappings are fixed, so conflicts are
+// reported instead), and platform.modelManager.backends becomes the host
+// model servers that answer (pins from the --model-manager flags win).
+// Reachability from pods (bind address, firewall) is checked at platform
+// time, with the fixes.
+func discoverInto(cfg *config.Config, pinEnabled *bool, pinBackends []string) *lab.Discovery {
+	disc := lab.Discover(cfg)
+	fmt.Print(disc.Report(cfg))
+	fmt.Println()
+	applyPorts(cfg, disc)
+	before := cfg.Platform.ModelManager
+	cfg.Platform.ModelManager.ApplyDiscovered(disc.Backends(), cfg.Platform.Agents, pinEnabled, pinBackends)
+	reportModelManager(before, cfg.Platform.ModelManager, disc, cfg.Platform.Agents)
+	return disc
+}
+
+// applyPorts moves the configuration's host ports off foreign listeners when
+// no kind node of this configuration exists (fresh, or after `agentlab
+// down`); with the cluster in place its port mappings are fixed at node
+// creation, so a foreign listener on one of them is reported, not renumbered
+// around — the lab's own published ports never count as occupied.
+func applyPorts(cfg *config.Config, disc *lab.Discovery) {
+	if !disc.ClusterExists {
+		reportPortChanges(cfg.ChooseFreePorts(disc.ClusterPorts))
+		return
+	}
+	conflicts := cfg.PortConflicts(disc.ClusterPorts)
+	if len(conflicts) == 0 {
+		return
+	}
+	fmt.Println("Ports of the existing cluster are held by other processes on this machine:")
+	for _, c := range conflicts {
+		fmt.Printf("  %s\n", c)
+	}
+	fmt.Println("  The kind node cannot bind them while they are taken. Free the port, or `agentlab down`,")
+	fmt.Println("  re-run `agentlab configure` (which then picks free ones) and `agentlab up`.")
+	fmt.Println()
+}
+
+// reportPortChanges tells the user which ports were already occupied on this
+// machine and what the configuration uses instead. The form (or the saved
+// file) shows the adjusted numbers, but only this message explains why they
+// differ from the documented defaults.
 func reportPortChanges(changes []config.PortChange) {
 	if len(changes) == 0 {
 		return
 	}
-	fmt.Println("Some default ports are already in use on this machine; picked free ones:")
+	fmt.Println("Some ports are already in use on this machine; picked free ones:")
 	for _, ch := range changes {
 		fmt.Printf("  %s\n", ch)
 	}
 	fmt.Println()
 }
 
-// detectModelManager turns managed models on for a FRESH configuration when
-// an Ollama answers on this machine: the lab then installs the umbrella's
-// model-manager component with the Ollama backend. Reachability from pods
-// (bind address, firewall) is checked at platform time, with the fixes.
-func detectModelManager(cfg *config.Config) {
-	version, ok := lab.DetectHostOllama()
-	if !ok {
+// reportModelManager says what the discovery did to platform.modelManager.
+func reportModelManager(before, after config.ModelManager, disc *lab.Discovery, agents bool) {
+	var lines []string
+	if !slices.Equal(before.Backends, after.Backends) {
+		lines = append(lines, fmt.Sprintf("platform.modelManager.backends: %s -> %s", listOrNone(before.Backends), listOrNone(after.Backends)))
+	}
+	if before.Enabled != after.Enabled {
+		reason := "a host model server answers"
+		switch {
+		case !after.Enabled && !agents:
+			reason = "the agents runtime is off, and model-manager wires models into it"
+		case !after.Enabled:
+			reason = "no host model server answers on this machine"
+		}
+		lines = append(lines, fmt.Sprintf("platform.modelManager.enabled: %v -> %v (%s)", before.Enabled, after.Enabled, reason))
+	}
+	if len(lines) == 0 {
 		return
 	}
-	cfg.Platform.ModelManager.Enabled = true
-	fmt.Printf("Found Ollama %s on this machine: managed models (model-manager, Ollama backend) enabled.\n", version)
-	fmt.Printf("Turn it off with `agentlab configure --defaults --model-manager=false`.\n\n")
+	fmt.Println("Applied to the configuration:")
+	for _, l := range lines {
+		fmt.Printf("  %s\n", l)
+	}
+	if len(disc.Servers) > 0 && !after.Enabled && agents {
+		fmt.Println("  (managed models pinned off — `agentlab configure --defaults --model-manager` turns them on)")
+	}
+	fmt.Println()
+}
+
+func listOrNone(items []string) string {
+	if len(items) == 0 {
+		return "(none)"
+	}
+	return "[" + strings.Join(items, ", ") + "]"
 }
 
 // accessibleMode switches huh to its prompt-per-question accessible mode;
@@ -168,46 +232,51 @@ func accessibleMode() bool {
 func configureCmd() *cobra.Command {
 	var defaults, accessible bool
 	var platform, agents, observability, backstage, modelManager bool
+	var modelManagerBackends []string
 	cmd := &cobra.Command{
 		Use:   "configure",
-		Short: "Ask for the lab configuration interactively and save agentlab.yaml",
+		Short: "Discover this machine, then ask for the lab configuration (or keep it with --defaults) and save agentlab.yaml",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.Load()
 			if errors.Is(err, os.ErrNotExist) {
-				// Only a FRESH config gets its ports moved off occupied
-				// defaults: an existing agentlab.yaml describes a cluster
-				// whose kind mappings are already fixed (and would count as
-				// "occupied" themselves while the lab runs). Same for the
-				// model-manager detection: an existing file keeps its choice.
 				cfg = config.Default()
-				reportPortChanges(cfg.ChooseFreePorts())
-				detectModelManager(cfg)
 			} else if err != nil {
 				return err
 			}
+			// The component flags first: what the discovery applies depends
+			// on them (managed models need the agents runtime).
+			if cmd.Flags().Changed("platform") {
+				cfg.Platform.Enabled = platform
+			}
+			if cmd.Flags().Changed("agents") {
+				cfg.Platform.Agents = agents
+			}
+			if cmd.Flags().Changed("observability") {
+				cfg.Platform.Observability = observability
+			}
+			if cmd.Flags().Changed("backstage") {
+				cfg.Backstage.Enabled = backstage
+				cfg.Normalize() // backstage implies the platform
+			}
+			var pinEnabled *bool
+			if cmd.Flags().Changed("model-manager") {
+				pinEnabled = &modelManager
+			}
+			var pinBackends []string
+			if cmd.Flags().Changed("model-manager-backends") {
+				pinBackends = modelManagerBackends
+			}
+			// Every run discovers the machine — an existing agentlab.yaml
+			// follows the host too: a server that appeared is added, one that
+			// is gone drops out, ports move while no cluster holds them.
+			disc := discoverInto(cfg, pinEnabled, pinBackends)
 			if defaults {
-				if cmd.Flags().Changed("platform") {
-					cfg.Platform.Enabled = platform
-				}
-				if cmd.Flags().Changed("agents") {
-					cfg.Platform.Agents = agents
-				}
-				if cmd.Flags().Changed("observability") {
-					cfg.Platform.Observability = observability
-				}
-				if cmd.Flags().Changed("model-manager") {
-					cfg.Platform.ModelManager.Enabled = modelManager
-				}
-				if cmd.Flags().Changed("backstage") {
-					cfg.Backstage.Enabled = backstage
-					cfg.Normalize() // backstage implies the platform
-				}
 				if err := cfg.Validate(); err != nil {
 					return err
 				}
 			} else {
-				if err := forms.Run(cfg, accessible || accessibleMode()); err != nil {
+				if err := forms.Run(cfg, accessible || accessibleMode(), forms.Hints{ModelServers: disc.ModelServersHint()}); err != nil {
 					return err
 				}
 			}
@@ -224,24 +293,37 @@ func configureCmd() *cobra.Command {
 				fmt.Printf("  extra model %s (%s %s)\n", m.Name, m.Provider, m.Model)
 			}
 			if cfg.ModelManagerEnabled() {
-				endpoint := cfg.Platform.ModelManager.Endpoint
-				if endpoint == "" {
-					endpoint = "autodetected from the kind docker network at platform time"
+				mm := cfg.Platform.ModelManager
+				primary := mm.Primary()
+				fmt.Printf("  models     model-manager fronts the host %s (%s backend, %s)\n",
+					config.BackendServerName(primary), primary, endpointNote(mm, primary))
+				for _, b := range mm.Secondary() {
+					fmt.Printf("             %s (%s): tool-calling models wired as ModelConfigs at platform time — statically, model-manager fronts one backend per instance today\n",
+						config.BackendServerName(b), endpointNote(mm, b))
 				}
-				fmt.Printf("  models     managed by model-manager (%s backend, %s)\n", cfg.Platform.ModelManager.Backend, endpoint)
 			}
 			fmt.Println("\nNext: agentlab up")
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&defaults, "defaults", false, "skip the form; keep current values (or the canonical defaults)")
-	cmd.Flags().BoolVar(&platform, "platform", false, "with --defaults: enable/disable the agent platform")
-	cmd.Flags().BoolVar(&agents, "agents", false, "with --defaults: enable/disable the agents runtime (kagent, part of the platform install)")
-	cmd.Flags().BoolVar(&observability, "observability", false, "with --defaults: enable/disable the observability stack (Prometheus + mcp-prometheus)")
-	cmd.Flags().BoolVar(&backstage, "backstage", false, "with --defaults: enable/disable Backstage (implies the platform)")
-	cmd.Flags().BoolVar(&modelManager, "model-manager", false, "with --defaults: enable/disable managed models (the model-manager component with the host Ollama; needs agents)")
+	cmd.Flags().BoolVar(&defaults, "defaults", false, "skip the form; keep current values (or the canonical defaults) plus what the discovery finds")
+	cmd.Flags().BoolVar(&platform, "platform", false, "enable/disable the agent platform")
+	cmd.Flags().BoolVar(&agents, "agents", false, "enable/disable the agents runtime (kagent, part of the platform install)")
+	cmd.Flags().BoolVar(&observability, "observability", false, "enable/disable the observability stack (Prometheus + mcp-prometheus)")
+	cmd.Flags().BoolVar(&backstage, "backstage", false, "enable/disable Backstage (implies the platform)")
+	cmd.Flags().BoolVar(&modelManager, "model-manager", false, "pin managed models on/off instead of following the host model servers the discovery finds (needs agents)")
+	cmd.Flags().StringSliceVar(&modelManagerBackends, "model-manager-backends", nil, "pin the host model servers, in order (ollama, lemonade; the first is model-manager's backend) instead of the ones the discovery finds")
 	cmd.Flags().BoolVar(&accessible, "accessible", false, "prompt-per-question form mode (for screen readers and plain terminals)")
 	return cmd
+}
+
+// endpointNote says where a backend is dialed: the configured override or
+// the autodetection.
+func endpointNote(mm config.ModelManager, backend string) string {
+	if ep := mm.EndpointFor(backend); ep != "" {
+		return ep
+	}
+	return fmt.Sprintf("autodetected as http://<kind docker gateway>:%d at platform time", config.BackendPort(backend))
 }
 
 func loginCmd() *cobra.Command {


### PR DESCRIPTION
Part of #60 (the `platform.modelManager.backends` shape and the per-backend detection; model-manager fronting every backend at once follows the multi-backend model-manager).

## What

`agentlab configure` (with or without `--defaults`) now **discovers this machine on every run** — a fresh configuration and an existing `agentlab.yaml` alike — and prints what it found before it asks or writes anything:

```
Discovering this machine:
  tools             docker 29.7.2, kind v0.32.0, kubectl v1.36.4, helm v4.2.2
  cluster           kind "agentlab" exists — its port mappings are fixed at node creation (`agentlab down && agentlab up` to change them)
  Ollama            0.33.2 on :11434 — listens on the kind gateway 172.21.0.1: yes; 10 downloaded, 4 tool-calling
  Lemonade Server   11.9.0 on :13305 — listens on the kind gateway 172.21.0.1: yes; 4 downloaded, 3 tool-calling
  Anthropic key     $ANTHROPIC_API_KEY is not set — the default ModelConfig and Backstage's AI chat get a placeholder until it is exported and `agentlab platform` re-runs

Applied to the configuration:
  platform.modelManager.backends: [ollama] -> [ollama, lemonade]
```

- **Tools**: docker, kind, kubectl, helm versions; a missing tool or a Helm 3 is called out here, not minutes into `agentlab up`.
- **Ports, lab-aware**: while no kind node of this configuration exists (fresh, or after `down`), occupied ports move to free ones — an existing file included. Once the node exists its mappings are fixed, so the ports it publishes (`docker inspect` HostConfig.PortBindings) never count as occupied and a foreign listener on one of them is *reported*, not renumbered around. Before, only a fresh file was ever probed.
- **Host model servers**: an Ollama on 11434 and a Lemonade Server on 13305 are detected with version, whether they listen on the kind docker gateway (pods' path; the bind fix is named when not) and their downloaded models, counting the tool-calling ones (Ollama `/api/show` capabilities, Lemonade labels). A standalone `flm serve` (default 52625) is reported, not wired — no management API, catalog-only listing; the lab drives FLM through Lemonade.
- **`$ANTHROPIC_API_KEY`**: whether it is exported.

**`platform.modelManager.backends`** replaces the single `backend:` (the old `backend`/`endpoint` form still reads as the one-item list and is never written again). The discovery fills it from what answers, Ollama first; `endpoints.<backend>` overrides keep a backend whether or not one answers locally; `--model-manager[=false]` pins the flag and `--model-manager-backends ollama,lemonade` the list for that run. Managed models go on when a server answers (and the agents runtime is on) and off when none does.

**Interim wiring** (HACKS.md U14): model-manager 0.16.0 fronts one backend per instance, so the first entry is model-manager's backend (`model-manager.backend` + `model-manager.<backend>.endpoint` in the values — the ollama render is byte-identical to before) and every further backend's downloaded tool-calling models are rendered by `agentlab platform` as lab-labeled ModelConfigs `<backend>-<model>` in exactly the shape model-manager writes for that backend (Lemonade: `OpenAI` on `<endpoint>/api/v1`, placeholder key; Ollama: the native keyless provider), refreshed and pruned on every run, deduplicated against hand-written `extraModels` entries for the same model on the same host:port. Every backend is preflighted from a pod (`/api/version` / `/api/v1/health`) with the bind and firewall fixes spelled out. When model-manager is multi-backend, `platform.go` hands it the list and `hostmodels.go` goes; the file shape stays.

`models-test` is backend-aware (asserts the primary backend and the provider model-manager writes for it; the post-delete ground truth reads that server's own inventory) and ends with an **agent turn on a statically wired model** when a further backend is listed — "discovered" means "usable by agents".

The default `apsRef` moves to umbrella main `d5a88b0` (model-manager 0.16.0, agent-platform 3.6.0), which accepts `backend: lemonade`, so a Lemonade-only host renders.

Also: the interactive form's managed-models confirm names what was found; README (configure + managed-models sections), CLAUDE.md, HACKS.md U14.

## Verification

- `go test ./...`, `go vet`, golangci-lint (gosec, goconst, govet) clean, goimports clean.
- Unit tests: legacy-form fold, `ApplyDiscovered` (both/one/none/vanished/endpoint-kept/agents-off/pins), port conflicts vs. the cluster's own ports, renumbering an existing config without a cluster, detection against fake Ollama/Lemonade/FLM servers (httptest), inventories, ModelConfig naming, static wiring incl. the hand-written-entry dedupe, the scripted TUI form.
- Lab host (Ollama 0.33.2 + Lemonade Server 11.9.0 with FLM on the NPU, cluster `agentlab` up): `configure --defaults` on the live config → `backends: [ollama] -> [ollama, lemonade]`, ports untouched (the running node's), render identical for model-manager; `agentlab platform` → both preflights pass from a pod, `lemonade-qwen3-6-moe-35b-a3b-flm` + `lemonade-qwen3vl-it-4b-flm` Accepted (the hand-written `lemonade-npu` for qwen3-it-4b-FLM left alone), everything else reconciled as a no-op; `models-test` — see the comment below (the lab's muster had dropped all its MCPServer services after a container restart hours earlier, unrelated; rolled and re-run).
- Not lab-verifiable here: the lemonade-first path (model-manager fronting Lemonade) — this host has an Ollama, so Ollama is always primary; covered by unit tests and the umbrella's render guard.
