### PR TITLE
fix(lab): run the lab under rootless Podman

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -375,6 +375,16 @@ real installation runs its edge on 443, so the umbrella has no reason to
 carry a ported public URL; the overlay is the lab's permanent answer, not an
 interim.
 
+### U16. Podman: the side-load is one `kind load` per image — BLOCKED UPSTREAM
+`kind load docker-image a b c` runs `docker save -o <tar> a b c`. Podman's
+docker-compatible CLI writes ONE image carrying every name as a tag unless
+`--multi-image-archive` is passed, so the batch lands one image under all
+the tags (the Flux controllers crashlooped running flux-cli). Docker needs
+no flag, so kind cannot pass one portably. Under podman (`runtime.go`) the
+lab loads one image per call; under docker the batched call stays. Unblocks
+when kind's `load docker-image` saves with `--multi-image-archive` under
+its podman provider.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/HACKS.md
+++ b/HACKS.md
@@ -385,6 +385,15 @@ lab loads one image per call; under docker the batched call stays. Unblocks
 when kind's `load docker-image` saves with `--multi-image-archive` under
 its podman provider.
 
+### U17. Rootless Podman: the edge moves off 443 — NOT A BUG, A HOST LIMIT
+Rootless Podman publishes ports from the invoking user's network namespace,
+where the kernel refuses everything below
+`net.ipv4.ip_unprivileged_port_start` (1024). A bind probe alone reads a free
+443 as usable, because the lab's own process cannot bind it either way, so
+`configure` asks the engine instead (`MinPublishablePort`, `runtime.go`) and
+`ChooseFreePorts` moves the edge to 8443. Resolves for a user who runs Podman
+as root or lowers the sysctl; nothing to fix in the lab.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ follows the host instead of freezing the first run's view of it:
 Discovering this machine:
   tools             docker 29.7.2, kind v0.32.0, kubectl v1.36.4, helm v4.2.2
   cluster           kind "agentlab" exists — its port mappings are fixed at node creation (`agentlab down && agentlab up` to change them)
-  Ollama            0.33.2 on :11434 — listens on the kind gateway 172.21.0.1: yes; 10 downloaded, 4 tool-calling
-  Lemonade Server   11.9.0 on :13305 — listens on the kind gateway 172.21.0.1: yes; 4 downloaded, 3 tool-calling
+  Ollama            0.33.2 on :11434 — answers on 172.21.0.1 (the address pods dial): yes; 10 downloaded, 4 tool-calling
+  Lemonade Server   11.9.0 on :13305 — answers on 172.21.0.1 (the address pods dial): yes; 4 downloaded, 3 tool-calling
   Anthropic key     $ANTHROPIC_API_KEY is set — the agents' default ModelConfig and Backstage's AI chat get the real key at deploy time
 
 Applied to the configuration:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ YAML to hand-edit and no shell to source.
 
 ## Requirements
 
