### PR TITLE
fix(platform): edge Service serves the public port in-cluster off 443

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -369,11 +369,11 @@ is port-free while the Dex client (`dex.yaml.tmpl`) registers the ported one,
 and every login fails with "Unregistered redirect_uri". The lab's app-config
 overlay (`backstage-catalog.yaml.tmpl`) restates the three URLs from
 `.BackstageBaseURL`; at 443 the values are identical. In-cluster, the lab's
-edge Service (`gateway-nodeport.yaml.tmpl`) also serves the ported port off
-443, so the ported URLs resolve from pods (agentlab#67). Lab-only by
-construction: a real installation runs
-its edge on 443, so the umbrella has no reason to carry a ported public URL;
-the overlay is the lab's permanent answer, not an interim.
+edge Service (`gateway-nodeport.yaml.tmpl`) serves that port as well, so the
+ported URLs resolve from pods too (agentlab#67). Lab-only by construction: a
+real installation runs its edge on 443, so the umbrella has no reason to
+carry a ported public URL; the overlay is the lab's permanent answer, not an
+interim.
 
 ## Accepted lab trade-offs (not hacks to fix)
 

--- a/HACKS.md
+++ b/HACKS.md
@@ -368,10 +368,10 @@ carry one. With `platform.gatewayPort != 443` Backstage's OAuth `redirect_uri`
 is port-free while the Dex client (`dex.yaml.tmpl`) registers the ported one,
 and every login fails with "Unregistered redirect_uri". The lab's app-config
 overlay (`backstage-catalog.yaml.tmpl`) restates the three URLs from
-`.BackstageBaseURL`; at 443 the values are identical. Still open on a
-non-443 port: the in-cluster edge Service serves 443 only, so muster cannot
-fetch its own ported OAuth metadata and `platform-test` fails at the
-`lab-oauth-fixture` step. Lab-only by construction: a real installation runs
+`.BackstageBaseURL`; at 443 the values are identical. In-cluster, the lab's
+edge Service (`gateway-nodeport.yaml.tmpl`) also serves the ported port off
+443, so the ported URLs resolve from pods (agentlab#67). Lab-only by
+construction: a real installation runs
 its edge on 443, so the umbrella has no reason to carry a ported public URL;
 the overlay is the lab's permanent answer, not an interim.
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Applied to the configuration:
   exists** (a fresh lab, or after `agentlab down`), an occupied port is moved
   to a nearby free one, with a message saying what moved where (443 falls
   back to 8443). When the edge leaves 443, every public URL in this README
-  gains that port suffix (`https://backstage.127.0.0.1.nip.io:8443`), and
-  `platform-test`'s `lab-oauth-fixture` step fails: in-cluster the edge stays
-  on 443, so muster cannot reach its own ported OAuth metadata URL. Once the
+  gains that port suffix (`https://backstage.127.0.0.1.nip.io:8443`); the
+  lab's edge Service serves that port in-cluster as well, so the ported URLs
+  resolve from pods too and every proof still passes. Once the
   cluster exists its mappings are fixed at node creation, so the ports it
   publishes never count as occupied and a foreign listener on one of them is
   **reported**, not renumbered around (free it, or `agentlab down`, re-run

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ Applied to the configuration:
   back to 8443). When the edge leaves 443, every public URL in this README
   gains that port suffix (`https://backstage.127.0.0.1.nip.io:8443`); the
   lab's edge Service serves that port in-cluster as well, so the ported URLs
-  resolve from pods too and every proof still passes. Once the
-  cluster exists its mappings are fixed at node creation, so the ports it
-  publishes never count as occupied and a foreign listener on one of them is
-  **reported**, not renumbered around (free it, or `agentlab down`, re-run
-  `configure`, `agentlab up`).
+  resolve from pods too and every proof still passes. Once the cluster exists
+  its mappings are fixed at node creation, so the ports it publishes never
+  count as occupied and a foreign listener on one of them is **reported**, not
+  renumbered around (free it, or `agentlab down`, re-run `configure`,
+  `agentlab up`).
 - **Host model servers**: an Ollama on `:11434` and a Lemonade Server on
   `:13305` (their default ports) are detected with version, whether they
   listen on the kind docker gateway (pods' path to the host — the bind-address

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,11 @@ const GatewayNodePort = 30443
 // it.
 const GatewayPublicNodePort = 30444
 
+// PinnedNodePorts are the node-side ports the lab fixes itself. They share the
+// node's port space with DexPort, whose Service claims the host port as its
+// NodePort, so nothing else may take one of these numbers.
+var PinnedNodePorts = []int{MusterNodePort, KagentUINodePort, GatewayNodePort, GatewayPublicNodePort}
+
 // DefaultDexPort is the lab Dex NodePort when agentlab.yaml sets none.
 const DefaultDexPort = 32000
 
@@ -628,6 +633,9 @@ func (c *Config) Validate() error {
 	}
 	if err := ValidateNodePort(strconv.Itoa(c.DexPort)); err != nil {
 		return fmt.Errorf("dexPort: %w", err)
+	}
+	if slices.Contains(PinnedNodePorts, c.DexPort) {
+		return fmt.Errorf("dexPort: %d is a NodePort the lab already pins, and the apiserver rejects the second Service that claims it", c.DexPort)
 	}
 	if err := ValidateAIModel(c.AIModel); err != nil {
 		return fmt.Errorf("aiModel %q: %w", c.AIModel, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,12 @@ const KagentUINodePort = 30880
 // has a stable node-side port. Host side: Platform.GatewayPort.
 const GatewayNodePort = 30443
 
+// GatewayPublicNodePort pins the NodePort of the edge Service's second port
+// (platform.gatewayPort, rendered off 443 only) so the apiserver never picks
+// one that collides with the other fixed NodePorts. Nothing on the host maps
+// it.
+const GatewayPublicNodePort = 30444
+
 // DefaultDexPort is the lab Dex NodePort when agentlab.yaml sets none.
 const DefaultDexPort = 32000
 
@@ -122,10 +128,10 @@ type Platform struct {
 	// the edge Gateway Service.
 	Domain string `yaml:"domain"`
 	// Host-side port of the agentgateway edge (HTTPS). 443 keeps the public
-	// URLs port-free; any other value is only reachable from the host (the
-	// edge Service inside the cluster stays on 443), so in-cluster callers of
-	// a ported public URL — muster fetching its own OAuth metadata for the
-	// lab-oauth-fixture — time out. Change only if 443 is taken.
+	// URLs port-free; any other value suffixes every public URL with it, and
+	// the lab's edge Service (gateway-nodeport.yaml.tmpl) then also serves
+	// that port in-cluster, so the ported URLs resolve from pods too. Change
+	// only if 443 is taken.
 	GatewayPort int `yaml:"gatewayPort"`
 	// TLS optionally hands the edge an externally provisioned certificate
 	// pair (PEM) instead of the minted lab-CA wildcard — for users who own a

--- a/internal/config/ports.go
+++ b/internal/config/ports.go
@@ -81,7 +81,7 @@ func (c *Config) ports() []labPort {
 			}
 			return scan(lo, 65535)
 		}, func(to int) string {
-			return fmt.Sprintf("public URLs gain :%d, valid from the host only; platform-test's lab-oauth-fixture step will fail (muster cannot reach its own ported URL in-cluster)", to)
+			return fmt.Sprintf("public URLs gain :%d", to)
 		}},
 		{"backstage.port", "Backstage's direct debug access", &c.Backstage.Port, func(scan func(int, int) (int, bool)) (int, bool) {
 			return scan(c.Backstage.Port+1, 65535)
@@ -138,6 +138,7 @@ func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
 		MusterNodePort:         true,
 		KagentUINodePort:       true,
 		GatewayNodePort:        true,
+		GatewayPublicNodePort:  true,
 	}
 
 	scan := func(lo, hi int) (int, bool) {

--- a/internal/config/ports.go
+++ b/internal/config/ports.go
@@ -135,10 +135,9 @@ func (c *Config) chooseFreePorts(taken func(int) bool) []PortChange {
 		c.Platform.AgentsPort:  true,
 		c.Platform.GatewayPort: true,
 		BrowserCallbackPort:    true,
-		MusterNodePort:         true,
-		KagentUINodePort:       true,
-		GatewayNodePort:        true,
-		GatewayPublicNodePort:  true,
+	}
+	for _, p := range PinnedNodePorts {
+		reserved[p] = true
 	}
 
 	scan := func(lo, hi int) (int, bool) {

--- a/internal/config/ports_test.go
+++ b/internal/config/ports_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"net"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -137,5 +139,28 @@ func TestPortTakenProbe(t *testing.T) {
 	_ = l.Close()
 	if portTaken(port) {
 		t.Errorf("port %d is closed but probes taken", port)
+	}
+}
+
+// dexPort doubles as its Service's NodePort, so it may not take a node port a
+// lab Service already pins: the apiserver rejects the second claim at apply.
+func TestConfigValidateRejectsPinnedDexPort(t *testing.T) {
+	cfg := Default()
+	if _, err := cfg.EnsureHashes(); err != nil {
+		t.Fatal(err)
+	}
+	for _, pinned := range PinnedNodePorts {
+		if err := ValidateNodePort(strconv.Itoa(pinned)); err != nil {
+			continue // outside the NodePort range, so dexPort can never hold it
+		}
+		cfg.DexPort = pinned
+		err := cfg.Validate()
+		if err == nil || !strings.Contains(err.Error(), "dexPort") {
+			t.Fatalf("dexPort %d not rejected: %v", pinned, err)
+		}
+	}
+	cfg.DexPort = DefaultDexPort
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("default dexPort rejected: %v", err)
 	}
 }

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -39,13 +39,14 @@ const checksumPlaceholder = "REPLACED_AT_APPLY"
 // tmplData exposes the config plus computed values to the templates.
 type tmplData struct {
 	*config.Config
-	CertsDir            string // absolute, for the kind extraMount
-	MusterNodePort      int
-	KagentUINodePort    int
-	GatewayNodePort     int
-	BrowserCallbackPort int
-	DomainRegex         string // Platform.Domain with dots escaped, for the CoreDNS rewrite
-	AllGroups           []string
+	CertsDir              string // absolute, for the kind extraMount
+	MusterNodePort        int
+	KagentUINodePort      int
+	GatewayNodePort       int
+	GatewayPublicNodePort int
+	BrowserCallbackPort   int
+	DomainRegex           string // Platform.Domain with dots escaped, for the CoreDNS rewrite
+	AllGroups             []string
 	KubernetesClientSecret,
 	AgentPlatformClientSecret string
 	// ModelManagerEnabled mirrors cfg.ModelManagerEnabled(); Backends is
@@ -90,6 +91,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		MusterNodePort:            config.MusterNodePort,
 		KagentUINodePort:          config.KagentUINodePort,
 		GatewayNodePort:           config.GatewayNodePort,
+		GatewayPublicNodePort:     config.GatewayPublicNodePort,
 		BrowserCallbackPort:       config.BrowserCallbackPort,
 		DomainRegex:               strings.ReplaceAll(cfg.Platform.Domain, ".", `\.`),
 		AllGroups:                 config.Groups,

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/giantswarm/agentlab/internal/config"
 )
 
@@ -44,4 +46,44 @@ func excerptAround(s, marker string) string {
 	}
 	end := min(len(s), i+400)
 	return s[i:end]
+}
+
+// The lab-owned edge Service serves the public port in-cluster: exactly one
+// port at 443, and off 443 a second one on gatewayPort mapped onto the same
+// 443 listener, its NodePort pinned like the first.
+func TestGatewayEdgeServicePorts(t *testing.T) {
+	type port struct {
+		Name       string `yaml:"name"`
+		Port       int    `yaml:"port"`
+		TargetPort int    `yaml:"targetPort"`
+		NodePort   int    `yaml:"nodePort"`
+	}
+	render := func(gatewayPort int) []port {
+		cfg := config.Default()
+		cfg.Platform.GatewayPort = gatewayPort
+		out, err := renderTemplate(cfg, "gateway-nodeport.yaml.tmpl", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var svc struct {
+			Spec struct {
+				Ports []port `yaml:"ports"`
+			} `yaml:"spec"`
+		}
+		if err := yaml.Unmarshal(out, &svc); err != nil {
+			t.Fatalf("gatewayPort %d: %v\n%s", gatewayPort, err, out)
+		}
+		return svc.Spec.Ports
+	}
+
+	if got := render(443); len(got) != 1 || got[0] != (port{"https", 443, 443, config.GatewayNodePort}) {
+		t.Fatalf("443: want the single NodePort entry, got %+v", got)
+	}
+	got := render(8443)
+	if len(got) != 2 || got[0] != (port{"https", 443, 443, config.GatewayNodePort}) {
+		t.Fatalf("8443: want the NodePort entry plus one, got %+v", got)
+	}
+	if got[1] != (port{"https-public", 8443, 443, config.GatewayPublicNodePort}) {
+		t.Fatalf("8443: want the public port onto the 443 listener with its pinned nodePort, got %+v", got[1])
+	}
 }

--- a/internal/lab/templates/gateway-nodeport.yaml.tmpl
+++ b/internal/lab/templates/gateway-nodeport.yaml.tmpl
@@ -21,3 +21,12 @@ spec:
       port: 443
       targetPort: 443
       nodePort: {{ .GatewayNodePort }}
+{{- /* Off 443 the public URLs carry the port; this entry serves it in-cluster
+   onto the same 443 listener. Not rendered at 443: it would duplicate the
+   entry above. */}}
+{{- if ne .Platform.GatewayPort 443 }}
+    - name: https-public
+      port: {{ .Platform.GatewayPort }}
+      targetPort: 443
+      nodePort: {{ .GatewayPublicNodePort }}
+{{- end }}


### PR DESCRIPTION
## Problem

With `platform.gatewayPort` other than 443 (`configure` moves the edge to 8443 when 443 is busy; rootless Podman cannot publish 443) every public URL the lab renders carries the port. Inside the cluster the CoreDNS rewrite sends every `*.<domain>` name to the lab-owned `agentgateway-edge` Service, and that Service exposed exactly one port, 443. A pod dialing a ported public URL reached the edge ClusterIP on a port nothing listened on and timed out.

Two in-cluster callers do that: muster in its OAuth client role fetching its own metadata for the `lab-oauth-fixture` challenge (`platform-test`), and Backstage's muster login (`backstage-test`). Both failed off 443. Issue #67 (from the review of #53) named the fixture step; the Backstage one showed up while verifying.

## Changes

1. **A second port on the edge Service** (`gateway-nodeport.yaml.tmpl`), rendered only off 443: `platform.gatewayPort` mapped onto the same 443 listener. Same pods, same certificate; SNI carries no port, so nothing on the data plane changes. At 443 the entry would duplicate the first one, which the apiserver rejects, so the guard is load-bearing and the default lab's manifest is byte-identical to before.
2. **Its NodePort is pinned** (`config.GatewayPublicNodePort` 30444, reserved in `ports.go`). A NodePort Service gets a node port for every entry; left unset, the apiserver picks a random one, which could land on a NodePort the umbrella install pins later in the same boot. Nothing on the host maps 30444.
3. **`dexPort` may no longer hold a pinned NodePort.** `dexPort` doubles as
   its own Service's NodePort, but `Validate` checked the 30000-32767 range
   only, so `30443`, `30444` or `30880` passed and then failed at apply time
   with the apiserver rejecting the second claim. `PinnedNodePorts` is now the
   one list, used by both `Validate` and `chooseFreePorts`.
4. Docs stop describing the gap: the `gatewayPort` comment in `config.go`, the port-move note in `ports.go`, the README port bullet, HACKS.md U15.

## Verification

`TestConfigValidateRejectsPinnedDexPort`: every pinned port inside the
NodePort range is rejected, the default `dexPort` is not.

`TestGatewayEdgeServicePorts`: exactly one port at 443, two at 8443 with `port == gatewayPort`, `targetPort == 443` and the pinned nodePort. The 443 render was diffed against `main`'s template output: identical.

Real proof on `gatewayPort: 8443` (Fedora, rootless Podman, with #71): fresh `down` + `up`, then the Service from this branch applied and every proof run.

```
$ kubectl -n agent-platform get svc agentgateway-edge -o jsonpath='{range .spec.ports[*]}{.name} port={.port} nodePort={.nodePort}{"\n"}{end}'
https port=443 nodePort=30443
https-public port=8443 nodePort=30444

$ agentlab platform-test
    challenge: https://muster.127.0.0.1.nip.io:8443/oauth/proxy/start?state=… (client id via cimd)
    proxy start redirects to https://muster.127.0.0.1.nip.io:8443/oauth/authorize (the authorization server)
PASS: per-server OAuth sign-in -> muster (OAuth client) -> challenge on /oauth/proxy/start (fixture lab-oauth-fixture)

$ agentlab backstage-test
all sign-ins resolved and reached muster

$ agentlab test
passed: 10   failed: 0

$ agentlab models-test
PASS: muster aggregates x_model-manager_* and calls them (get_model, list_models)
```

Without the second port on the same lab, `platform-test` fails at the fixture step (`failed to discover OAuth metadata for https://muster.127.0.0.1.nip.io:8443`) and `backstage-test` times out on `/api/muster/auth/login`.

Closes #67

