### PR TITLE
fix(lab): recover the exited node a lost down/docker race leaves behind; keep local builds out of the preload manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1071,6 +1071,28 @@ next version lands.
 - Kubernetes 1.35 still accepts the `--oidc-*` flags. The modern alternative is
   `--authentication-config` (structured `AuthenticationConfiguration`, which
   also supports CEL claim mappings). The flags are simpler and were kept here.
+- **`agentlab down` can lose a race with docker and leave an exited node.**
+  `kind delete cluster` is `docker rm -f` of the node container; docker gives
+  it ten seconds after SIGKILL to exit and then gives up (`could not kill
+  container: ... did not receive an exit event`) — a node busy with an
+  `agentlab up` side-load in another shell has taken 44 s. The container
+  stays in `docker ps -a` as `Exited (137)`, kind still lists the cluster,
+  and docker's restart policy does not fire (an API kill counts as a manual
+  stop). `agentlab down` therefore waits (up to 90 s) for the node to exit
+  and deletes again, and `agentlab up` on a cluster whose node is not running
+  starts the container (`docker start`, which kind supports) and waits for
+  the apiserver before touching anything — instead of failing inside `kind
+  get kubeconfig` with a runc `nsexec ... No such file or directory` or
+  `container ... is not running`. Do not run `down` while another `agentlab`
+  process is using the cluster (`ps -eo pid,args | grep '[a]gentlab '`).
+- **The image cache manifest only records what a registry can serve.**
+  `state/preload-images.txt` is snapshotted from the node after every boot;
+  an image built on the host and side-loaded (`kind load docker-image
+  backstage-dev:<tag>`) shows up there as `docker.io/library/backstage-dev:<tag>`
+  — a Docker Hub ref that does not exist — and once the local copy is pruned
+  every boot would ask Docker Hub for it (`denied: requested access to the
+  resource is denied` in the dockerd log, once per ref). Images the host cache
+  knows without a registry digest are therefore left out of the snapshot.
 
 ## Wiring another app to this Dex
 