-`go` (>= 1.25), `docker`, `kind` (>= 0.31), `kubectl`, `helm` (**>= 4** — Helm 3
+`go` (>= 1.25), `docker` (or Podman >= 4's docker-compatible CLI), `kind`
+(>= 0.31), `kubectl`, `helm` (**>= 4** — Helm 3
 cannot store the umbrella chart's release any more: the dependency archives put
 the release Secret over etcd's 1 MiB cap, see
 [agent-platform-standalone#21](https://github.com/giantswarm/agent-platform-standalone/issues/21);

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ see below), `git`.
 (The old script stack also needed openssl, curl, jq and python3; the binary
 does all of that itself.)
 
+Under **rootless Podman** the lab publishes its ports from your own network
+namespace, which cannot bind anything below
+`net.ipv4.ip_unprivileged_port_start` (1024 by default). `agentlab configure`
+detects this and moves the agentgateway edge off its default 443 — to 8443,
+so the public URLs gain `:8443` — and reports the move. Run Podman as root, or
+lower the sysctl, to keep 443.
+
 ## Quick start
 
 Install the `agentlab` binary one of three ways:

--- a/internal/config/discovery_test.go
+++ b/internal/config/discovery_test.go
@@ -141,7 +141,7 @@ func TestPortConflictsIgnoreTheClustersOwnPorts(t *testing.T) {
 func TestChooseFreePortsOnExistingConfigWithoutCluster(t *testing.T) {
 	cfg := Default()
 	cfg.Platform.MusterPort = 8092 // moved by an earlier run; still free
-	changes := cfg.chooseFreePorts(takenSet(cfg.Backstage.Port))
+	changes := cfg.chooseFreePorts(takenSet(cfg.Backstage.Port), everyPortPublishable)
 	if len(changes) != 1 || changes[0].Field != "backstage.port" {
 		t.Fatalf("changes = %v, want exactly backstage.port", changes)
 	}

--- a/internal/config/ports.go
+++ b/internal/config/ports.go
@@ -10,19 +10,24 @@ import (
 )
 
 // PortChange records one port of the configuration that was moved off its
-// value because something on this machine already listens there. Field is
-// the agentlab.yaml path, What names the component for the human-facing
-// message, Note carries an extra caveat where a non-default port has
-// consequences beyond the number itself.
+// value because this machine cannot serve the lab there. Field is the
+// agentlab.yaml path, What names the component for the human-facing message,
+// Why says what made the port unusable, and Note carries an extra caveat
+// where a non-default port has consequences beyond the number itself.
 type PortChange struct {
 	Field    string
 	What     string
 	From, To int
+	Why      string
 	Note     string
 }
 
 func (ch PortChange) String() string {
-	s := fmt.Sprintf("%s: %d is in use, using %d instead (%s", ch.Field, ch.From, ch.To, ch.What)
+	why := ch.Why
+	if why == "" {
+		why = "is in use"
+	}
+	s := fmt.Sprintf("%s: %d %s, using %d instead (%s", ch.Field, ch.From, why, ch.To, ch.What)
 	if ch.Note != "" {
 		s += "; " + ch.Note
 	}
@@ -91,15 +96,17 @@ func (c *Config) ports() []labPort {
 
 // ChooseFreePorts probes every host-side port of the configuration on
 // 127.0.0.1 — the address all kind port mappings bind — and moves each
-// occupied one to a nearby free port, returning what changed so the caller
+// unusable one to a nearby free port, returning what changed so the caller
 // can tell the user. Ports in `ours` are the lab's own (published by an
 // existing kind node of this very configuration) and never count as
-// occupied. Meant for a configuration whose cluster does not exist (yet, or
-// any more): an existing cluster's mappings are fixed at node creation, where
-// renumbering would only mislead — PortConflicts is the read-only check for
-// that case.
-func (c *Config) ChooseFreePorts(ours map[int]bool) []PortChange {
-	return c.chooseFreePorts(func(p int) bool { return !ours[p] && portTaken(p) })
+// occupied. Ports below minPublishable are ones the container engine cannot
+// bind at all (rootless podman and the privileged range); pass 1 where every
+// port is available. Meant for a configuration whose cluster does not exist
+// (yet, or any more): an existing cluster's mappings are fixed at node
+// creation, where renumbering would only mislead — PortConflicts is the
+// read-only check for that case.
+func (c *Config) ChooseFreePorts(ours map[int]bool, minPublishable int) []PortChange {
+	return c.chooseFreePorts(func(p int) bool { return !ours[p] && portTaken(p) }, minPublishable)
 }
 
 // PortConflicts reports which host-side ports of the configuration another
@@ -121,7 +128,11 @@ func (c *Config) portConflicts(taken func(int) bool) []PortConflict {
 
 // chooseFreePorts is ChooseFreePorts with the probe injected, so tests can
 // run against a fixed set of "occupied" ports instead of the machine.
-func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
+func (c *Config) chooseFreePorts(taken func(int) bool, minPublishable int) []PortChange {
+	// A port the engine cannot publish is unusable whatever the probe says:
+	// binding it here succeeds as often as not (the lab runs unprivileged
+	// too), so the probe alone would call it free.
+	unusable := func(p int) bool { return p < minPublishable || taken(p) }
 	// Every port with a fixed meaning in the lab, so replacements never
 	// collide with each other or with it: the config's own host ports, the
 	// browser-login callback (host-side, pre-registered in Dex), and the
@@ -142,7 +153,7 @@ func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
 
 	scan := func(lo, hi int) (int, bool) {
 		for p := lo; p <= hi; p++ {
-			if !reserved[p] && !taken(p) {
+			if !reserved[p] && !unusable(p) {
 				return p, true
 			}
 		}
@@ -151,7 +162,7 @@ func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
 
 	var changes []PortChange
 	for _, lp := range c.ports() {
-		if !taken(*lp.port) {
+		if !unusable(*lp.port) {
 			continue
 		}
 		to, ok := lp.pick(scan)
@@ -162,6 +173,9 @@ func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
 		}
 		reserved[to] = true
 		ch := PortChange{Field: lp.field, What: lp.what, From: *lp.port, To: to}
+		if *lp.port < minPublishable {
+			ch.Why = fmt.Sprintf("cannot be published by this container engine (nothing below %d can)", minPublishable)
+		}
 		if lp.note != nil {
 			ch.Note = lp.note(to)
 		}

--- a/internal/config/ports_test.go
+++ b/internal/config/ports_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+// everyPortPublishable is the minPublishable of an engine that binds as root
+// — docker, and podman run by root. Nothing is out of reach.
+const everyPortPublishable = 1
+
 // takenSet builds a probe stub that reports exactly the given ports occupied.
 func takenSet(ports ...int) func(int) bool {
 	set := map[int]bool{}
@@ -19,7 +23,7 @@ func takenSet(ports ...int) func(int) bool {
 func TestChooseFreePortsNothingTaken(t *testing.T) {
 	cfg := Default()
 	want := Default()
-	if changes := cfg.chooseFreePorts(takenSet()); len(changes) != 0 {
+	if changes := cfg.chooseFreePorts(takenSet(), everyPortPublishable); len(changes) != 0 {
 		t.Fatalf("expected no changes, got %v", changes)
 	}
 	got := []int{cfg.DexPort, cfg.Platform.MusterPort, cfg.Platform.AgentsPort, cfg.Platform.GatewayPort, cfg.Backstage.Port}
@@ -36,7 +40,7 @@ func TestChooseFreePortsMovesEveryTakenPort(t *testing.T) {
 	changes := cfg.chooseFreePorts(takenSet(
 		cfg.DexPort, cfg.Platform.MusterPort, cfg.Platform.AgentsPort,
 		cfg.Platform.GatewayPort, cfg.Backstage.Port,
-	))
+	), everyPortPublishable)
 	if len(changes) != 5 {
 		t.Fatalf("expected 5 changes, got %d: %v", len(changes), changes)
 	}
@@ -73,7 +77,7 @@ func TestChooseFreePortsSkipsOtherLabPorts(t *testing.T) {
 	for p := 8082; p <= 8089; p++ {
 		occupied = append(occupied, p)
 	}
-	cfg.chooseFreePorts(takenSet(occupied...))
+	cfg.chooseFreePorts(takenSet(occupied...), everyPortPublishable)
 	if cfg.Platform.AgentsPort != 8091 {
 		t.Fatalf("agentsPort = %d, want 8091 (8090 is muster's)", cfg.Platform.AgentsPort)
 	}
@@ -81,7 +85,7 @@ func TestChooseFreePortsSkipsOtherLabPorts(t *testing.T) {
 
 func TestChooseFreePortsGatewayPrefers8443(t *testing.T) {
 	cfg := Default()
-	changes := cfg.chooseFreePorts(takenSet(443, 8443))
+	changes := cfg.chooseFreePorts(takenSet(443, 8443), everyPortPublishable)
 	if cfg.Platform.GatewayPort != 8444 {
 		t.Fatalf("gatewayPort = %d, want 8444", cfg.Platform.GatewayPort)
 	}
@@ -96,7 +100,7 @@ func TestChooseFreePortsDexWrapsWithinNodePortRange(t *testing.T) {
 	for p := cfg.DexPort; p <= 32767; p++ {
 		occupied = append(occupied, p)
 	}
-	cfg.chooseFreePorts(takenSet(occupied...))
+	cfg.chooseFreePorts(takenSet(occupied...), everyPortPublishable)
 	if cfg.DexPort != 30000 {
 		t.Fatalf("dexPort = %d, want 30000 (wrap to the bottom of the NodePort range)", cfg.DexPort)
 	}
@@ -107,7 +111,7 @@ func TestChooseFreePortsReplacementsDoNotCollide(t *testing.T) {
 	cfg := Default()
 	cfg.Platform.MusterPort = 9000
 	cfg.Platform.AgentsPort = 9001
-	cfg.chooseFreePorts(takenSet(9000, 9001))
+	cfg.chooseFreePorts(takenSet(9000, 9001), everyPortPublishable)
 	if cfg.Platform.MusterPort == cfg.Platform.AgentsPort {
 		t.Fatalf("muster and agents both landed on %d", cfg.Platform.MusterPort)
 	}
@@ -121,7 +125,7 @@ func TestChooseFreePortsReplacementsDoNotCollide(t *testing.T) {
 // reports the real bind error) instead of looping or panicking.
 func TestChooseFreePortsExhaustedRangeKeepsPort(t *testing.T) {
 	cfg := Default()
-	cfg.chooseFreePorts(func(int) bool { return true })
+	cfg.chooseFreePorts(func(int) bool { return true }, everyPortPublishable)
 	if cfg.DexPort != 32000 {
 		t.Fatalf("dexPort = %d, want the untouched 32000", cfg.DexPort)
 	}
@@ -162,5 +166,48 @@ func TestConfigValidateRejectsPinnedDexPort(t *testing.T) {
 	cfg.DexPort = DefaultDexPort
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("default dexPort rejected: %v", err)
+	}
+}
+
+// Rootless podman cannot publish below net.ipv4.ip_unprivileged_port_start,
+// so the gateway's default 443 has to move even though nothing listens there
+// — the bind probe alone reads a free privileged port as usable.
+func TestChooseFreePortsMovesUnpublishablePrivilegedPort(t *testing.T) {
+	cfg := Default()
+	if cfg.Platform.GatewayPort >= 1024 {
+		t.Fatalf("this test needs a privileged default gateway port, got %d", cfg.Platform.GatewayPort)
+	}
+	changes := cfg.chooseFreePorts(takenSet(), 1024)
+	if len(changes) != 1 {
+		t.Fatalf("expected only the gateway to move, got %v", changes)
+	}
+	ch := changes[0]
+	if ch.Field != "platform.gatewayPort" || ch.From != 443 || ch.To != 8443 {
+		t.Errorf("got %+v, want platform.gatewayPort 443 -> 8443", ch)
+	}
+	if cfg.Platform.GatewayPort != 8443 {
+		t.Errorf("config keeps %d, want 8443", cfg.Platform.GatewayPort)
+	}
+	// The message must not claim the port is in use: nothing listens there.
+	if strings.Contains(ch.String(), "is in use") {
+		t.Errorf("%q blames a listener that does not exist", ch.String())
+	}
+	if !strings.Contains(ch.String(), "cannot be published") {
+		t.Errorf("%q does not say why 443 is unusable", ch.String())
+	}
+}
+
+// A replacement is never picked from the unpublishable range either.
+func TestChooseFreePortsReplacementIsPublishable(t *testing.T) {
+	cfg := Default()
+	cfg.Platform.MusterPort = 700
+	changes := cfg.chooseFreePorts(takenSet(), 1024)
+	for _, ch := range changes {
+		if ch.To < 1024 {
+			t.Errorf("%s moved to %d, below the publishable floor", ch.Field, ch.To)
+		}
+	}
+	if cfg.Platform.MusterPort < 1024 {
+		t.Errorf("muster port stayed at %d, below the publishable floor", cfg.Platform.MusterPort)
 	}
 }

--- a/internal/lab/discover.go
+++ b/internal/lab/discover.go
@@ -2,10 +2,12 @@ package lab
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -43,10 +45,12 @@ type HostServer struct {
 	Backend string // config.ModelManagerBackend*
 	Version string
 	Port    int
-	// OnGateway: the server also answers on the kind docker gateway address,
-	// i.e. it is bound to every interface and pods can reach it. nil when
-	// the kind network does not exist yet (nothing to dial).
+	// OnGateway: the server also answers on the address pods dial, i.e. it is
+	// bound to every interface and pods can reach it. nil when that address
+	// is not known yet (nothing to dial) or the probe could not run, which
+	// ReachErr then explains.
 	OnGateway *bool
+	ReachErr  error
 	Models    []HostModel
 	ModelsErr error
 }
@@ -88,8 +92,12 @@ func Discover(cfg *config.Config) *Discovery {
 		}
 		s := HostServer{Backend: b, Version: version, Port: config.BackendPort(b)}
 		if d.KindGateway != "" {
-			answers := hostServerAnswers(cfg.ControlPlaneNode(), net.JoinHostPort(d.KindGateway, strconv.Itoa(s.Port)))
-			s.OnGateway = &answers
+			answers, err := hostServerAnswers(cfg.ControlPlaneNode(), net.JoinHostPort(d.KindGateway, strconv.Itoa(s.Port)))
+			if err != nil {
+				s.ReachErr = err
+			} else {
+				s.OnGateway = &answers
+			}
 		}
 		s.Models, s.ModelsErr = hostModelsFn(b, base)
 		d.Servers = append(d.Servers, s)
@@ -165,9 +173,14 @@ func (d *Discovery) Report(cfg *config.Config) string {
 		if dockerIsPodman() {
 			reach = "the address pods dial is not known while the node is not running (`agentlab up` starts it)"
 		}
-		if s.OnGateway != nil && *s.OnGateway {
+		switch {
+		case s.ReachErr != nil:
+			// Not a verdict on the server: the probe itself did not run, so
+			// the bind hint would send the user to fix the wrong thing.
+			reach = fmt.Sprintf("cannot tell whether pods reach it on %s (%v)", d.KindGateway, s.ReachErr)
+		case s.OnGateway != nil && *s.OnGateway:
 			reach = fmt.Sprintf("answers on %s (the address pods dial): yes", d.KindGateway)
-		} else if s.OnGateway != nil {
+		case s.OnGateway != nil:
 			reach = fmt.Sprintf("does NOT answer on %s (the address pods dial) — pods cannot reach it (%s)", d.KindGateway, bindHint(s.Backend))
 		}
 		models := "models not listed"
@@ -210,19 +223,48 @@ func bindHint(backend string) string {
 	return "OLLAMA_HOST=0.0.0.0, restart Ollama"
 }
 
+// nodeDialTimeout bounds the node-side dial, the podman counterpart of
+// tcpAnswers' own timeout. Longer, because it pays for `docker exec` too.
+const nodeDialTimeout = 2 * time.Second
+
 // hostServerAnswers is tcpAnswers from where it matters: under podman the
-// host cannot dial host.containers.internal itself, so the node dials it.
-func hostServerAnswers(node, addr string) bool {
+// host cannot dial host.containers.internal itself, so the node dials it. A
+// non-nil error means the probe did not run — never that the server is
+// unreachable.
+func hostServerAnswers(node, addr string) (bool, error) {
 	if !dockerIsPodman() {
-		return tcpAnswers(addr)
+		return tcpAnswers(addr), nil
 	}
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("probing %s: %w", addr, err)
 	}
-	_, err = outputQuiet("docker", "exec", node, "timeout", "2", "bash", "-c",
+	_, err = outputQuiet("docker", "exec", node,
+		"timeout", strconv.Itoa(int(nodeDialTimeout.Seconds())), "bash", "-c",
 		fmt.Sprintf("exec 3<>/dev/tcp/%s/%s", host, port))
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	// bash exits 1 when the dial is refused and `timeout` exits 124 when it
+	// hangs: both are answers about the server. Every other code is the
+	// probe failing (no bash or no timeout in the node, docker exec itself),
+	// which says nothing about the server.
+	switch exitCode(err) {
+	case 1, 124:
+		return false, nil
+	default:
+		return false, fmt.Errorf("dialing %s from node %q: %w", addr, node, err)
+	}
+}
+
+// exitCode digs the process exit status out of a wrapped command error; -1
+// when the command did not run or did not exit normally.
+func exitCode(err error) int {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
 }
 
 // tcpAnswers reports whether something accepts a TCP connection at addr.

--- a/internal/lab/discover.go
+++ b/internal/lab/discover.go
@@ -268,12 +268,18 @@ func kindNodePublishedPorts(node string) (exists bool, ports map[int]bool) {
 	return true, ports
 }
 
+// dockerVersion is the engine version, naming podman when its
+// docker-compatible CLI is what answers (runtime.go).
 func dockerVersion() string {
 	out, err := outputQuiet("docker", "version", "-f", "{{.Server.Version}}")
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(out)
+	v := strings.TrimSpace(out)
+	if dockerIsPodman() {
+		v += " (podman)"
+	}
+	return v
 }
 
 func kindVersion() string {

--- a/internal/lab/discover.go
+++ b/internal/lab/discover.go
@@ -77,7 +77,7 @@ func Discover(cfg *config.Config) *Discovery {
 		{"helm", helmVersion()},
 	}
 	d.ClusterExists, d.ClusterPorts = kindNodePublishedPorts(cfg.ControlPlaneNode())
-	if gw, err := kindGatewayIP(); err == nil {
+	if gw, err := kindGatewayIP(cfg.ControlPlaneNode()); err == nil {
 		d.KindGateway = gw
 	}
 	for _, b := range config.ModelManagerBackends {
@@ -88,7 +88,7 @@ func Discover(cfg *config.Config) *Discovery {
 		}
 		s := HostServer{Backend: b, Version: version, Port: config.BackendPort(b)}
 		if d.KindGateway != "" {
-			answers := tcpAnswers(net.JoinHostPort(d.KindGateway, strconv.Itoa(s.Port)))
+			answers := hostServerAnswers(cfg.ControlPlaneNode(), net.JoinHostPort(d.KindGateway, strconv.Itoa(s.Port)))
 			s.OnGateway = &answers
 		}
 		s.Models, s.ModelsErr = hostModelsFn(b, base)
@@ -162,10 +162,13 @@ func (d *Discovery) Report(cfg *config.Config) string {
 	}
 	for _, s := range d.Servers {
 		reach := "kind gateway not known yet (first `agentlab up` creates the network)"
+		if dockerIsPodman() {
+			reach = "the address pods dial is not known while the node is not running (`agentlab up` starts it)"
+		}
 		if s.OnGateway != nil && *s.OnGateway {
-			reach = fmt.Sprintf("listens on the kind gateway %s: yes", d.KindGateway)
+			reach = fmt.Sprintf("answers on %s (the address pods dial): yes", d.KindGateway)
 		} else if s.OnGateway != nil {
-			reach = fmt.Sprintf("does NOT listen on the kind gateway %s — pods cannot reach it (%s)", d.KindGateway, bindHint(s.Backend))
+			reach = fmt.Sprintf("does NOT answer on %s (the address pods dial) — pods cannot reach it (%s)", d.KindGateway, bindHint(s.Backend))
 		}
 		models := "models not listed"
 		if s.ModelsErr == nil {
@@ -205,6 +208,21 @@ func bindHint(backend string) string {
 		return "`lemonade config set host=0.0.0.0`, restart lemond"
 	}
 	return "OLLAMA_HOST=0.0.0.0, restart Ollama"
+}
+
+// hostServerAnswers is tcpAnswers from where it matters: under podman the
+// host cannot dial host.containers.internal itself, so the node dials it.
+func hostServerAnswers(node, addr string) bool {
+	if !dockerIsPodman() {
+		return tcpAnswers(addr)
+	}
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	_, err = outputQuiet("docker", "exec", node, "timeout", "2", "bash", "-c",
+		fmt.Sprintf("exec 3<>/dev/tcp/%s/%s", host, port))
+	return err == nil
 }
 
 // tcpAnswers reports whether something accepts a TCP connection at addr.

--- a/internal/lab/discover_test.go
+++ b/internal/lab/discover_test.go
@@ -2,9 +2,12 @@ package lab
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/agentlab/internal/config"
@@ -161,5 +164,57 @@ func TestDiscoveryBackendsAndHint(t *testing.T) {
 	}
 	if (&Discovery{}).ModelServersHint() != "" {
 		t.Fatalf("empty discovery should hint nothing")
+	}
+}
+
+// The node-side dial answers about the SERVER only when it actually ran: a
+// refused connection (bash exits 1) and a hang (`timeout` exits 124) are
+// verdicts, every other exit is the probe itself failing and must not be
+// reported as an unreachable server.
+func TestHostServerAnswersUnderPodman(t *testing.T) {
+	for name, tc := range map[string]struct {
+		exit      int
+		want      bool
+		wantProbe bool // the probe failed, so there is no verdict
+	}{
+		"server answers":     {0, true, false},
+		"connection refused": {1, false, false},
+		"dial hangs":         {124, false, false},
+		"no bash in node":    {127, false, true},
+		"exec not permitted": {126, false, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			installFakeTool(t, dir, "docker", "exit "+strconv.Itoa(tc.exit))
+			withPodman(t, true)
+			got, err := hostServerAnswers("agentlab-control-plane", "169.254.1.2:11434")
+			if (err != nil) != tc.wantProbe {
+				t.Fatalf("err = %v, want probe failure %v", err, tc.wantProbe)
+			}
+			if !tc.wantProbe && got != tc.want {
+				t.Errorf("answers = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A probe that could not run leaves OnGateway unset, and the report says so
+// instead of blaming the server's bind address.
+func TestReportSaysWhenTheProbeCouldNotRun(t *testing.T) {
+	d := &Discovery{
+		KindGateway: "169.254.1.2",
+		Servers: []HostServer{{
+			Backend:  config.ModelManagerBackendOllama,
+			Version:  "0.20.2",
+			Port:     config.OllamaPort,
+			ReachErr: errors.New("no bash in the node"),
+		}},
+	}
+	out := d.Report(config.Default())
+	if !strings.Contains(out, "cannot tell whether pods reach it on 169.254.1.2") {
+		t.Errorf("report does not name the failed probe:\n%s", out)
+	}
+	if strings.Contains(out, "OLLAMA_HOST=0.0.0.0") {
+		t.Errorf("report blames the server's bind address for a probe failure:\n%s", out)
 	}
 }

--- a/internal/lab/modelmanager.go
+++ b/internal/lab/modelmanager.go
@@ -87,21 +87,44 @@ func loopbackBase(backend string) string {
 	return fmt.Sprintf("http://127.0.0.1:%d", config.BackendPort(backend))
 }
 
-// kindGatewayIP returns the IPv4 gateway of the kind docker network — the
-// address pods use to reach services on the host.
-func kindGatewayIP() (string, error) {
+// kindGatewayIP returns the address pods dial to reach services on the host:
+// the IPv4 gateway of the kind docker network. Under rootless podman the
+// bridge gateway is not the host (pasta routes host traffic through
+// host.containers.internal, 169.254.1.2, and nothing answers on the
+// gateway), so there the address is what the node resolves that name to —
+// which needs the node, like the network needs the cluster.
+func kindGatewayIP(node string) (string, error) {
+	if dockerIsPodman() {
+		out, err := outputQuiet("docker", "exec", node, "getent", "hosts", "host.containers.internal")
+		if err != nil {
+			return "", fmt.Errorf("node %q cannot resolve host.containers.internal (the node must be running, and podman writes the name into its /etc/hosts): %w", node, err)
+		}
+		if ip := firstIPv4(out); ip != "" {
+			return ip, nil
+		}
+		return "", fmt.Errorf("node %q resolves host.containers.internal to no IPv4 address", node)
+	}
 	out, err := outputQuiet("docker", "network", "inspect", kindDockerNetwork,
 		"-f", `{{range .IPAM.Config}}{{.Gateway}}{{"\n"}}{{end}}`)
 	if err != nil {
 		return "", fmt.Errorf("docker network %q not found (the kind cluster creates it): %w", kindDockerNetwork, err)
 	}
-	for _, line := range strings.Split(out, "\n") {
-		ip := net.ParseIP(strings.TrimSpace(line))
-		if ip != nil && ip.To4() != nil {
-			return ip.String(), nil
-		}
+	if ip := firstIPv4(out); ip != "" {
+		return ip, nil
 	}
 	return "", fmt.Errorf("docker network %q has no IPv4 gateway", kindDockerNetwork)
+}
+
+// firstIPv4 returns the first IPv4 address leading a line of out.
+func firstIPv4(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if f := strings.Fields(line); len(f) > 0 {
+			if ip := net.ParseIP(f[0]); ip != nil && ip.To4() != nil {
+				return ip.String()
+			}
+		}
+	}
+	return ""
 }
 
 // resolveBackendEndpoint is the URL model-manager (or an agent pod) dials for
@@ -113,7 +136,7 @@ func resolveBackendEndpoint(cfg *config.Config, backend string) (string, error) 
 	if ep := cfg.Platform.ModelManager.EndpointFor(backend); ep != "" {
 		return strings.TrimSuffix(ep, "/"), nil
 	}
-	gw, err := kindGatewayIP()
+	gw, err := kindGatewayIP(cfg.ControlPlaneNode())
 	if err != nil {
 		return "", fmt.Errorf("autodetecting the %s endpoint: %w (set platform.modelManager.endpoints.%s to skip the detection)",
 			config.BackendServerName(backend), err, backend)

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -318,6 +318,12 @@ func ModelsTest(cfg *config.Config, email, backendName, model string) error {
 	if err != nil {
 		return err
 	}
+	if dockerIsPodman() && cfg.Platform.ModelManager.EndpointFor(backendName) == "" {
+		// This step runs on the host, and the host cannot dial the pods'
+		// address under podman (host.containers.internal, runtime.go): the
+		// autodetected server is this machine's, so read it on loopback.
+		endpoint = loopbackBase(backendName)
+	}
 	server := config.BackendServerName(backendName)
 	remaining, err := hostServerModels(backendName, endpoint)
 	if err != nil {

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -314,6 +314,8 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 		note("cannot derive the platform images from the charts (%v); the node pulls anything missing", err)
 	} else {
 		switch res := sideloadImages(cfg, hostPullImages(imgs)); {
+		case res.err != nil && res.n > 0:
+			note("side-loaded %d of %d platform images (%s); the rest failed (%v) and the node pulls them", res.n, len(imgs), res.d, res.err)
 		case res.err != nil:
 			note("side-loading failed (%v); the node pulls anything missing", res.err)
 		case res.n > 0:

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -94,29 +94,35 @@ func sideloadImages(cfg *config.Config, images []string) preloadResult {
 	if len(images) == 0 {
 		return preloadResult{}
 	}
-	if err := kindLoadImages(cfg, images); err != nil {
-		return preloadResult{err: err}
-	}
-	return preloadResult{n: len(images), d: time.Since(start).Round(time.Second)}
+	loaded, err := kindLoadImages(cfg, images)
+	return preloadResult{n: loaded, d: time.Since(start).Round(time.Second), err: err}
 }
 
-// kindLoadImages is one `kind load docker-image` for the batch — except
-// under podman, where kind's own multi-image save would fold the batch into
-// one image under every tag (runtime.go): there it is one call per image,
-// which saves a single image and is always right. kind stages and cleans its
-// own archive either way.
-func kindLoadImages(cfg *config.Config, images []string) error {
+// kindLoadImages side-loads images and reports how many landed. It is one
+// `kind load docker-image` for the batch — except under podman, where kind's
+// own multi-image save would fold the batch into one image under every tag
+// (runtime.go): there it is one call per image, which saves a single image
+// and is always right. kind stages and cleans its own archive either way. A
+// failed image does not stop the rest, so the count and the error are both
+// reported and a partial load reads as one.
+func kindLoadImages(cfg *config.Config, images []string) (int, error) {
 	if !dockerIsPodman() {
 		args := append([]string{"load", "docker-image", "--name", cfg.ClusterName}, images...)
-		return runQuiet("kind", args...)
+		if err := runQuiet("kind", args...); err != nil {
+			return 0, err
+		}
+		return len(images), nil
 	}
+	loaded := 0
 	var errs []error
 	for _, img := range images {
 		if err := runQuiet("kind", "load", "docker-image", "--name", cfg.ClusterName, img); err != nil {
 			errs = append(errs, err)
+			continue
 		}
+		loaded++
 	}
-	return errors.Join(errs...)
+	return loaded, errors.Join(errs...)
 }
 
 // pullLabImages starts pulling the snapshot manifest's images into the host
@@ -194,6 +200,8 @@ func sideloadDexImage(cfg *config.Config, ready <-chan bool) {
 func reportPreload(loaded <-chan preloadResult) {
 	res := <-loaded
 	switch {
+	case res.err != nil && res.n > 0:
+		note("preloaded %d cached images into the node (%s); the rest failed (%v) and their pods pull from the network", res.n, res.d, res.err)
 	case res.err != nil:
 		note("image preload failed (%v); pods will pull from the network", res.err)
 	case res.n > 0:

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -2,6 +2,7 @@ package lab
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -93,11 +94,29 @@ func sideloadImages(cfg *config.Config, images []string) preloadResult {
 	if len(images) == 0 {
 		return preloadResult{}
 	}
-	args := append([]string{"load", "docker-image", "--name", cfg.ClusterName}, images...)
-	if err := runQuiet("kind", args...); err != nil {
+	if err := kindLoadImages(cfg, images); err != nil {
 		return preloadResult{err: err}
 	}
 	return preloadResult{n: len(images), d: time.Since(start).Round(time.Second)}
+}
+
+// kindLoadImages is one `kind load docker-image` for the batch — except
+// under podman, where kind's own multi-image save would fold the batch into
+// one image under every tag (runtime.go): there it is one call per image,
+// which saves a single image and is always right. kind stages and cleans its
+// own archive either way.
+func kindLoadImages(cfg *config.Config, images []string) error {
+	if !dockerIsPodman() {
+		args := append([]string{"load", "docker-image", "--name", cfg.ClusterName}, images...)
+		return runQuiet("kind", args...)
+	}
+	var errs []error
+	for _, img := range images {
+		if err := runQuiet("kind", "load", "docker-image", "--name", cfg.ClusterName, img); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // pullLabImages starts pulling the snapshot manifest's images into the host

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -365,7 +365,9 @@ func nodeImageTags(node string) ([]string, error) {
 // tagged here. A pulled image re-tagged into ANOTHER repository shows <none>
 // too (the digest belongs to the repository it was pulled as); re-tagged within
 // the same repository it keeps the digest, and so still reads as pulled. Refs
-// are spelled the way docker prints them (shortRef).
+// are spelled the way docker prints them (shortRef). Podman prints a digest
+// for local builds too, but spells them `localhost/<name>`: that name is
+// what marks them local there.
 func hostImageProvenance() (map[string]bool, error) {
 	out, err := outputQuiet("docker", "images", "--digests", "--format", "{{.Repository}}:{{.Tag}}\t{{.Digest}}")
 	if err != nil {
@@ -385,7 +387,9 @@ func parseImageProvenance(out string) map[string]bool {
 			continue
 		}
 		digest = strings.TrimSpace(digest)
-		prov[ref] = prov[ref] || (digest != "" && digest != "<none>")
+		ref = shortRef(ref)
+		backed := digest != "" && digest != "<none>" && !strings.HasPrefix(ref, "localhost/")
+		prov[ref] = prov[ref] || backed
 	}
 	return prov
 }

--- a/internal/lab/preload_test.go
+++ b/internal/lab/preload_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/agentlab/internal/config"
@@ -179,5 +180,62 @@ func TestParseImageProvenancePodman(t *testing.T) {
 	}
 	if _, known := prov["postgres:18.3-alpine"]; !known {
 		t.Error("podman's docker.io/library/ rows must key the map as docker spells them")
+	}
+}
+
+// The reason this whole podman branch exists: `kind load docker-image a b c`
+// runs one `docker save` of all three, and podman's archive is single-image,
+// so the batch would land one image under every tag. Under podman the lab
+// therefore loads one image per call; under docker the batch stays one call.
+func TestKindLoadImagesOneCallPerImageUnderPodman(t *testing.T) {
+	images := []string{refPostgres, refGolangADK, refMusterDev}
+	for name, tc := range map[string]struct {
+		podman    bool
+		wantCalls []string
+	}{
+		"docker batches": {false, []string{
+			"kind load docker-image --name agentlab " + refPostgres + " " + refGolangADK + " " + refMusterDev,
+		}},
+		"podman loads one at a time": {true, []string{
+			"kind load docker-image --name agentlab " + refPostgres,
+			"kind load docker-image --name agentlab " + refGolangADK,
+			"kind load docker-image --name agentlab " + refMusterDev,
+		}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			calls := installFakeTool(t, dir, "kind", "exit 0")
+			withPodman(t, tc.podman)
+			cfg := config.Default()
+			loaded, err := kindLoadImages(cfg, images)
+			if err != nil {
+				t.Fatalf("kindLoadImages: %v", err)
+			}
+			if loaded != len(images) {
+				t.Errorf("loaded %d images, want %d", loaded, len(images))
+			}
+			got := strings.Split(strings.TrimSpace(readCalls(t, calls)), "\n")
+			if !slices.Equal(got, tc.wantCalls) {
+				t.Errorf("calls\n got  %v\n want %v", got, tc.wantCalls)
+			}
+		})
+	}
+}
+
+// Under podman a failed image must not stop the rest, and the count must say
+// how many landed so the caller can report a partial load as one.
+func TestKindLoadImagesPartialFailureUnderPodman(t *testing.T) {
+	dir := t.TempDir()
+	installFakeTool(t, dir, "kind", `case "$5" in
+`+refGolangADK+`) echo "no such image" >&2; exit 1 ;;
+*) exit 0 ;;
+esac`)
+	withPodman(t, true)
+	loaded, err := kindLoadImages(config.Default(), []string{refPostgres, refGolangADK, refMusterDev})
+	if err == nil {
+		t.Fatal("a failed image must surface as an error")
+	}
+	if loaded != 2 {
+		t.Errorf("loaded = %d, want 2 (the failure must not stop the rest)", loaded)
 	}
 }

--- a/internal/lab/preload_test.go
+++ b/internal/lab/preload_test.go
@@ -15,6 +15,7 @@ const (
 	refBackstageDev = "docker.io/library/backstage-dev:multi-backend-022f5b7e"
 	refMusterDev    = "gsoci.azurecr.io/giantswarm/muster:dev"
 	refGolangADK    = "gsoci.azurecr.io/giantswarm/golang-adk:0.10.0"
+	refSocat        = "docker.io/alpine/socat:1.8.1.3"
 )
 
 func TestScrapeImages(t *testing.T) {
@@ -79,10 +80,10 @@ func TestRegistryBacked(t *testing.T) {
 		"gsoci.azurecr.io/giantswarm/muster:5.10.2\tsha256:b97b80cd922c4aa2b6aa61e3fca50194d211b1b5a90b5931ce1eef5ff74d35a5\n" +
 		"<none>:<none>\t<none>\n")
 	for ref, want := range map[string]bool{
-		refBackstageDev:                  false, // built here
-		refPostgres:                      true,  // pulled from Docker Hub
-		"docker.io/alpine/socat:1.8.1.3": true,  // pulled, non-library namespace
-		refMusterDev:                     false, // a dev build tagged into a registry repo
+		refBackstageDev: false, // built here
+		refPostgres:     true,  // pulled from Docker Hub
+		refSocat:        true,  // pulled, non-library namespace
+		refMusterDev:    false, // a dev build tagged into a registry repo
 		"gsoci.azurecr.io/giantswarm/muster:5.10.2": true,
 		refGolangADK: true, // unknown to the host: the node pulled it
 	} {
@@ -94,9 +95,9 @@ func TestRegistryBacked(t *testing.T) {
 		t.Error("untagged rows must not enter the provenance map")
 	}
 	for ref, want := range map[string]string{
-		refPostgres:                      "postgres:18.3-alpine",
-		"docker.io/alpine/socat:1.8.1.3": "alpine/socat:1.8.1.3",
-		"ghcr.io/dexidp/dex:v2.45.1":     "ghcr.io/dexidp/dex:v2.45.1",
+		refPostgres:                  "postgres:18.3-alpine",
+		refSocat:                     "alpine/socat:1.8.1.3",
+		"ghcr.io/dexidp/dex:v2.45.1": "ghcr.io/dexidp/dex:v2.45.1",
 	} {
 		if got := shortRef(ref); got != want {
 			t.Errorf("shortRef(%q) = %q, want %q", ref, got, want)
@@ -158,4 +159,25 @@ esac`)
 	check("dev image pruned on the host, muster:dev pulled for real",
 		[]string{refPostgres, refGolangADK, refMusterDev},
 		[]string{refBackstageDev})
+}
+
+// Podman gives local builds a digest like any pull but spells them
+// `localhost/<name>`; that name marks them local, and podman's fully
+// qualified rows key the map the way docker spells them.
+func TestParseImageProvenancePodman(t *testing.T) {
+	prov := parseImageProvenance("localhost/backstage-dev:t1\tsha256:0537\n" +
+		"docker.io/library/postgres:18.3-alpine\tsha256:5445\n" +
+		"docker.io/alpine/socat:1.8.1.3\tsha256:5f27\n")
+	for ref, want := range map[string]bool{
+		"localhost/backstage-dev:t1":             false,
+		"docker.io/library/postgres:18.3-alpine": true,
+		refSocat:                                 true,
+	} {
+		if got := registryBacked(ref, prov); got != want {
+			t.Errorf("registryBacked(%q) = %v, want %v", ref, got, want)
+		}
+	}
+	if _, known := prov["postgres:18.3-alpine"]; !known {
+		t.Error("podman's docker.io/library/ rows must key the map as docker spells them")
+	}
 }

--- a/internal/lab/runtime.go
+++ b/internal/lab/runtime.go
@@ -8,12 +8,17 @@ import (
 // The lab drives containers through the `docker` CLI, and Podman's
 // docker-compatible CLI answers to it too (kind picks its podman provider
 // the same way). Docker is the primary path; where podman differs, the code
-// branches on dockerIsPodman:
+// branches on dockerIsPodman. The differences:
 //
 //   - `docker save a b c` writes ONE image carrying every name as a tag
 //     (podman's archive is single-image unless --multi-image-archive is
 //     passed), and kind's `load docker-image` runs exactly that save — so
-//     the lab loads one image per call (kindLoadImages, HACKS.md U16).
+//     the lab loads one image per call (kindLoadImages, HACKS.md U16);
+//   - pods reach the host at host.containers.internal, not the bridge
+//     gateway, and the host cannot dial that address itself (kindGatewayIP,
+//     hostServerAnswers);
+//   - local builds are spelled `localhost/<name>` and carry a digest like any
+//     pull, so the name is what marks them local (parseImageProvenance).
 
 // dockerIsPodman reports whether the `docker` on PATH is Podman's
 // docker-compatible CLI. Cached for the process: the answer cannot change

--- a/internal/lab/runtime.go
+++ b/internal/lab/runtime.go
@@ -1,6 +1,8 @@
 package lab
 
 import (
+	"os"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -18,7 +20,10 @@ import (
 //     gateway, and the host cannot dial that address itself (kindGatewayIP,
 //     hostServerAnswers);
 //   - local builds are spelled `localhost/<name>` and carry a digest like any
-//     pull, so the name is what marks them local (parseImageProvenance).
+//     pull, so the name is what marks them local (parseImageProvenance);
+//   - rootless podman publishes ports from the user's own network namespace
+//     and cannot bind the privileged range, so the gateway's default 443 has
+//     to move (MinPublishablePort, config.ChooseFreePorts).
 
 // dockerIsPodman reports whether the `docker` on PATH is Podman's
 // docker-compatible CLI. Cached for the process: the answer cannot change
@@ -32,4 +37,34 @@ var dockerIsPodman = sync.OnceValue(func() bool {
 // compatible CLI, "Docker version 29.7.2, build ..." for docker.
 func isPodmanVersion(out string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(out)), "podman")
+}
+
+// defaultUnprivilegedPortStart is the kernel's own default for
+// net.ipv4.ip_unprivileged_port_start.
+const defaultUnprivilegedPortStart = 1024
+
+// MinPublishablePort is the lowest host port the container engine can publish.
+// Docker's daemon binds as root, so every port is available to it. Rootless
+// podman publishes from the invoking user's network namespace, where the
+// kernel refuses everything below net.ipv4.ip_unprivileged_port_start — the
+// lab's default gateway port 443 among them.
+func MinPublishablePort() int {
+	if !dockerIsPodman() || os.Geteuid() == 0 {
+		return 1
+	}
+	return unprivilegedPortStart(os.ReadFile)
+}
+
+// unprivilegedPortStart reads net.ipv4.ip_unprivileged_port_start. An
+// unreadable or unparsable sysctl means the kernel default holds.
+func unprivilegedPortStart(readFile func(string) ([]byte, error)) int {
+	raw, err := readFile("/proc/sys/net/ipv4/ip_unprivileged_port_start")
+	if err != nil {
+		return defaultUnprivilegedPortStart
+	}
+	start, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || start < 1 || start > 65535 {
+		return defaultUnprivilegedPortStart
+	}
+	return start
 }

--- a/internal/lab/runtime.go
+++ b/internal/lab/runtime.go
@@ -1,0 +1,30 @@
+package lab
+
+import (
+	"strings"
+	"sync"
+)
+
+// The lab drives containers through the `docker` CLI, and Podman's
+// docker-compatible CLI answers to it too (kind picks its podman provider
+// the same way). Docker is the primary path; where podman differs, the code
+// branches on dockerIsPodman:
+//
+//   - `docker save a b c` writes ONE image carrying every name as a tag
+//     (podman's archive is single-image unless --multi-image-archive is
+//     passed), and kind's `load docker-image` runs exactly that save — so
+//     the lab loads one image per call (kindLoadImages, HACKS.md U16).
+
+// dockerIsPodman reports whether the `docker` on PATH is Podman's
+// docker-compatible CLI. Cached for the process: the answer cannot change
+// under a running command.
+var dockerIsPodman = sync.OnceValue(func() bool {
+	out, err := outputQuiet("docker", "--version")
+	return err == nil && isPodmanVersion(out)
+})
+
+// isPodmanVersion reads `docker --version`: "podman version 5.8.4" for the
+// compatible CLI, "Docker version 29.7.2, build ..." for docker.
+func isPodmanVersion(out string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(out)), "podman")
+}

--- a/internal/lab/runtime_test.go
+++ b/internal/lab/runtime_test.go
@@ -1,10 +1,76 @@
 package lab
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"testing"
+)
 
-// isPodmanVersion tells podman's `docker --version` line from docker's.
+// withPodman makes the engine-detection answer fixed for one test. The real
+// dockerIsPodman caches its shell-out for the process, which no test can
+// undo, so every podman-branch test goes through here.
+func withPodman(t *testing.T, podman bool) {
+	t.Helper()
+	prev := dockerIsPodman
+	dockerIsPodman = func() bool { return podman }
+	t.Cleanup(func() { dockerIsPodman = prev })
+}
+
 func TestIsPodmanVersion(t *testing.T) {
-	if !isPodmanVersion("podman version 5.8.4\n") || isPodmanVersion("Docker version 29.7.2, build abc") {
-		t.Fatal("isPodmanVersion misreads `docker --version`")
+	for _, tc := range []struct {
+		out  string
+		want bool
+	}{
+		{"podman version 5.8.4\n", true},
+		{"  Podman version 4.9.0  ", true},
+		{"Docker version 29.7.2, build 1.fc44", false},
+		{"docker version 20.10.7, build f0df350", false},
+		{"Client: Docker Engine - Community\n 29.7.2", false},
+		{"", false},
+	} {
+		if got := isPodmanVersion(tc.out); got != tc.want {
+			t.Errorf("isPodmanVersion(%q) = %v, want %v", tc.out, got, tc.want)
+		}
+	}
+}
+
+func TestUnprivilegedPortStart(t *testing.T) {
+	read := func(content string, err error) func(string) ([]byte, error) {
+		return func(string) ([]byte, error) { return []byte(content), err }
+	}
+	for name, tc := range map[string]struct {
+		read func(string) ([]byte, error)
+		want int
+	}{
+		"kernel default":   {read("1024\n", nil), 1024},
+		"lowered by admin": {read("80\n", nil), 80},
+		"unreadable":       {read("", errors.New("no such file")), defaultUnprivilegedPortStart},
+		"not a number":     {read("nope\n", nil), defaultUnprivilegedPortStart},
+		"out of range":     {read("70000\n", nil), defaultUnprivilegedPortStart},
+		"zero":             {read("0\n", nil), defaultUnprivilegedPortStart},
+	} {
+		if got := unprivilegedPortStart(tc.read); got != tc.want {
+			t.Errorf("%s: unprivilegedPortStart = %d, want %d", name, got, tc.want)
+		}
+	}
+}
+
+// Docker's daemon binds as root, so the whole port range is publishable; only
+// a rootless podman has a floor.
+func TestMinPublishablePortUnderDocker(t *testing.T) {
+	withPodman(t, false)
+	if got := MinPublishablePort(); got != 1 {
+		t.Errorf("MinPublishablePort() under docker = %d, want 1", got)
+	}
+}
+
+func TestMinPublishablePortUnderPodman(t *testing.T) {
+	withPodman(t, true)
+	want := 1
+	if os.Geteuid() != 0 {
+		want = unprivilegedPortStart(os.ReadFile)
+	}
+	if got := MinPublishablePort(); got != want {
+		t.Errorf("MinPublishablePort() under podman = %d, want %d", got, want)
 	}
 }

--- a/internal/lab/runtime_test.go
+++ b/internal/lab/runtime_test.go
@@ -1,0 +1,10 @@
+package lab
+
+import "testing"
+
+// isPodmanVersion tells podman's `docker --version` line from docker's.
+func TestIsPodmanVersion(t *testing.T) {
+	if !isPodmanVersion("podman version 5.8.4\n") || isPodmanVersion("Docker version 29.7.2, build abc") {
+		t.Fatal("isPodmanVersion misreads `docker --version`")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func discoverInto(cfg *config.Config, pinEnabled *bool, pinBackends []string) *l
 // around — the lab's own published ports never count as occupied.
 func applyPorts(cfg *config.Config, disc *lab.Discovery) {
 	if !disc.ClusterExists {
-		reportPortChanges(cfg.ChooseFreePorts(disc.ClusterPorts))
+		reportPortChanges(cfg.ChooseFreePorts(disc.ClusterPorts, lab.MinPublishablePort()))
 		return
 	}
 	conflicts := cfg.PortConflicts(disc.ClusterPorts)
@@ -182,15 +182,15 @@ func applyPorts(cfg *config.Config, disc *lab.Discovery) {
 	fmt.Println()
 }
 
-// reportPortChanges tells the user which ports were already occupied on this
-// machine and what the configuration uses instead. The form (or the saved
+// reportPortChanges tells the user which ports this machine cannot serve the
+// lab on and what the configuration uses instead. The form (or the saved
 // file) shows the adjusted numbers, but only this message explains why they
 // differ from the documented defaults.
 func reportPortChanges(changes []config.PortChange) {
 	if len(changes) == 0 {
 		return
 	}
-	fmt.Println("Some ports are already in use on this machine; picked free ones:")
+	fmt.Println("Some ports are not usable on this machine; picked ones that are:")
 	for _, ch := range changes {
 		fmt.Printf("  %s\n", ch)
 	}


### PR DESCRIPTION
## Incident

2026-09-06, host demiurg (Fedora 44, rootless Podman 5.8.4 as the `docker` CLI via podman-docker): a fresh `agentlab up` died at the Flux install. Both controllers crashlooped on `unknown flag: --watch-all-namespaces`, and `crictl images` in the node showed why — all three Flux tags pointed at ONE image ID, the flux-cli one. The host had three distinct images.

`kind load docker-image a b c` runs `docker save -o <tar> a b c` underneath, whatever the provider. Docker writes three images into that archive; Podman writes one image carrying every name as a tag unless `--multi-image-archive` is passed, and it does not check that the names resolve to the same image. kind never passes the flag, so every batched side-load under Podman lands one image under all the tags. Reproduced outside kind: `podman save -o x.tar <three images>` gives a `manifest.json` with a single entry and three `RepoTags`.

Two more Podman differences surfaced once the images were right:

- The address pods dial to reach the host. `docker network inspect kind -f '{{range .IPAM.Config}}…'` errors under Podman (its JSON has `subnets[].gateway`), and the bridge gateway it names is not the host anyway: rootless Podman routes host traffic through pasta, pods reach the host at `host.containers.internal` (169.254.1.2), and the host cannot dial that address itself. `configure` reported "kind gateway not known yet" on a running cluster, and `agentlab platform` could not autodetect the Ollama endpoint.
- Local builds. Podman spells them `localhost/<name>` and gives them a digest like any pull, so the `<none>`-digest rule from #70 never marks anything local there.

## Changes

1. **One `kind load` per image under Podman** (`runtime.go`, `preload.go`). `dockerIsPodman` reads `docker --version` once per process. Under Podman `kindLoadImages` loads one image per call — a single-image save is always right, kind stages and cleans its own archive, and kind's already-in-node check by image ID keeps working; a failed image does not stop the rest. Under docker the batched call is unchanged. `configure` reports the engine as `docker <version> (podman)`.
2. **The host address comes from the node** (`modelmanager.go`, `discover.go`). Under Podman `kindGatewayIP` asks the node what `host.containers.internal` resolves to (first IPv4); the discovery probe dials from inside the node, since the host cannot; the discovery line says "answers on <ip> (the address pods dial)" instead of "the kind gateway". `models-test`'s last step, which reads the host server from the host, uses the server's loopback port under Podman unless an endpoint is configured (`modelstest.go`). Docker keeps `docker network inspect` and the host-side dial.
3. **`localhost/` marks a local build** (`preload.go`). The provenance map keys refs the way docker spells them and treats any `localhost/` repository as not registry-backed, so a dev image built under Podman lands in the manifest's `# local-only:` memory instead of the pull set.

4. **The edge moves off 443 under rootless Podman** (`runtime.go`, `ports.go`). Rootless Podman publishes from the user's own network namespace and cannot bind below `net.ipv4.ip_unprivileged_port_start`. The bind probe cannot see this — agentlab is unprivileged either way, so a free 443 fails with `EACCES`, falls through to the dial and reads as free — so `MinPublishablePort` asks the engine and `ChooseFreePorts` treats the range below it as unusable. The gateway's own pick already prefers 8443. This was the one manual step left in the verification below; `configure --defaults` now does it and says why.

Docs: README requirements name Podman >= 4's docker-compatible CLI and the rootless port floor; HACKS.md U16 records the kind side (blocked upstream: kind's `load docker-image` passing `--multi-image-archive` under its Podman provider) and U17 the port floor; HACKS.md U16 records the kind side (blocked upstream: kind's `load docker-image` passing `--multi-image-archive` under its Podman provider). `runtime.go` lists the differences in one place.

Not covered on purpose: a dev build tagged straight into a registry repository is not detected as local under Podman (every tagged row has a digest there), and a real docker CLI pointed at a Podman socket is treated as docker — same blind spot as kind's own provider detection.

## Verification

Unit tests: `TestIsPodmanVersion`, `TestParseImageProvenancePodman` (a `localhost/` build is local-only; Podman's fully qualified rows key the map as docker spells them). `go test ./...`, `go vet` clean; each commit builds and tests on its own.

Real proof on this host, `gatewayPort: 8443` (picked automatically since the last commits; rootless Podman cannot publish 443), model-manager on, Ollama bound to 0.0.0.0. Fresh `agentlab down` + `agentlab up` on the branch, then every proof. `platform-test` and `backstage-test` ran with #67's second edge Service port applied by hand, since this branch does not carry it and both fail on the ported URL without it.

<details><summary>A — main: the Flux install on Podman</summary>

```
==> [01:57] Installing Flux source+helm controllers (flux2 chart 2.19.0, for the agent create flow)
    side-loaded 3 flux images (14s)
Release "flux" does not exist. Installing it now.
Error: resource Deployment/flux-system/helm-controller not ready. status: InProgress, message: Available: 0/1
resource Deployment/flux-system/source-controller not ready. status: InProgress, message: Available: 0/1
context deadline exceeded

$ kubectl -n flux-system logs deploy/source-controller --previous
✗ unknown flag: --watch-all-namespaces

$ docker exec agentlab-control-plane crictl images | grep flux
ghcr.io/fluxcd/flux-cli            v2.9.1    fd16349b03947    146MB
ghcr.io/fluxcd/helm-controller     v1.6.2    fd16349b03947    146MB
ghcr.io/fluxcd/source-controller   v1.9.2    fd16349b03947    146MB

$ podman save -o flux.tar ghcr.io/fluxcd/source-controller:v1.9.2 ghcr.io/fluxcd/helm-controller:v1.6.2 ghcr.io/fluxcd/flux-cli:v2.9.1
$ tar -xOf flux.tar manifest.json | jq -c '.[] | [.Config[:20], .RepoTags]'
["68a316851048a818d951",["ghcr.io/fluxcd/helm-controller:v1.6.2","ghcr.io/fluxcd/flux-cli:v2.9.1","ghcr.io/fluxcd/source-controller:v1.9.2"]]
```
</details>

<details><summary>B — branch: fresh up, discovery, node images</summary>

```
$ agentlab configure --defaults
  tools             docker 5.8.4 (podman), kind v0.31.0, kubectl v1.34.3, helm v4.2.4
  Ollama            0.20.2 on :11434 — answers on 169.254.1.2 (the address pods dial): yes; 3 downloaded, 2 tool-calling

$ agentlab up
==> [00:01] Creating kind cluster "agentlab"
==> [00:39] Deploying Dex
    side-loaded ghcr.io/dexidp/dex:v2.45.1 from the host cache (16s)
==> [01:02] Verifying the end-to-end OIDC chain
==> [05:51] Checking host Ollama is reachable from pods (http://169.254.1.2:11434)
    host Ollama answers from inside the cluster: "version":"0.20.2"
Lab is up.

$ kubectl -n flux-system get pods -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.containerStatuses[*].imageID}{"\n"}{end}'
helm-controller-75f9b8c4f4-mhkgb sha256:41c3eeb9bf8985836eb0821313c5c8044dcb3e01d6b2cda5f27167a639bdae66
source-controller-74fc58954-s294j sha256:68a316851048a818d95165f69428087e9edf229119a12584e4af65f1476040dd

37 images in the node; no image ID carries more than one tag (the kube-* -amd64 aliases aside, which kind ships that way)
```
</details>

<details><summary>C — branch: the four proofs</summary>

```
$ agentlab test
passed: 10   failed: 0

$ agentlab models-test
PASS: no token -> 401 at the gateway; Dex token -> model-manager REST through agentgateway
PASS: ollama backend: list -> pull qwen2.5:0.5b (progress) -> ModelConfig qwen2-5-0-5b (Ollama provider, backend label) Accepted -> agent turn
PASS: muster aggregates x_model-manager_* and calls them (get_model, list_models)
    host Ollama at http://127.0.0.1:11434 no longer has it (3 models left)

$ agentlab platform-test        # with #67's 8443 Service port applied
PASS: Claude Code -> muster (Dex) -> mcp-kubernetes -> kind apiserver
PASS: the forwarded Dex id_token reaches the apiserver — kube-system Secrets: platform-admin allowed, viewer forbidden
PASS: per-server OAuth sign-in -> muster (OAuth client) -> challenge on /oauth/proxy/start (fixture lab-oauth-fixture)
PASS: Claude Code -> muster (Dex) -> mcp-prometheus -> Prometheus (platform targets scraped)
PASS: Backstage metrics path -> edge -> Prometheus (Mimir-shaped /prometheus API)

$ agentlab backstage-test       # same
all sign-ins resolved and reached muster
```
</details>

## Review pass

Rebased on main (picks up #72's edge Service port, applied by hand in the verification above). Three findings fixed, each with tests, and both engines re-checked on one host — Docker 29.7.2 keeps `gatewayPort: 443` and the batched `kind load`; Podman 5.8.4 reports `docker 5.8.4 (podman)` and moves the edge to 8443 on its own.

- The privileged-port trap above, which otherwise left a fresh rootless `up` failing in kind with no guidance.
- `kindLoadImages` returned only the joined error, so a partial Podman side-load was reported as a total failure while most images were on the node. It now returns the count too.
- The node-side reachability probe mapped every `docker exec` failure to "the server does not answer", so a node without `bash` sent the user to rebind Ollama. Exit 1 and 124 stay verdicts; anything else leaves the reachability unknown and says so.
- The Podman side-load itself is now covered: three images are one `kind load` under Docker and three under Podman, and a failure in the middle still loads the other two.
