### PR TITLE
fix(config): default apsRef follows umbrella main e946a2f (v0.35.24, backstage 0.226.0)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -445,7 +445,7 @@ func Default() *Config {
 			Domain:        "127.0.0.1.nip.io",
 			GatewayPort:   443,
 			APSRepo:       "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:        "bb940965cf203a5d48ecccda55f362bb541a2691", // main: muster 5.8.2 (kubernetes mode never falls back to the filesystem, muster#1143/#1145) + agent-platform-mcps 0.7.0 (#125, #150, #153)
+			APSRef:        "e946a2f2f68f7408042f1ba36ad539ecd286d39b", // main: backstage 0.226.0 (one Serving group per backend, #121) on muster 5.8.2 + agent-platform-mcps 0.7.0 (#125, #150, #153) + model-manager 0.17.0 (several backends per instance) + agent-platform 3.7.0
 		},
 		Backstage: Backstage{
 			Enabled: true,


### PR DESCRIPTION
## What

The default `platform.apsRef` moves from umbrella `434d12a` (v0.35.17) to `e946a2f2f68f7408042f1ba36ad539ecd286d39b` — agent-platform-standalone main after [#121](https://github.com/giantswarm/agent-platform-standalone/pull/121) (Renovate: backstage 0.223.1 → **0.226.0**), released as [v0.35.24](https://github.com/giantswarm/agent-platform-standalone/releases/tag/v0.35.24) (chart `oci://gsoci.azurecr.io/charts/giantswarm/agent-platform-standalone:0.35.24` carries `backstage 0.226.0`).

Backstage 0.226.0 ([backstage#2264](https://github.com/giantswarm/backstage/pull/2264)) renders one Serving group per backend of a model-manager installation, reads `GET /backends` (fallback `/backend`), and names every pull/import target and action per backend — the portal side of the multi-backend model-manager (model-manager 0.17.0, fleet 3.7.0, agentlab v0.16.0 / #63).

## Lab proof (2026-09-04, demiurg: Ollama 0.33.2 + Lemonade Server 11.9.0 on the host)

Branch binary built in a worktree, run from the shared checkout under `state/lab-lock`; `agentlab.yaml` `apsRef` moved to `e946a2f2…` (backup kept, restored state = this pin).

| Step | Result |
|---|---|
| `agentlab platform` | rc=0 in 97 s — vendored `agent-platform-standalone @ e946a2f2f68f`, helm release `agent-platform` revision 58, both host-backend preflights, model-manager 0.17.0 with `--backends=ollama,lemonade`, Backstage pod on the **chart image** `gsoci.azurecr.io/giantswarm/backstage:0.226.0` (`imagePullPolicy: Always`, no dev image) |
| `agentlab backstage-test` | rc=0 — admin/dev/viewer headless sign-ins on 0.226.0; muster servers agent-manager, mcp-kubernetes, mcp-prometheus, model-manager `Connected`, lab-oauth-fixture `Auth Required`; template registered |
| `agentlab models-test` (ollama) | rc=0 in 23 s — 401 without token; pull `qwen2.5:0.5b` → ModelConfig `qwen2-5-0-5b` (Ollama provider, backend label) Accepted → agent turn → unload → delete; muster `x_model-manager_*`; caller identity (`requestedBy=admin@lab.local`, viewer Forbidden) |
| `agentlab models-test --backend lemonade` | rc=0 in 144 s — pull `qwen3-4b-FLM` (3.1 GB, 2m04s) → ModelConfig `qwen3-4b-flm` (OpenAI provider against `…:13305/api/v1`, backend label) Accepted → agent turn answered from the NPU → unload → delete (status 200); host inventory before = after (`gemma3-4b-FLM, qwen3-it-4b-FLM, qwen3.6-moe-35b-a3b-FLM, qwen3vl-it-4b-FLM`). A first attempt stalled inside `flm pull` (Hugging Face CDN transfer frozen at 1.2 GB for 5+ min); the stuck pull was terminated, the truncated proof model removed through model-manager (`unload`, `unwire`, `DELETE …?backend=lemonade`), and the rerun downloaded at ~32 MB/s |
| `agentlab platform-test` | rc=0 in 5 s — 5 PASS: Claude Code → muster (Dex) → mcp-kubernetes → apiserver; forwarded id_token RBAC (admin allowed, viewer forbidden); per-server OAuth challenge (lab-oauth-fixture); muster → mcp-prometheus → Prometheus; Backstage metrics path via the edge |

**Two Serving groups on the chart image.** Chrome held no Dex session after the pod roll (Dex showed its password form — not entered), so the rendering proof is the headless DOM recipe on the same code the image ships: the real `ServingProvider` + `ServingPage` of tag `v0.226.0` rendered in jest on payloads captured from the lab's model-manager through the gateway (`agentlab login` token; `GET /api/v1/backends`, `/models`, `/nodes`), parsed with the portal's own zod schemas:

```
GROUP HEADINGS (h3): ["Lemonade 11.9.0","Ollama 0.33.2"]
GROUP HEADER TEXT:   ["Lemonade 11.9.0 http://172.21.0.1:13305/api/v1", "Ollama 0.33.2 http://172.21.0.1:11434"]
GRID 1 (Lemonade): 4 rows   (engine chips flm · vision/tools/thinking)
GRID 2 (Ollama):  10 rows
listBackends calls: 1, getBackend calls: 0   (the source read /backends, never the /backend fallback)
```

`GET …/model-manager/api/v1/backends` on the wire (lab gateway, JWT-validated): `ollama 0.33.2 http://172.21.0.1:11434` and `lemonade 11.9.0 http://172.21.0.1:13305` (`agentEndpoint …/api/v1`), both `healthy: true`; `/nodes` lists one host row per backend (`172.21.0.1` ollama, `172.21.0.1` lemonade). Without a token the gateway answers 401.

Host inventory untouched: Lemonade still lists `gemma3-4b-FLM, qwen3-it-4b-FLM, qwen3.6-moe-35b-a3b-FLM, qwen3vl-it-4b-FLM` (the proof model `qwen3-4b-FLM` is pulled and deleted by the proof).
