### PR TITLE
docs: what CPU and memory docker needs for the lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,62 @@ see below), `git`.
 (The old script stack also needed openssl, curl, jq and python3; the binary
 does all of that itself.)
 
+### Docker resources
+
+The lab runs the whole platform on a single kind node, so whatever backs
+docker — Docker Desktop's VM, Colima, a podman machine — has to fit it. **CPU
+is the binding constraint, and it is a hard one**: the kube-scheduler refuses
+a pod whose CPU *request* does not fit, so a node that is 100m short simply
+leaves pods `Pending` forever. It does not degrade, it stalls.
+
+What a full default lab requests (measured from the chart renders at the
+pinned versions, plus kind's own control plane on a live node):
+
+| | CPU | Memory |
+|---|---|---|
+| kind's Kubernetes: apiserver, controller-manager, scheduler, etcd, CNI, CoreDNS | 950m | ~140 MiB |
+| the agent platform: muster + valkey, agentgateway + controller, mcp-kubernetes, agent-manager, model-manager, kagent + UI + postgres, Backstage | 1080m | ~1750 MiB |
+| Dex | 50m | 64 MiB |
+| Flux source + helm controllers (installed by the Backstage step, when agents are on — they are the agent create flow's delivery engine) | 200m | 128 MiB |
+| observability: kube-state-metrics + mcp-prometheus | 300m | 328 MiB |
+| **total requests** | **≈ 2.6 CPU** | **≈ 2.4 GiB** |
+
+The memory column *understates* real use, and by a lot: the Prometheus server
+(its CR sets no `resources`), the prometheus-operator and node-exporter
+declare nothing at all, and Backstage requests 250 MiB while its Node process
+uses several times that. A node running the platform with Backstage and
+observability **off** was observed at 2.4 GiB actual — i.e. the whole
+requests budget — so a full lab wants roughly twice that.
+
+Give docker at least:
+
+| | CPUs | Memory |
+|---|---|---|
+| the full default lab (platform + agents + observability + Backstage) | **6** | **8 GiB** |
+| the floor that still schedules | 4 | 6 GiB |
+| platform + agents only (`configure --backstage=false --observability=false`) | 3 | 4 GiB |
+
+That last row is the one that has actually been measured on a live node: it
+requests ~2.05 CPU (no Backstage, no observability, and no Flux — that comes
+with Backstage) and sat at 2.4 GiB of real use.
+
+Add headroom on top for the agent pods the platform creates at run time:
+every kagent agent is another pod, and `models-test` and `agents-test` each
+create one.
+
+Two CPUs — Docker Desktop's default — is not enough for any of it. The
+symptoms are specific, and worth recognising because nothing says "out of
+CPU": `agentgateway` (or any late pod) sits `Pending` while
+`kubectl describe node` shows CPU requests at 95%+ of allocatable; the
+platform install then waits on a workload that will never start and times
+out. With the platform up but the node full, `models-test` gets as far as the
+agent turn and fails there — the agent's own pod cannot be scheduled, so the
+Agent CR never goes `Ready`.
+
+Disk is not usually the constraint. A first boot pulls a few GiB of images —
+on the *host*, always, and side-loads them into the node — and that host
+cache survives `agentlab down`, so a re-boot does not pay for them again.
+
 ## Quick start
 
 Install the `agentlab` binary one of three ways:


### PR DESCRIPTION
The `## Requirements` section lists the tools and says nothing about the machine, so the first sign that docker is too small is a boot that *stalls*: the kube-scheduler leaves a pod `Pending` when its CPU request does not fit, and nothing in the output says "out of CPU".

Both failures are ones I hit on Docker Desktop's default 2 CPUs while testing the LM Studio backend:

- the platform install waits forever on `agentgateway`, which needs 100m against 85m free;
- with the platform up but the node full, `models-test` gets as far as the agent turn and fails there — the kagent agent's own pod cannot be scheduled, so the Agent CR never goes `Ready`.

## What the section adds

**What a full default lab requests, per group** — measured from the chart renders at the pinned versions, plus kind's own control plane on a live node: **≈ 2.6 CPU and ≈ 2.4 GiB of requests**, of which 950m is Kubernetes' own control plane.

**Why the memory column understates real use** — the Prometheus server (its CR sets no `resources`), the prometheus-operator and node-exporter declare nothing at all, and Backstage requests 250 MiB for a Node process that uses several times that.

**What to give docker:**

| | CPUs | Memory |
|---|---|---|
| the full default lab | 6 | 8 GiB |
| the floor that still schedules | 4 | 6 GiB |
| platform + agents only | 3 | 4 GiB |

**And the two symptoms**, so they are recognisable rather than mysterious.

## Confidence, honestly

The **requests** figures are measured. The last table row is the one that ran on a live node: ~2.05 CPU of requests and 2.4 GiB of real use.

The full-lab **memory** recommendation is an informed extrapolation, not a measurement — a full lab has never been up on this machine, because 2 CPUs cannot schedule one. It comes from the measured partial lab plus the known appetite of the components that declare no requests. Happy to soften the wording if you'd rather the README not commit to 8 GiB without a full-lab measurement behind it.

## One correction it carries

Flux is counted with Backstage, not with agents: `fluxUp` runs inside the Backstage branch of `platformUp`, because the create flow's Deploy button is what needs the source and helm controllers. Getting that right is also what reconciled the computed total with the live measurement — the earlier arithmetic was 200m off until I noticed no Flux pods on a Backstage-less cluster.

Independent of the LM Studio PRs (#77) — docs only, no behaviour change.

Rebased onto main: the section now sits after the rootless-Podman paragraph #71 added to `## Requirements` (they cover different constraints — ports there, CPU and memory here), and its opening sentence accounts for rootless Podman on Linux, where there is no VM in between.

