### PR TITLE
fix(release): ignore the CI's .ldflags scratch file so release binaries report vX.Y.Z, not +dirty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ kubeconfig.oidc
 /agentlab
 /agentlab.yaml
 /state/
+
+# Scratch file the architect CI writes next to the sources before `go build`;
+# untracked it would flip Go's VCS stamp to vcs.modified=true and every
+# release binary would report vX.Y.Z+dirty (pkg/project reads that stamp).
+.ldflags


### PR DESCRIPTION
## What

The v0.17.0 release assets print `agentlab version v0.17.0+dirty (commit fa1b57d, …)`, while `go install github.com/giantswarm/agentlab@v0.17.0` prints a clean `v0.17.0`. Cause: architect's go-test step writes the `.ldflags` scratch file next to the sources and go-build reads it back; untracked, it makes Go's VCS stamp `vcs.modified=true`, and `pkg/project` (new in v0.17.0) shows that as `+dirty` — also in the `appVersion` of the usage signals.

`git status --porcelain` does not list ignored files, so ignoring `.ldflags` keeps the stamp clean. Local builds and `go install` are unaffected.

## Verification

Two worktrees, each with a stray `.ldflags` next to the sources, then `go build` and `--version`:

- at this commit (ignore in place): `v0.17.1-0.20260907103801-7574a145ac18 (commit 7574a14, …)`, `go version -m` shows `vcs.modified=false`
- at the parent fa1b57d (no ignore): `v0.17.0+dirty (commit fa1b57d, …)`

The merge auto-releases v0.17.1, whose assets should print `v0.17.1 (commit …)` without `+dirty`.

The upstream fix (the orb keeping its scratch file out of the tree, or excluding it via `.git/info/exclude`) is a separate architect-orb change; this keeps agentlab's own release binaries honest meanwhile.
