### PR TITLE
fix(release): ignore the build outputs the Makefile and the CI write into the tree, so every release binary reports vX.Y.Z

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,14 @@ kubeconfig.oidc
 /agentlab.yaml
 /state/
 
-# Scratch file the architect CI writes next to the sources before `go build`;
-# untracked it would flip Go's VCS stamp to vcs.modified=true and every
-# release binary would report vX.Y.Z+dirty (pkg/project reads that stamp).
+# Build outputs and CI scratch files, all written next to the sources: the
+# devctl Makefile's agentlab-v<version>-<os>-<arch> and bin-dist/, the
+# architect CI's .ldflags, .platforms and agentlab-<os>-<arch> (six of them,
+# built concurrently). Untracked, any of these flips Go's VCS stamp to
+# vcs.modified=true and the binaries built after it report vX.Y.Z+dirty
+# (pkg/project reads that stamp; kubectl-gs ignores kubectl-gs* for the same
+# reason).
+/agentlab-*
+/bin-dist/
 .ldflags
+.platforms


### PR DESCRIPTION
## What

v0.17.1 (#74) ignored `.ldflags`, but its assets still print `agentlab version v0.17.1+dirty`. architect's go-build writes `agentlab-<os>-<arch>` for six architectures (plus `agentlab` and `.platforms`) into the working tree, concurrently, so every binary built after the first sees an untracked file and Go stamps `vcs.modified=true`. The devctl Makefile's `agentlab-v<version>-<os>-<arch>` and `bin-dist/` are the same kind of output. kubectl-gs ignores `kubectl-gs*` and `bin-dist/` for exactly this reason; this does the equivalent: `/agentlab-*`, `/bin-dist/`, `.ldflags`, `.platforms`.

## Verification

Clean worktree at v0.17.1 without this change: `go build -o agentlab-linux-amd64` → `v0.17.1 (commit 2baa859, …)`, then a second `go build` → `v0.17.1+dirty`. With this commit: `.ldflags`, `.platforms`, `agentlab-linux-amd64`, `agentlab` in the tree, then the linux/arm64 build → `git status --porcelain` empty, `vcs.modified=false`. The merge auto-releases v0.17.2; its assets should print `v0.17.2 (commit …)`.

Upstream, architect-orb#924 will exclude the same files via `.git/info/exclude` for every repo the orb builds.