### PR TITLE
fix(platform): bump the default apsRef to agent-platform-standalone bb94096 — muster 5.8.2 (muster#1143), agent-platform-mcps 0.7.0

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -445,7 +445,7 @@ func Default() *Config {
 			Domain:        "127.0.0.1.nip.io",
 			GatewayPort:   443,
 			APSRepo:       "https://github.com/giantswarm/agent-platform-standalone",
-			APSRef:        "434d12a972188afcaf417b7b4416ec979171d8f2", // main: model-manager 0.17.0 (several backends per instance) + agent-platform 3.7.0 (#143, #144, #147)
+			APSRef:        "bb940965cf203a5d48ecccda55f362bb541a2691", // main: muster 5.8.2 (kubernetes mode never falls back to the filesystem, muster#1143/#1145) + agent-platform-mcps 0.7.0 (#125, #150, #153)
 		},
 		Backstage: Backstage{
 			Enabled: true,


### PR DESCRIPTION
## What

The default `platform.apsRef` moves from `434d12a` (umbrella v0.35.17) to `bb94096` (umbrella v0.35.23, main as of 2026-09-04 16:19 UTC).

## Why

- **muster 5.8.2** carries giantswarm/muster#1145: with `kubernetes: true` a muster whose apiserver is unreachable at startup retries (5 attempts) and exits instead of silently swapping in the filesystem client and deleting every MCPServer service (giantswarm/muster#1143 — first seen in this lab after a kind node restart: `Found 0 MCPServer definitions`, no `x_*` tools, CRs frozen at `Connected`).
- agent-platform-mcps 0.7.0 (pinned authorization server on the raw MCPServers), and the standalone ATS upgrade hook now applies CRDs with `--force-conflicts` (giantswarm/agent-platform-standalone#153).

## Lab proof on this pin

`agentlab platform` (helm rev 57, vendored at `bb940965cf20`): muster 5.8.2 logs `Initialized reconciliation manager in kubernetes mode` and `Found 5 MCPServer definitions for auto-start processing`, zero `Deleting MCPServer service`. `agentlab platform-test` (5 PASS), `backstage-test`, `test` (10/10) and `models-test` (ollama: pull → ModelConfig → agent turn → unload → delete, `x_model-manager_*` via muster) pass.