--- a/internal/lab/down.go
+++ b/internal/lab/down.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -12,7 +13,19 @@ import (
 // immediate `agentlab up` reuses the same trust chain.
 func Down(cfg *config.Config) error {
 	if err := run("kind", "delete", "cluster", "--name", cfg.ClusterName); err != nil {
-		return err
+		// kind delete is `docker rm -f` of the node, and docker gives up on
+		// a node that does not exit within ten seconds of SIGKILL ("could
+		// not kill container: ... did not receive an exit event"), leaving
+		// the container in `docker ps -a` and the cluster listed by kind.
+		// The node is dying, not surviving (node.go): wait for it, then
+		// delete again — now a plain rm of an exited container.
+		if werr := waitForNodeExit(cfg.ClusterName, nodeExitTimeout, 2*time.Second); werr != nil {
+			return fmt.Errorf("%w (kind delete cluster: %v)", werr, err)
+		}
+		step("Retrying kind delete cluster")
+		if err := run("kind", "delete", "cluster", "--name", cfg.ClusterName); err != nil {
+			return err
+		}
 	}
 	_ = os.Remove(".token")
 	// The exported kubeconfig described a cluster that no longer exists.

--- a/internal/lab/node.go
+++ b/internal/lab/node.go
@@ -37,13 +37,16 @@ import (
 // finds them, exited ones included.
 const kindClusterLabel = "io.x-k8s.kind.cluster"
 
-// Docker container states as `docker ps` and `docker inspect` spell them.
+// Docker container states as `docker ps` and `docker inspect` spell them, and
+// the verbs that bring a container back to running.
 const (
 	stateRunning = "running"
 	statePaused  = "paused"
 	stateExited  = "exited"
 	stateCreated = "created"
 	stateDead    = "dead"
+	verbStart    = "start"
+	verbUnpause  = "unpause"
 )
 
 // nodeExitTimeout bounds how long Down waits for a node docker could not kill
@@ -160,9 +163,9 @@ func nodeStartVerb(state string) string {
 	case stateRunning:
 		return ""
 	case statePaused:
-		return "unpause"
+		return verbUnpause
 	default:
-		return "start"
+		return verbStart
 	}
 }
 

--- a/internal/lab/node.go
+++ b/internal/lab/node.go
@@ -1,0 +1,205 @@
+package lab
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The kind node is a docker container, and kind's notion of "the cluster
+// exists" is that container's existence in ANY state: `kind get clusters`
+// lists a cluster whose node is exited, and `kind get kubeconfig` then fails
+// inside `docker exec` — a runc "nsexec ... failed to open /proc/<pid>/ns/ipc"
+// while the node is still dying, "container ... is not running" once it is
+// dead — with nothing in the message that names the node's state. Two lab
+// operations meet such a node:
+//
+//   - `agentlab down` while the node is busy (an `agentlab up` in another
+//     shell side-loading a hundred images) races docker: `kind delete
+//     cluster` is `docker rm -f`, docker gives the node ten seconds after
+//     SIGKILL to exit, a node mid-import has taken 44 s, and docker answers
+//     "cannot remove container: could not kill container: tried to kill
+//     container, but did not receive an exit event". The container stays in
+//     `docker ps -a` (Exited (137) once it does die), kind keeps listing the
+//     cluster, and docker's on-failure restart policy never fires because an
+//     API kill counts as a manual stop — nothing recovers or removes the node
+//     by itself.
+//   - `agentlab up` after that: the cluster "exists", its node is exited.
+//
+// kind supports a stopped node: it is a container like any other, and
+// `docker start` brings containerd, the kubelet and the static pods back with
+// the cluster state and the side-loaded images intact.
+
+// kindClusterLabel is the docker label kind stamps on every node container of
+// a cluster; `docker ps -a --filter label=<label>=<name>` is how kind itself
+// finds them, exited ones included.
+const kindClusterLabel = "io.x-k8s.kind.cluster"
+
+// Docker container states as `docker ps` and `docker inspect` spell them.
+const (
+	stateRunning = "running"
+	statePaused  = "paused"
+	stateExited  = "exited"
+	stateCreated = "created"
+	stateDead    = "dead"
+)
+
+// nodeExitTimeout bounds how long Down waits for a node docker could not kill
+// in time; the one observed case took 44 s.
+const nodeExitTimeout = 90 * time.Second
+
+// containerState is one `docker ps -a` row of a cluster's node containers.
+type containerState struct {
+	name, state string
+}
+
+// nodeState reads a node container's docker state (running, exited, paused,
+// created, restarting, dead); the error carries docker's words when there is
+// no such container.
+func nodeState(node string) (string, error) {
+	out, err := outputQuiet("docker", "inspect", "-f", "{{.State.Status}}", node)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// clusterContainers lists a kind cluster's node containers with their states,
+// from `docker ps -a` — so an exited node counts, which is the whole point.
+func clusterContainers(cluster string) ([]containerState, error) {
+	out, err := outputQuiet("docker", "ps", "-a", "--filter", "label="+kindClusterLabel+"="+cluster,
+		"--format", "{{.Names}}\t{{.State}}")
+	if err != nil {
+		return nil, err
+	}
+	return parseContainerStates(out), nil
+}
+
+// parseContainerStates reads the "name<TAB>state" lines clusterContainers
+// asks docker ps for.
+func parseContainerStates(out string) []containerState {
+	var cs []containerState
+	for line := range strings.Lines(out) {
+		name, state, ok := strings.Cut(strings.TrimSpace(line), "\t")
+		if ok && name != "" {
+			cs = append(cs, containerState{name: name, state: strings.TrimSpace(state)})
+		}
+	}
+	return cs
+}
+
+// alive keeps the containers whose process still exists — everything but
+// exited, created and dead. Paused and restarting count as alive: a paused
+// container cannot exit until it is thawed, a restarting one is about to run.
+func alive(cs []containerState) []containerState {
+	var out []containerState
+	for _, c := range cs {
+		switch c.state {
+		case stateExited, stateCreated, stateDead:
+		default:
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func containerNames(cs []containerState) string {
+	names := make([]string, 0, len(cs))
+	for _, c := range cs {
+		names = append(names, c.name+" ("+c.state+")")
+	}
+	return strings.Join(names, ", ")
+}
+
+// waitForNodeExit polls the cluster's node containers every interval until
+// none is alive — exited, or already removed — thawing a paused one so the
+// pending SIGKILL can land, and fails once timeout passes with a node still
+// alive. Called by Down after `kind delete cluster` failed; says what it is
+// waiting for, once.
+func waitForNodeExit(cluster string, timeout, interval time.Duration) error {
+	start := time.Now()
+	announced := false
+	for {
+		cs, err := clusterContainers(cluster)
+		if err != nil {
+			return err
+		}
+		live := alive(cs)
+		if len(live) == 0 {
+			if announced {
+				note("node exited after %s", time.Since(start).Round(time.Second))
+			}
+			return nil
+		}
+		if !announced {
+			step("Waiting up to %s for %s to exit: docker could not kill it in time and kind still lists the cluster",
+				timeout, containerNames(live))
+			announced = true
+		}
+		for _, c := range live {
+			if c.state == statePaused {
+				note("%s is paused and cannot exit — unpausing it", c.name)
+				_ = runQuiet("docker", "unpause", c.name)
+			}
+		}
+		if time.Since(start) >= timeout {
+			return fmt.Errorf("%s still alive %s after docker gave up killing it; see `journalctl -u docker`, and run `agentlab down` again once `docker ps -a` shows it exited",
+				containerNames(live), timeout)
+		}
+		time.Sleep(interval)
+	}
+}
+
+// nodeStartVerb is the docker verb that brings a node container in the given
+// state back to running: nothing for a running one, unpause for a paused one,
+// start for everything else (exited after a lost `down` race, created, dead).
+func nodeStartVerb(state string) string {
+	switch state {
+	case stateRunning:
+		return ""
+	case statePaused:
+		return "unpause"
+	default:
+		return "start"
+	}
+}
+
+// ensureNodeRunning brings an existing cluster's node container back to
+// running when it is not and waits for the apiserver to answer — the recovery
+// for the exited node a lost `down` race leaves behind (see the file comment).
+// A running node is left alone. Called by Up before anything reads the
+// cluster, so a node that cannot come back fails by state and with the fix,
+// not as an opaque `kind get kubeconfig` error.
+func ensureNodeRunning(cfg *config.Config) error {
+	node := cfg.ControlPlaneNode()
+	state, err := nodeState(node)
+	if err != nil {
+		return fmt.Errorf("kind lists cluster %q but its node container cannot be inspected: %w", cfg.ClusterName, err)
+	}
+	verb := nodeStartVerb(state)
+	if verb == "" {
+		return nil
+	}
+	step("Node container %s is %s — docker %s, then waiting for the apiserver", node, state, verb)
+	start := time.Now()
+	// outputQuiet, so the error carries docker's words ("is restarting", "no
+	// such container") instead of leaving them on the terminal.
+	if _, err := outputQuiet("docker", verb, node); err != nil {
+		return fmt.Errorf("node container %s is %s and could not be started: %w;\nrun `agentlab up` again once `docker ps -a` shows it settled, or `agentlab down` to start over", node, state, err)
+	}
+	// Only a running node has a kubeconfig to export (kind reads it off the
+	// node); from here on the lab's kubectl is pinned to it.
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
+	if !waitFor(60, 2*time.Second, func() bool {
+		_, err := outputQuiet("kubectl", "get", "--raw=/readyz")
+		return err == nil
+	}) {
+		return fmt.Errorf("node container %s started but its apiserver never answered /readyz; check `docker logs %s` and `docker exec %s crictl ps`, or `agentlab down` to start over", node, node, node)
+	}
+	note("apiserver answers again (%s)", time.Since(start).Round(time.Second))
+	return nil
+}

--- a/internal/lab/node_test.go
+++ b/internal/lab/node_test.go
@@ -53,7 +53,7 @@ const dockerPSCall = "docker ps -a --filter label=io.x-k8s.kind.cluster=agentlab
 func TestAliveContainers(t *testing.T) {
 	cs := parseContainerStates("agentlab-control-plane\texited\nagentlab-worker\trunning\nagentlab-worker2\tpaused\n\n")
 	if want := []containerState{
-		{"agentlab-control-plane", "exited"}, {"agentlab-worker", "running"}, {"agentlab-worker2", "paused"},
+		{"agentlab-control-plane", stateExited}, {"agentlab-worker", stateRunning}, {"agentlab-worker2", statePaused},
 	}; !slices.Equal(cs, want) {
 		t.Fatalf("parseContainerStates = %v, want %v", cs, want)
 	}
@@ -63,12 +63,12 @@ func TestAliveContainers(t *testing.T) {
 	if got := alive(parseContainerStates("")); len(got) != 0 {
 		t.Errorf("no containers: alive = %v, want none", got)
 	}
-	for _, state := range []string{"exited", "created", "dead"} {
+	for _, state := range []string{stateExited, stateCreated, stateDead} {
 		if got := alive([]containerState{{"n", state}}); len(got) != 0 {
 			t.Errorf("%s container counted as alive", state)
 		}
 	}
-	for _, state := range []string{"running", "paused", "restarting", "removing"} {
+	for _, state := range []string{stateRunning, statePaused, "restarting", "removing"} {
 		if got := alive([]containerState{{"n", state}}); len(got) != 1 {
 			t.Errorf("%s container not counted as alive", state)
 		}
@@ -79,7 +79,7 @@ func TestAliveContainers(t *testing.T) {
 // everything else started — `docker start` on a paused container fails.
 func TestNodeStartVerb(t *testing.T) {
 	for state, want := range map[string]string{
-		"running": "", "paused": "unpause", "exited": "start", "created": "start", "dead": "start",
+		stateRunning: "", statePaused: verbUnpause, stateExited: verbStart, stateCreated: verbStart, stateDead: verbStart,
 	} {
 		if got := nodeStartVerb(state); got != want {
 			t.Errorf("nodeStartVerb(%q) = %q, want %q", state, got, want)
@@ -106,7 +106,7 @@ ps)
   fi ;;
 esac`)
 
-	t.Setenv("FAKE_LIVE_STATE", "running")
+	t.Setenv("FAKE_LIVE_STATE", stateRunning)
 	if err := waitForNodeExit("agentlab", time.Second, time.Millisecond); err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ esac`)
 
 	_ = os.Remove(counter)
 	_ = os.Remove(calls)
-	t.Setenv("FAKE_LIVE_STATE", "paused")
+	t.Setenv("FAKE_LIVE_STATE", statePaused)
 	if err := waitForNodeExit("agentlab", time.Second, time.Millisecond); err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ esac`)
 	cfg := config.Default()
 	const inspect = "docker inspect -f {{.State.Status}} agentlab-control-plane\n"
 
-	t.Setenv("FAKE_NODE_STATE", "running")
+	t.Setenv("FAKE_NODE_STATE", stateRunning)
 	if err := ensureNodeRunning(cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ esac`)
 	}
 
 	_ = os.Remove(dockerCalls)
-	t.Setenv("FAKE_NODE_STATE", "exited")
+	t.Setenv("FAKE_NODE_STATE", stateExited)
 	if err := ensureNodeRunning(cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ esac`)
 	}
 
 	_ = os.Remove(dockerCalls)
-	t.Setenv("FAKE_NODE_STATE", "paused")
+	t.Setenv("FAKE_NODE_STATE", statePaused)
 	if err := ensureNodeRunning(cfg); err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ esac`)
 		t.Errorf("paused node: docker calls = %q, want an unpause", log)
 	}
 
-	t.Setenv("FAKE_NODE_STATE", "exited")
+	t.Setenv("FAKE_NODE_STATE", stateExited)
 	t.Setenv("FAKE_START_FAILS", "1")
 	err := ensureNodeRunning(cfg)
 	if err == nil {

--- a/internal/lab/node_test.go
+++ b/internal/lab/node_test.go
@@ -1,0 +1,216 @@
+package lab
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// installFakeTool puts a stand-in for a command on PATH: a shell script that
+// appends every invocation ("<name> <args>") to the returned log file and
+// then runs body with the arguments in $@. The same device as installFakeKind,
+// for the docker and kubectl the node recovery shells out to.
+func installFakeTool(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	bin := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(bin, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	calls := filepath.Join(dir, name+"-calls")
+	script := "#!/bin/sh\n" +
+		"echo \"" + name + " $*\" >> \"" + calls + "\"\n" +
+		body + "\n"
+	if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o700); err != nil { // #nosec G306 -- an executable stand-in under t.TempDir
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return calls
+}
+
+// readCalls returns a stand-in's invocation log; none yet reads as empty.
+func readCalls(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path) // #nosec G304 -- the call log this test's stand-in wrote under t.TempDir
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+// The docker ps invocation Down's wait loop issues, as the stand-in logs it
+// (the --format value carries a literal tab).
+const dockerPSCall = "docker ps -a --filter label=io.x-k8s.kind.cluster=agentlab --format {{.Names}}\t{{.State}}\n"
+
+// TestAliveContainers: the docker ps rows parse by name and state, and only
+// exited, created and dead containers count as gone — paused and restarting
+// ones still have a process, and no rows at all (docker finished the removal
+// after all) is nothing alive.
+func TestAliveContainers(t *testing.T) {
+	cs := parseContainerStates("agentlab-control-plane\texited\nagentlab-worker\trunning\nagentlab-worker2\tpaused\n\n")
+	if want := []containerState{
+		{"agentlab-control-plane", "exited"}, {"agentlab-worker", "running"}, {"agentlab-worker2", "paused"},
+	}; !slices.Equal(cs, want) {
+		t.Fatalf("parseContainerStates = %v, want %v", cs, want)
+	}
+	if got, want := alive(cs), cs[1:]; !slices.Equal(got, want) {
+		t.Errorf("alive = %v, want %v", got, want)
+	}
+	if got := alive(parseContainerStates("")); len(got) != 0 {
+		t.Errorf("no containers: alive = %v, want none", got)
+	}
+	for _, state := range []string{"exited", "created", "dead"} {
+		if got := alive([]containerState{{"n", state}}); len(got) != 0 {
+			t.Errorf("%s container counted as alive", state)
+		}
+	}
+	for _, state := range []string{"running", "paused", "restarting", "removing"} {
+		if got := alive([]containerState{{"n", state}}); len(got) != 1 {
+			t.Errorf("%s container not counted as alive", state)
+		}
+	}
+}
+
+// TestNodeStartVerb: a running node is left alone, a paused one unpaused,
+// everything else started — `docker start` on a paused container fails.
+func TestNodeStartVerb(t *testing.T) {
+	for state, want := range map[string]string{
+		"running": "", "paused": "unpause", "exited": "start", "created": "start", "dead": "start",
+	} {
+		if got := nodeStartVerb(state); got != want {
+			t.Errorf("nodeStartVerb(%q) = %q, want %q", state, got, want)
+		}
+	}
+}
+
+// TestWaitForNodeExit drives Down's wait against a stand-in docker whose
+// node is still running on the first two polls and exited on the third: the
+// wait returns once nothing is alive, having polled exactly that often; a
+// paused node is unpaused so the pending SIGKILL can land; and a node still
+// alive at the timeout fails by name and state with the fix.
+func TestWaitForNodeExit(t *testing.T) {
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "ps-count")
+	calls := installFakeTool(t, dir, "docker", `
+case "$1" in
+ps)
+  n=$(cat "`+counter+`" 2>/dev/null || echo 0); n=$((n+1)); echo "$n" > "`+counter+`"
+  if [ "$n" -le 2 ]; then
+    printf '%s\n' "agentlab-control-plane	$FAKE_LIVE_STATE"
+  else
+    printf 'agentlab-control-plane\texited\n'
+  fi ;;
+esac`)
+
+	t.Setenv("FAKE_LIVE_STATE", "running")
+	if err := waitForNodeExit("agentlab", time.Second, time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	log := readCalls(t, calls)
+	if n := strings.Count(log, dockerPSCall); n != 3 {
+		t.Errorf("docker ps run %d times, want 3 (running, running, exited):\n%s", n, log)
+	}
+	if strings.Contains(log, "unpause") {
+		t.Errorf("a running node must not be unpaused:\n%s", log)
+	}
+
+	_ = os.Remove(counter)
+	_ = os.Remove(calls)
+	t.Setenv("FAKE_LIVE_STATE", "paused")
+	if err := waitForNodeExit("agentlab", time.Second, time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	if log := readCalls(t, calls); strings.Count(log, "docker unpause agentlab-control-plane\n") != 2 {
+		t.Errorf("a paused node is unpaused on every poll it is seen paused (2), got:\n%s", log)
+	}
+
+	// Never exits: the bound holds and the error says what is still alive.
+	_ = os.Remove(counter)
+	_ = os.Remove(calls)
+	installFakeTool(t, dir, "docker", `printf 'agentlab-control-plane\trunning\n'`)
+	err := waitForNodeExit("agentlab", 20*time.Millisecond, 5*time.Millisecond)
+	if err == nil {
+		t.Fatal("a node that never exits must fail the wait")
+	}
+	for _, want := range []string{"agentlab-control-plane (running)", "still alive", "journalctl -u docker", "agentlab down"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("timeout error %q lacks %q", err, want)
+		}
+	}
+}
+
+// TestEnsureNodeRunning drives Up's node check against stand-ins for docker,
+// kind and kubectl: a running node is left completely alone (no start, no
+// kubeconfig export); an exited node is started, the kubeconfig exported and
+// the apiserver probed before Up goes on; a paused node is unpaused; and a
+// node docker cannot start fails by node, state and fix instead of as the
+// `kind get kubeconfig` error it used to be.
+func TestEnsureNodeRunning(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	installFakeKind(t, dir)
+	resetKindKubeconfigCache(t)
+	kubectlCalls := installFakeTool(t, dir, "kubectl", "exit 0")
+	dockerCalls := installFakeTool(t, dir, "docker", `
+case "$1" in
+inspect) echo "$FAKE_NODE_STATE" ;;
+start|unpause)
+  if [ -n "$FAKE_START_FAILS" ]; then
+    echo "Error response from daemon: cannot start a dying container" >&2
+    exit 1
+  fi ;;
+esac`)
+	cfg := config.Default()
+	const inspect = "docker inspect -f {{.State.Status}} agentlab-control-plane\n"
+
+	t.Setenv("FAKE_NODE_STATE", "running")
+	if err := ensureNodeRunning(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if log := readCalls(t, dockerCalls); log != inspect {
+		t.Errorf("running node: docker calls = %q, want the inspect alone", log)
+	}
+	if _, err := os.Stat(labKubeconfigPath); !os.IsNotExist(err) {
+		t.Errorf("running node: kubeconfig export happened (%v); Up does that itself", err)
+	}
+
+	_ = os.Remove(dockerCalls)
+	t.Setenv("FAKE_NODE_STATE", "exited")
+	if err := ensureNodeRunning(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if log, want := readCalls(t, dockerCalls), inspect+"docker start agentlab-control-plane\n"; log != want {
+		t.Errorf("exited node: docker calls = %q, want %q", log, want)
+	}
+	if raw, err := os.ReadFile(labKubeconfigPath); err != nil || string(raw) != fakeKindKubeconfig {
+		t.Errorf("exited node: kubeconfig not exported after the start (err %v)", err)
+	}
+	if log := readCalls(t, kubectlCalls); log != "kubectl get --raw=/readyz\n" {
+		t.Errorf("exited node: kubectl calls = %q, want one /readyz probe", log)
+	}
+
+	_ = os.Remove(dockerCalls)
+	t.Setenv("FAKE_NODE_STATE", "paused")
+	if err := ensureNodeRunning(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if log := readCalls(t, dockerCalls); !strings.Contains(log, "docker unpause agentlab-control-plane\n") {
+		t.Errorf("paused node: docker calls = %q, want an unpause", log)
+	}
+
+	t.Setenv("FAKE_NODE_STATE", "exited")
+	t.Setenv("FAKE_START_FAILS", "1")
+	err := ensureNodeRunning(cfg)
+	if err == nil {
+		t.Fatal("a node docker cannot start must fail Up")
+	}
+	for _, want := range []string{"agentlab-control-plane is exited", "cannot start a dying container", "agentlab up", "agentlab down"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("start failure %q lacks %q", err, want)
+		}
+	}
+}

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -229,19 +229,77 @@ func snapshotPreloadImages(cfg *config.Config) {
 			images = append(images, tag)
 		}
 	}
-	if len(images) == 0 {
-		return
-	}
 	slices.Sort(images)
 	images = slices.Compact(images)
-	content := "# Images the last successful boot ran; the next `agentlab up` pulls\n" +
+	// Images built here were side-loaded by whoever built them and have no
+	// registry to be pulled from on the next boot. They are remembered as
+	// such, so a later `docker image prune` on the host does not make them
+	// look like images the node pulled itself (localOnly).
+	prov, provErr := hostImageProvenance()
+	remembered := readLocalOnlyRefs()
+	var local []string
+	images = slices.DeleteFunc(images, func(img string) bool {
+		if !localOnly(img, prov, provErr == nil, remembered) {
+			return false
+		}
+		local = append(local, img)
+		return true
+	})
+	if len(images) == 0 && len(local) == 0 {
+		return
+	}
+	var b strings.Builder
+	b.WriteString("# Images the last successful boot ran; the next `agentlab up` pulls\n" +
 		"# them on the host and side-loads them into the fresh node. Regenerated\n" +
-		"# after every boot — safe to delete.\n" +
-		strings.Join(images, "\n") + "\n"
+		"# after every boot — safe to delete.\n")
+	for _, img := range images {
+		b.WriteString(img + "\n")
+	}
+	if len(local) > 0 {
+		b.WriteString("# Built or tagged on this host and side-loaded: no registry serves them,\n" +
+			"# so they stay out of the pull set even once the local copy is pruned.\n")
+		for _, img := range local {
+			b.WriteString(localOnlyMarker + img + "\n")
+		}
+	}
 	if err := os.MkdirAll(StateDir, 0o750); err != nil {
 		return
 	}
-	_ = os.WriteFile(preloadImagesFile, []byte(content), 0o600)
+	_ = os.WriteFile(preloadImagesFile, []byte(b.String()), 0o600)
+}
+
+// localOnlyMarker prefixes the manifest lines that remember local-only refs —
+// comments to readPreloadManifest, so they never enter the pull set.
+const localOnlyMarker = "# local-only: "
+
+// localOnly reports whether a node image is a local build the next boot must
+// not try to pull. The host cache's current knowledge decides whenever it has
+// any (registryBacked: a real pull of the same repo:tag makes it pullable
+// again); for a ref the host no longer knows — the local copy was pruned — the
+// manifest's memory decides.
+func localOnly(ref string, prov map[string]bool, provOK bool, remembered []string) bool {
+	if provOK {
+		if _, known := prov[shortRef(ref)]; known {
+			return !registryBacked(ref, prov)
+		}
+	}
+	return slices.Contains(remembered, ref)
+}
+
+// readLocalOnlyRefs returns the refs the manifest remembers as local builds;
+// no manifest, no memory.
+func readLocalOnlyRefs() []string {
+	raw, err := os.ReadFile(filepath.FromSlash(preloadImagesFile))
+	if err != nil {
+		return nil
+	}
+	var refs []string
+	for line := range strings.Lines(string(raw)) {
+		if ref, ok := strings.CutPrefix(strings.TrimSpace(line), localOnlyMarker); ok && ref != "" {
+			refs = append(refs, ref)
+		}
+	}
+	return refs
 }
 
 // readPreloadManifest returns the cached image list, tolerating comments and
@@ -280,4 +338,56 @@ func nodeImageTags(node string) ([]string, error) {
 		tags = append(tags, img.RepoTags...)
 	}
 	return tags, nil
+}
+
+// hostImageProvenance maps every repo:tag in the host docker cache to whether
+// a registry digest backs it: `docker images --digests` prints the digest of
+// the manifest a pulled image came from, and <none> for an image built or
+// tagged here. A pulled image re-tagged into ANOTHER repository shows <none>
+// too (the digest belongs to the repository it was pulled as); re-tagged within
+// the same repository it keeps the digest, and so still reads as pulled. Refs
+// are spelled the way docker prints them (shortRef).
+func hostImageProvenance() (map[string]bool, error) {
+	out, err := outputQuiet("docker", "images", "--digests", "--format", "{{.Repository}}:{{.Tag}}\t{{.Digest}}")
+	if err != nil {
+		return nil, err
+	}
+	return parseImageProvenance(out), nil
+}
+
+// parseImageProvenance reads hostImageProvenance's "repo:tag<TAB>digest"
+// lines; untagged rows are skipped, and a ref listed more than once is backed
+// if any of its rows is.
+func parseImageProvenance(out string) map[string]bool {
+	prov := map[string]bool{}
+	for line := range strings.Lines(out) {
+		ref, digest, ok := strings.Cut(strings.TrimSpace(line), "\t")
+		if !ok || strings.HasSuffix(ref, ":<none>") {
+			continue
+		}
+		digest = strings.TrimSpace(digest)
+		prov[ref] = prov[ref] || (digest != "" && digest != "<none>")
+	}
+	return prov
+}
+
+// shortRef spells a fully qualified ref (as crictl lists it) the way docker
+// prints it: the docker.io registry and its library/ namespace are implicit.
+func shortRef(ref string) string {
+	ref = strings.TrimPrefix(ref, "docker.io/library/")
+	return strings.TrimPrefix(ref, "docker.io/")
+}
+
+// registryBacked reports whether a node image can be pulled again on the next
+// boot. A ref the host cache does not know was pulled by the node itself —
+// pullable by construction; one the host knows with a registry digest was
+// pulled on the host. One the host knows WITHOUT a digest was built or tagged
+// here and side-loaded (a dev-image swap): no registry has it —
+// `docker.io/library/backstage-dev:<tag>` is what docker makes of a bare
+// `backstage-dev:<tag>` — and recording it means every boot after the local
+// copy is pruned asks Docker Hub for it and dockerd logs "denied: requested
+// access to the resource is denied" per ref.
+func registryBacked(ref string, prov map[string]bool) bool {
+	backed, known := prov[shortRef(ref)]
+	return !known || backed
 }

--- a/internal/lab/preload_test.go
+++ b/internal/lab/preload_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/giantswarm/agentlab/internal/config"
 )
 
+// Fixture refs, hoisted so the linter's constant check stays quiet.
+const (
+	refPostgres     = "docker.io/library/postgres:18.3-alpine"
+	refBackstageDev = "docker.io/library/backstage-dev:multi-backend-022f5b7e"
+	refMusterDev    = "gsoci.azurecr.io/giantswarm/muster:dev"
+	refGolangADK    = "gsoci.azurecr.io/giantswarm/golang-adk:0.10.0"
+)
+
 func TestScrapeImages(t *testing.T) {
 	rendered := `
 apiVersion: apps/v1
@@ -46,7 +54,7 @@ spec:
 `
 	got := scrapeImages(rendered)
 	want := []string{
-		"docker.io/library/postgres:18.3-alpine",
+		refPostgres,
 		"gsoci.azurecr.io/giantswarm/agentgateway:v1.4.1",
 		"gsoci.azurecr.io/giantswarm/mcp-kubernetes:1.0.9",
 		"gsoci.azurecr.io/giantswarm/muster:5.7.2",
@@ -71,12 +79,12 @@ func TestRegistryBacked(t *testing.T) {
 		"gsoci.azurecr.io/giantswarm/muster:5.10.2\tsha256:b97b80cd922c4aa2b6aa61e3fca50194d211b1b5a90b5931ce1eef5ff74d35a5\n" +
 		"<none>:<none>\t<none>\n")
 	for ref, want := range map[string]bool{
-		"docker.io/library/backstage-dev:multi-backend-022f5b7e": false, // built here
-		"docker.io/library/postgres:18.3-alpine":                 true,  // pulled from Docker Hub
-		"docker.io/alpine/socat:1.8.1.3":                         true,  // pulled, non-library namespace
-		"gsoci.azurecr.io/giantswarm/muster:dev":                 false, // a dev build tagged into a registry repo
-		"gsoci.azurecr.io/giantswarm/muster:5.10.2":              true,
-		"gsoci.azurecr.io/giantswarm/golang-adk:0.10.0":          true, // unknown to the host: the node pulled it
+		refBackstageDev:                  false, // built here
+		refPostgres:                      true,  // pulled from Docker Hub
+		"docker.io/alpine/socat:1.8.1.3": true,  // pulled, non-library namespace
+		refMusterDev:                     false, // a dev build tagged into a registry repo
+		"gsoci.azurecr.io/giantswarm/muster:5.10.2": true,
+		refGolangADK: true, // unknown to the host: the node pulled it
 	} {
 		if got := registryBacked(ref, prov); got != want {
 			t.Errorf("registryBacked(%q) = %v, want %v", ref, got, want)
@@ -86,9 +94,9 @@ func TestRegistryBacked(t *testing.T) {
 		t.Error("untagged rows must not enter the provenance map")
 	}
 	for ref, want := range map[string]string{
-		"docker.io/library/postgres:18.3-alpine": "postgres:18.3-alpine",
-		"docker.io/alpine/socat:1.8.1.3":         "alpine/socat:1.8.1.3",
-		"ghcr.io/dexidp/dex:v2.45.1":             "ghcr.io/dexidp/dex:v2.45.1",
+		refPostgres:                      "postgres:18.3-alpine",
+		"docker.io/alpine/socat:1.8.1.3": "alpine/socat:1.8.1.3",
+		"ghcr.io/dexidp/dex:v2.45.1":     "ghcr.io/dexidp/dex:v2.45.1",
 	} {
 		if got := shortRef(ref); got != want {
 			t.Errorf("shortRef(%q) = %q, want %q", ref, got, want)
@@ -142,12 +150,12 @@ esac`)
 		"postgres:18.3-alpine\tsha256:54451e\n" +
 		"gsoci.azurecr.io/giantswarm/muster:dev\t<none>\n")
 	check("host knows both local images",
-		[]string{"docker.io/library/postgres:18.3-alpine", "gsoci.azurecr.io/giantswarm/golang-adk:0.10.0"},
-		[]string{"docker.io/library/backstage-dev:multi-backend-022f5b7e", "gsoci.azurecr.io/giantswarm/muster:dev"})
+		[]string{refPostgres, refGolangADK},
+		[]string{refBackstageDev, refMusterDev})
 
 	writeHost("postgres:18.3-alpine\tsha256:54451e\n" +
 		"gsoci.azurecr.io/giantswarm/muster:dev\tsha256:0ff1ce\n")
 	check("dev image pruned on the host, muster:dev pulled for real",
-		[]string{"docker.io/library/postgres:18.3-alpine", "gsoci.azurecr.io/giantswarm/golang-adk:0.10.0", "gsoci.azurecr.io/giantswarm/muster:dev"},
-		[]string{"docker.io/library/backstage-dev:multi-backend-022f5b7e"})
+		[]string{refPostgres, refGolangADK, refMusterDev},
+		[]string{refBackstageDev})
 }

--- a/internal/lab/preload_test.go
+++ b/internal/lab/preload_test.go
@@ -1,8 +1,12 @@
 package lab
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
 )
 
 func TestScrapeImages(t *testing.T) {
@@ -52,4 +56,98 @@ spec:
 	if !slices.Equal(got, want) {
 		t.Fatalf("scrapeImages:\n got  %v\n want %v", got, want)
 	}
+}
+
+// TestRegistryBacked: the snapshot keeps what the next boot can pull — refs
+// the host cache does not know (the node pulled them itself) and refs it
+// knows with a registry digest — and drops what it knows without one: images
+// built or tagged here and side-loaded, which docker spells
+// `docker.io/library/<name>` in the node although no registry has them.
+func TestRegistryBacked(t *testing.T) {
+	prov := parseImageProvenance("backstage-dev:multi-backend-022f5b7e\t<none>\n" +
+		"postgres:18.3-alpine\tsha256:54451ecb8ab38c24c3ec123f2fd501303a3a1856a5c66e98cecf2460d5e1e9d7\n" +
+		"alpine/socat:1.8.1.3\tsha256:5f275aa1b6e9889c851f61097142ee050fc6ac4615b4ea64ac1f2b0e81ff8d7f\n" +
+		"gsoci.azurecr.io/giantswarm/muster:dev\t<none>\n" +
+		"gsoci.azurecr.io/giantswarm/muster:5.10.2\tsha256:b97b80cd922c4aa2b6aa61e3fca50194d211b1b5a90b5931ce1eef5ff74d35a5\n" +
+		"<none>:<none>\t<none>\n")
+	for ref, want := range map[string]bool{
+		"docker.io/library/backstage-dev:multi-backend-022f5b7e": false, // built here
+		"docker.io/library/postgres:18.3-alpine":                 true,  // pulled from Docker Hub
+		"docker.io/alpine/socat:1.8.1.3":                         true,  // pulled, non-library namespace
+		"gsoci.azurecr.io/giantswarm/muster:dev":                 false, // a dev build tagged into a registry repo
+		"gsoci.azurecr.io/giantswarm/muster:5.10.2":              true,
+		"gsoci.azurecr.io/giantswarm/golang-adk:0.10.0":          true, // unknown to the host: the node pulled it
+	} {
+		if got := registryBacked(ref, prov); got != want {
+			t.Errorf("registryBacked(%q) = %v, want %v", ref, got, want)
+		}
+	}
+	if _, dangling := prov["<none>:<none>"]; dangling {
+		t.Error("untagged rows must not enter the provenance map")
+	}
+	for ref, want := range map[string]string{
+		"docker.io/library/postgres:18.3-alpine": "postgres:18.3-alpine",
+		"docker.io/alpine/socat:1.8.1.3":         "alpine/socat:1.8.1.3",
+		"ghcr.io/dexidp/dex:v2.45.1":             "ghcr.io/dexidp/dex:v2.45.1",
+	} {
+		if got := shortRef(ref); got != want {
+			t.Errorf("shortRef(%q) = %q, want %q", ref, got, want)
+		}
+	}
+}
+
+// TestSnapshotPreloadImagesSkipsLocalBuilds runs the snapshot against a
+// stand-in docker. The node's crictl list holds infra images, a pulled
+// official image, an image the node pulled itself, a dev image built on the
+// host and a dev build tagged into a registry repo: the pull set gets the two
+// pullable refs, the two local ones are remembered as such. Then the host
+// prunes the dev image and pulls that repo:tag for real: the memory
+// keeps the pruned one out, the real pull brings the other in.
+func TestSnapshotPreloadImagesSkipsLocalBuilds(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	hostImages := filepath.Join(dir, "host-images")
+	t.Setenv("FAKE_HOST_IMAGES", hostImages)
+	installFakeTool(t, dir, "docker", `
+case "$1" in
+exec) cat <<'JSON'
+{"images":[
+ {"repoTags":["docker.io/library/backstage-dev:multi-backend-022f5b7e"]},
+ {"repoTags":["docker.io/library/postgres:18.3-alpine"]},
+ {"repoTags":["gsoci.azurecr.io/giantswarm/golang-adk:0.10.0"]},
+ {"repoTags":["gsoci.azurecr.io/giantswarm/muster:dev"]},
+ {"repoTags":["registry.k8s.io/etcd:3.6.4-0","docker.io/kindest/kindnetd:v20250512-df8de77b"]}
+]}
+JSON
+;;
+images) cat "$FAKE_HOST_IMAGES" ;;
+esac`)
+	writeHost := func(rows string) {
+		if err := os.WriteFile(hostImages, []byte(rows), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	check := func(phase string, wantPull, wantLocal []string) {
+		t.Helper()
+		snapshotPreloadImages(config.Default())
+		if got := readPreloadManifest(); !slices.Equal(got, wantPull) {
+			t.Errorf("%s: pull set\n got  %v\n want %v", phase, got, wantPull)
+		}
+		if got := readLocalOnlyRefs(); !slices.Equal(got, wantLocal) {
+			t.Errorf("%s: local-only memory\n got  %v\n want %v", phase, got, wantLocal)
+		}
+	}
+
+	writeHost("backstage-dev:multi-backend-022f5b7e\t<none>\n" +
+		"postgres:18.3-alpine\tsha256:54451e\n" +
+		"gsoci.azurecr.io/giantswarm/muster:dev\t<none>\n")
+	check("host knows both local images",
+		[]string{"docker.io/library/postgres:18.3-alpine", "gsoci.azurecr.io/giantswarm/golang-adk:0.10.0"},
+		[]string{"docker.io/library/backstage-dev:multi-backend-022f5b7e", "gsoci.azurecr.io/giantswarm/muster:dev"})
+
+	writeHost("postgres:18.3-alpine\tsha256:54451e\n" +
+		"gsoci.azurecr.io/giantswarm/muster:dev\tsha256:0ff1ce\n")
+	check("dev image pruned on the host, muster:dev pulled for real",
+		[]string{"docker.io/library/postgres:18.3-alpine", "gsoci.azurecr.io/giantswarm/golang-adk:0.10.0", "gsoci.azurecr.io/giantswarm/muster:dev"},
+		[]string{"docker.io/library/backstage-dev:multi-backend-022f5b7e"})
 }

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -49,6 +49,12 @@ func Up(cfg *config.Config) error {
 
 	if kindClusterExists(cfg.ClusterName) {
 		step("kind cluster %q already exists", cfg.ClusterName)
+		// Its node may be exited — what a `down` that lost its race with
+		// docker leaves behind (node.go); `kind get kubeconfig` below would
+		// fail on it with an opaque docker exec error.
+		if err := ensureNodeRunning(cfg); err != nil {
+			return err
+		}
 	} else {
 		step("Creating kind cluster %q", cfg.ClusterName)
 		if err := run("kind", "create", "cluster", "--config", kindCfgPath, "--wait", "120s"); err != nil {


### PR DESCRIPTION
## Incident

2026-09-06 13:32, host demiurg: a sibling session's `agentlab up` was side-loading ~100 images into the node (`docker exec … ctr images import`) when `agentlab down` ran in a terminal. `kind delete cluster` is `docker rm -f` of the node; docker gives the node ten seconds after SIGKILL to exit, then logged `Container failed to exit within 10s of kill - trying direct SIGKILL` and answered the `DELETE /containers/agentlab-control-plane?force=1` with 500 `cannot remove container: could not kill container: tried to kill container, but did not receive an exit event`. The node actually died 44 s later.

- `agentlab down` returned kind's error; the container stayed in `docker ps -a` as `Exited (137)` and `kind get clusters` kept listing the cluster.
- `agentlab up` saw "kind cluster already exists" and died in `kind get kubeconfig` (`docker exec … cat /etc/kubernetes/admin.conf`: runc `nsexec-1: failed to open /proc/4246/ns/ipc` while the node was dying, `container … is not running` once dead).
- Docker's on-failure restart policy did not fire: an API kill counts as a manual stop. The sibling recovered by hand with `docker start agentlab-control-plane` and a second `agentlab up`.

Separately, the boot-time host pre-pull recorded local-only side-loaded refs (`docker.io/library/backstage-dev:*`, `…/model-manager:dev-*`, `…/agent-manager:dev-*`) in `state/preload-images.txt`; once pruned locally, every boot asked Docker Hub for them and dockerd logged one `denied: requested access to the resource is denied / unauthorized: authentication required` per ref (33 in the 13:35 boot).

## Changes

1. **`Down` survives docker's "did not receive an exit event"** (`down.go`, `node.go`). When `kind delete cluster` fails, Down polls `docker ps -a --filter label=io.x-k8s.kind.cluster=<name>` every 2 s until no node container is alive (exited or already gone; a paused one is unpaused so the pending SIGKILL can land), says once what it is waiting for, then retries `kind delete cluster` — now a plain rm of an exited container. Bounded at 90 s; exits non-zero only if the node is still alive after that, naming it and pointing at `journalctl -u docker`.
2. **`Up` recognises a cluster whose node container is not running** (`up.go`, `node.go`). After `kindClusterExists`, `ensureNodeRunning` reads `docker inspect --format {{.State.Status}}`; a running node is left completely alone (no extra calls). Anything else is brought back with `docker start` (`docker unpause` for a paused one — what kind itself supports and what the sibling did by hand), the kubeconfig is exported and `/readyz` polled (up to 120 s) before anything touches the cluster. If docker cannot start it, the error names the node, its state and the fix (`agentlab up` again once settled, or `agentlab down`).
3. **The preload manifest only records what a registry can serve** (`preload.go`). At snapshot time `docker images --digests` classifies every host-known image: a registry digest means pulled (kept), `<none>` means built or tagged here (dropped). Refs the host does not know were pulled by the node itself and stay. Dropped refs are remembered as `# local-only: <ref>` comment lines in the manifest, so a later `docker image prune` on the host does not make them look like node pulls while the cluster lives; the host's current knowledge wins whenever it has any (a real pull of the same repo:tag makes it pullable again). `hostPullImages` keeps its quiet-on-failure semantics for genuinely optional refs.

Limitation: docker shows a repository's digest on every tag of that repository, so a pulled image re-tagged *within the same repository* (`muster:5.10.2` → `muster:dev`) still reads as pulled. Re-tags into another repository (the dev-image swap shape, `backstage-dev:<tag>`) read `<none>` and are handled.

## Verification

Unit tests (stand-in `docker`/`kind`/`kubectl` on PATH, the repo's `installFakeKind` pattern): `TestAliveContainers`, `TestNodeStartVerb`, `TestWaitForNodeExit` (running→running→exited poll count, paused→unpause, timeout error), `TestEnsureNodeRunning` (running untouched; exited → start + kubeconfig + `/readyz`; paused → unpause; start failure wording), `TestRegistryBacked`, `TestSnapshotPreloadImagesSkipsLocalBuilds` (two phases: host knows both local images; dev image pruned + re-tag pulled for real). `go test ./...`, `go vet`, `goimports -local` clean.

Real proof on a **throwaway** cluster `agentlab-chip` (own ports 32001/7008/8093/8082/8443, platform and Backstage off, from a worktree; the shared `agentlab` cluster, its images and lock were not touched — lab lock held with an owner file during the run). `agentlab-before` = `main` (b69b41d), `agentlab` = this branch. "Too busy to die" was reproduced deterministically: a cgroup `io.max` write throttle (5 MB/s) on the node plus one 100 MB `dd … oflag=direct` inside it — a single uninterruptible syscall, the same shape as a node mid `ctr images import`. Docker's output is byte-identical to the incident.

<details><summary>A — up on an exited node (before/after)</summary>

```
### A1 the half-deleted state: node container killed, kind still lists the cluster
[15:07:48] docker ps -a: agentlab-chip-control-plane exited (Exited (137) Less than a second ago);
[15:07:48] kind get clusters: agentlab agentlab-chip ats

### A2 BEFORE: agentlab up on that cluster
rc=1
==> [00:00] kind cluster "agentlab-chip" already exists
Error: no kubeconfig for kind cluster "agentlab-chip" (is the lab up? `agentlab up`): kind get kubeconfig --name agentlab-chip: exit status 1: ERROR: failed to get cluster internal kubeconfig: command "docker exec --privileged agentlab-chip-control-plane cat /etc/kubernetes/admin.conf" failed with error: exit status 1
Command Output: Error response from daemon: container 00685414d0ad… is not running

### A3 AFTER: agentlab up on that cluster
rc=0 after 45s
==> [00:00] kind cluster "agentlab-chip" already exists
==> [00:00] Node container agentlab-chip-control-plane is exited — docker start, then waiting for the apiserver
    apiserver answers again (7s)
==> [00:07] Deploying Dex
==> [00:08] Waiting for Dex to become ready
==> [00:09] Applying RBAC bound to OIDC groups
==> [00:09] Waiting for the issuer to answer on https://localhost:32001/dex
==> [00:37] Verifying the end-to-end OIDC chain
    apiserver accepts Dex tokens
Lab is up.
[15:08:34] docker ps -a: agentlab-chip-control-plane running (Up 45 seconds);
```
</details>

<details><summary>B — down while the node is too busy to die (before/after)</summary>

```
### B1 BEFORE: agentlab down while the node is too busy to die (throttled 100 MB direct write inside it)
io.max on agentlab-chip-control-plane: 253:0 rbps=max wbps=5242880 riops=max wiops=max
[15:08:34] 100 MB direct write in flight inside agentlab-chip-control-plane (throttled to 5 MB/s)
rc=1 after 13s
Deleting cluster "agentlab-chip" ...
ERROR: failed to delete cluster "agentlab-chip": failed to delete nodes: command "docker rm -f -v agentlab-chip-control-plane" failed with error: exit status 1
Command Output: Error response from daemon: cannot remove container "agentlab-chip-control-plane": could not kill container: tried to kill container, but did not receive an exit event
Error: exit status 1
[15:08:47] docker ps -a: agentlab-chip-control-plane running (Up 57 seconds);
[15:08:47] kind get clusters: agentlab agentlab-chip ats
[15:08:47] waiting for the node to actually die ...
137
docker wait exit code=0 at +21s
[15:08:55] docker ps -a: agentlab-chip-control-plane exited (Exited (137) Less than a second ago);
[15:08:55] kind get clusters: agentlab agentlab-chip ats
dockerd: Container failed to exit within 10s of kill - trying direct SIGKILL
dockerd: could not kill container: tried to kill container, but did not receive an exit event

### B2 AFTER: agentlab up recovers the node docker left behind
rc=0 after 43s
==> [00:00] kind cluster "agentlab-chip" already exists
==> [00:00] Node container agentlab-chip-control-plane is exited — docker start, then waiting for the apiserver
    apiserver answers again (7s)
…
Lab is up.

### B3 AFTER: agentlab down while the node is too busy to die
io.max on agentlab-chip-control-plane: 253:0 rbps=max wbps=5242880 riops=max wiops=max
[15:09:38] 100 MB direct write in flight inside agentlab-chip-control-plane (throttled to 5 MB/s)
rc=0 after 23s
Deleting cluster "agentlab-chip" ...
ERROR: failed to delete cluster "agentlab-chip": failed to delete nodes: command "docker rm -f -v agentlab-chip-control-plane" failed with error: exit status 1
Command Output: Error response from daemon: cannot remove container "agentlab-chip-control-plane": could not kill container: tried to kill container, but did not receive an exit event
==> [00:12] Waiting up to 1m30s for agentlab-chip-control-plane (running) to exit: docker could not kill it in time and kind still lists the cluster
    node exited after 10s
==> [00:22] Retrying kind delete cluster
Deleting cluster "agentlab-chip" ...
Deleted nodes: ["agentlab-chip-control-plane"]
Lab destroyed. certs/ kept (agentlab certs --force to regenerate).
[15:10:01] docker ps -a:
[15:10:01] kind get clusters: agentlab ats
```
</details>

<details><summary>C — preload manifest: local-only refs (before/after)</summary>

```
### C1 manifest after the fresh boot (fixed binary)
ghcr.io/dexidp/dex:v2.45.1

### C2 a local-only image (built/tagged here: no registry digest), side-loaded into the node
chip-local:1 digest=<none>
Image: "chip-local:1" … not yet present on node "agentlab-chip-control-plane", loading...
docker.io/library/chip-local    1    d529dd0c6e559    8.7MB

### C3 BEFORE: re-run up; the snapshot records the local-only ref
docker.io/library/chip-local:1
ghcr.io/dexidp/dex:v2.45.1

### C4 BEFORE: prune the local copy and boot again -> Docker Hub is asked for docker.io/library/chip-local:1
dockerd pull denials during this boot: 1
Sep 06 15:04:25 demiurg dockerd[1638]: level=error msg="Not continuing with pull after error" error="errors:\ndenied: requested access to the resource is denied\nunauthorized: authentication required\n"
docker.io/library/chip-local:1
ghcr.io/dexidp/dex:v2.45.1

### C5 AFTER: local copy present again (built here, no digest) -> the snapshot leaves it out and remembers why
ghcr.io/dexidp/dex:v2.45.1
# Built or tagged on this host and side-loaded: no registry serves them,
# so they stay out of the pull set even once the local copy is pruned.
# local-only: docker.io/library/chip-local:1

### C6 AFTER: prune the local copy and boot again -> nothing asks Docker Hub; the memory keeps it out
dockerd pull denials during this boot: 0
(manifest unchanged)

### C7 AFTER: one more boot with the copy still pruned (the node still holds the image) -> still quiet
dockerd pull denials during this boot: 0
(manifest unchanged)
```
</details>

## Notes

- #43 (pipo02mix) touches `up.go` at the top of `Up` and appends at the end of the file; this PR's `up.go` change is confined to the cluster-exists block and all new code lives in `node.go`, so the two merge cleanly in either order. #52 does not overlap.
- Throwaway cluster, its kube context, the probe image and the lab lock were removed after the run; the shared lab is untouched.
