### PR TITLE
feat(lab): fake-fleet MCPServer fixture carries agent-platform.giantswarm.io/tool-group=infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,56 @@ To drive the UI: **Agent Platform → MCP Servers**, expand `lab-oauth-fixture`,
 **Sign in** — the popup lands on muster's authorization page, then Dex. After a
 muster pod roll the row reads `Failed` for about a minute (Reconnect, or wait).
 
+### The fake fleet and the tool-group label
+
+A real installation federates many management clusters: agent-platform-mcps
+renders one MCPServer per cluster and per infrastructure family — `kubernetes`,
+`capi`, `prometheus` — each declaring `spec.family` (so muster exposes the
+family once, `x_kubernetes_<tool>` with a `management_cluster` argument) and
+labelled `muster.giantswarm.io/management-cluster: <cluster>`. The lab has one
+cluster and its bundled `mcp-kubernetes` declares no family, so nothing here
+looks like a fleet — yet the portal's MCP servers page, its dashboard's fleet
+coverage and the agent create flow's Tools step group servers by family and by
+tier. `agentlab platform` therefore ships a **fake fleet**
+(`fleet-fixture.yaml.tmpl`, `fleetfixture.go`): three families × two fake
+management clusters (`lab-01`, `lab-02`), six MCPServers named
+`<family>-<cluster>` in `agent-platform`, each with the family block, the
+management-cluster label, the `muster.giantswarm.io/type` the fleet charts
+stamp, and the tier label:
+
+```yaml
+agent-platform.giantswarm.io/tool-group: infrastructure
+```
+
+**What the label is for.** It is the Agent Platform's tiering of MCP servers —
+three groups the portal's MCP servers page, the Tools step, muster's toolset
+presets and the docs all use under the same names: **Agent Platform**
+(`agent-platform`: agent-manager, model-manager, muster's core tools),
+**Infrastructure** (`infrastructure`: the kubernetes/capi/prometheus families)
+and **Registered servers** (no label: whatever an installation or a user
+registers, including everything the portal's Register server flow creates).
+The chart that ships a server stamps it; every consumer only reads it, e.g.
+`kubectl get mcpservers.muster.giantswarm.io -A -l agent-platform.giantswarm.io/tool-group=infrastructure`
+lists the fleet families. Orientation and preset membership, not
+authorization — that stays with the servers' OAuth and the clusters' RBAC.
+In the lab only the fake fleet carries the label: `lab-oauth-fixture` and
+anything you register by hand stay unlabelled on purpose, so the Registered
+servers group has members; the vendored agent-manager / model-manager /
+umbrella charts bring their own labels (`agent-platform`; `infrastructure` on
+the bundled `mcp-kubernetes`) once bumped to the releases that stamp them.
+
+The members point at muster's own protected `/mcp` with `auth.type: oauth`,
+like the OAuth fixture, and so read `Auth Required` — what an unconnected
+forwardToken fleet member shows on a real installation — at zero cost.
+Pointing them at the lab's single mcp-kubernetes instead makes muster open one
+connection per member per user session; a dozen of those rate-limited
+mcp-kubernetes (429) and took the session's real `mcp-kubernetes` connection
+down with them. The fixture exists to be grouped, listed and selected, not
+called. `agentlab platform-test` asserts the label: the `infrastructure`
+selector lists every member and, of the lab's own CRs, nothing else; every
+value in the cluster is one of the two the contract knows; `lab-oauth-fixture`
+is unlabelled. Servers the vendored charts label are reported, not judged.
+
 ### Agents (kagent)
 
 The platform's agent runtime is an **optional component**, on by default
@@ -722,6 +772,7 @@ same one-URL trick, just spelled with a name.
 | The muster/kagent ServiceMonitors, valkey PodMonitor and muster PrometheusRule follow `platform.observability` | Without it there is no Prometheus Operator, so none of those CRDs exist and the releases fail to render. With it they are scraped by the lab Prometheus — whose selectors are opened up (`*NilUsesHelmValues: false`) because upstream's default selects only monitors carrying the kps release label, and the platform's monitors come from other releases. Flipping observability rolls the muster pod once (the toggle changes its metrics-exporter env). |
 | `platform.observability`: the GS kube-prometheus-stack constituent installed directly, Prometheus server re-enabled, instead of the observability-bundle | The bundle is MC-shaped (Flux HelmReleases with a hardcoded remote kubeconfig, Alloy → Mimir, no local PromQL endpoint). See [Observability](#observability-prometheus--mcp-prometheus). |
 | `muster.muster.oauth.mcpClient.enabled: true` + the `lab-oauth-fixture` MCPServer | The umbrella leaves muster's OAuth *client* role — the proxy behind `core_auth_login` and the portal's Sign in — off; real installations turn it on, and without it no per-server sign-in can be exercised. The fixture is the one `Auth Required` downstream to sign in to (muster's own protected `/mcp`); see [Signing in to a downstream server](#signing-in-to-a-downstream-server-muster-as-oauth-client). |
+| The fake-fleet MCPServers (`<family>-lab-01`, `<family>-lab-02`) with `agent-platform.giantswarm.io/tool-group: infrastructure` | One cluster and a family-less bundled `mcp-kubernetes` look nothing like the federated fleet the portal's server groups, fleet coverage and Tools step are built for. Six `Auth Required` family members fake it, carrying the tier label the fleet charts stamp; see [The fake fleet and the tool-group label](#the-fake-fleet-and-the-tool-group-label). |
 | `muster.rbac.{mcpServerEditor,workflowEditor}.subjects` → `oidc:platform-admins` | The umbrella binds muster's editor Roles to Giant Swarm's admin groups, which do not exist here. Rebound to the lab's own admin group (`--oidc-groups-prefix=oidc:`, same spelling as the lab RBAC). Lists replace, so the GS groups are dropped. |
 | muster patched to `hostNetwork` + `maxSurge: 0` | Same issuer trick as the apiserver and Backstage. `maxSurge: 0` because two hostNetwork pods cannot both bind `:8090` on a one-node cluster. Applied by `agentlab post-render` — Helm 4 accepts only plugin-type post-renderers, so the install generates a `postrenderer/v1` plugin in `state/helm-plugins/` whose command is the agentlab binary itself, and passes it via `HELM_PLUGINS` + `--post-renderer agentlab-postrender`. The plain-Helm replacement for the Flux `postRenderers` the meta-package forwarded to helm-controller. |
 | `components.kagent.enabled` from `platform.agents`, `controller.auth.mode: unsecure`, kagent ServiceMonitor + OTel off | Agents are part of what the lab tests, so kagent is on by default (the umbrella defaults it off) but optional — `platform.agents: false` skips the runtime. `unsecure` because the GS `trusted-proxy` mode assumes a JWT-validating agentgateway in front; no Prometheus Operator / OTLP gateway in kind. See [Agents (kagent)](#agents-kagent). |
@@ -757,7 +808,8 @@ same one-URL trick, just spelled with a name.
   Harmless — Helm owns it and removes it on uninstall.
 - **Kubernetes tools carry the server-name prefix.** The umbrella's bundled
   `mcp-kubernetes` MCPServer declares no muster *family*, so its tools use
-  per-server prefixing: `call_tool(name=x_mcp-kubernetes_list, arguments={...})`.
+  per-server prefixing: `call_tool(name=x_mcp-kubernetes_list, arguments={...})`. The fake fleet's members are the lab's only family servers and they stay
+  `Auth Required`, so no `x_kubernetes_*` family tools appear in a session.
   (Real fleet installations register per-cluster servers with a `kubernetes`
   family and a `management_cluster` instance argument instead.)
 - **Tool results are double-wrapped.** `result.content[0].text` is JSON whose
@@ -853,7 +905,7 @@ the lab's `Auth Required` fixture:
   token audience  [kubernetes muster backstage]
   backstage user  user:default/dev
   ownership refs  [user:default/dev]
-  muster servers  [(mcp-kubernetes, Connected), (mcp-prometheus, Connected), (lab-oauth-fixture, Auth Required)]
+  muster servers  [(agent-manager, Connected), (capi-lab-01, Auth Required), (capi-lab-02, Auth Required), (kubernetes-lab-01, Auth Required), (kubernetes-lab-02, Auth Required), (lab-oauth-fixture, Auth Required), (mcp-kubernetes, Connected), (mcp-prometheus, Connected), (model-manager, Connected), (prometheus-lab-01, Auth Required), (prometheus-lab-02, Auth Required)]
   sign-in challenge lab-oauth-fixture -> https://muster.127.0.0.1.nip.io/oauth/proxy/start?state=… (client id via cimd)
   muster workflows [lab-cluster-overview]
   muster core tools 28 exposed
@@ -1220,6 +1272,7 @@ internal/lab/                  everything operational:
   login.go browser.go            password grant / authorization-code flow
   platform.go platformtest.go    agent platform install + MCP smoke test
   oauthfixture.go                the Auth Required MCPServer fixture + the per-server sign-in proof
+  fleetfixture.go                the fake-fleet MCPServers (families × fake clusters, tool-group label) + the label proof
   backstage.go backstagetest.go  Backstage deploy + headless sign-in proof
   postrender.go                  helm post-renderer (hostNetwork, route strip, nodePort pin)
   helmplugin.go                  generates the Helm 4 postrenderer plugin wrapping it

--- a/internal/lab/fleetfixture.go
+++ b/internal/lab/fleetfixture.go
@@ -1,0 +1,277 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The fake-fleet fixture.
+//
+// A real installation federates many management clusters: agent-platform-mcps
+// renders one MCPServer per cluster and per infrastructure family
+// (kubernetes, capi, prometheus), each declaring spec.family so muster exposes
+// the family once (x_kubernetes_<tool> with a management_cluster argument)
+// and labelled with the cluster it serves. The lab has one cluster and its
+// bundled mcp-kubernetes declares no family, so nothing in the lab looks like
+// a fleet — yet the portal's MCP servers page, its dashboard's fleet coverage
+// and the agent Tools step group servers by family and by the tool-group
+// label. This fixture fakes the fleet: fleetFixtureClusters × fleetFamilies
+// MCPServers in the platform namespace, each with the family block, the
+// management-cluster label and the tool-group label the fleet charts stamp.
+//
+// The label. agent-platform.giantswarm.io/tool-group sorts MCP servers into
+// the platform's three groups — agent-platform (agent-manager, model-manager,
+// muster core), infrastructure (the kubernetes/capi/prometheus families) and,
+// for a server without the label, Registered servers (whatever an
+// installation or a user registers). It is stamped by the chart that ships
+// the server and read by the portal (grouping), muster (the shipped
+// `infrastructure` / `agent-platform` toolset presets select by it) and
+// kubectl -l. Orientation and preset membership, not authorization. The
+// fixture carries `infrastructure`; the OAuth sign-in fixture
+// (oauthfixture.go) and anything registered by hand carry nothing, so the
+// Registered servers group has members too. The charts the lab vendors
+// (agent-manager, model-manager, the umbrella's mcp-kubernetes) bring their
+// own labels once bumped to the releases that stamp them.
+//
+// Where the members point. Like the OAuth fixture, at muster's own protected
+// /mcp with auth.type oauth: every member reads Auth Required — the state an
+// unconnected forwardToken fleet member shows on a real installation — at
+// zero cost. Pointing them at the lab's single mcp-kubernetes instead would
+// make muster open one connection per member per user session at session
+// start; a dozen such members rate-limited mcp-kubernetes (429) and took the
+// real mcp-kubernetes connection down with them. The fixture exists to be
+// grouped, listed and selected, not to be called.
+
+const (
+	// fleetFixtureLabel marks the fixture's CRs for cleanup and for the
+	// proofs; its value is the fixture's name.
+	fleetFixtureLabel = "agentlab.giantswarm.io/fixture"
+	fleetFixtureValue = "fake-fleet"
+	// managedByLabel/managedByAgentlabValue mark every CR the lab itself creates
+	// (as opposed to the vendored charts).
+	managedByLabel         = "app.kubernetes.io/managed-by"
+	managedByAgentlabValue = "agentlab"
+	// managementClusterLabel is muster's convention for the cluster a family
+	// member serves — the value the family's instanceArg selects.
+	managementClusterLabel = "muster.giantswarm.io/management-cluster"
+	// familyInstanceArg is the required argument every family tool takes.
+	familyInstanceArg = "management_cluster"
+	// toolGroupLabel and its two values: the Agent Platform's tiering of MCP
+	// servers. Absent means Registered servers.
+	toolGroupLabel          = "agent-platform.giantswarm.io/tool-group"
+	toolGroupInfrastructure = "infrastructure"
+	toolGroupAgentPlatform  = "agent-platform"
+)
+
+// fleetFixtureClusters are the fake management clusters. Two is a fleet for
+// every consumer (family rows with more than one cell, coverage per cluster)
+// at the smallest footprint.
+var fleetFixtureClusters = []string{"lab-01", "lab-02"}
+
+// fleetFamily is one infrastructure family the fleet charts ship, with the
+// muster.giantswarm.io/type the charts stamp on its members.
+type fleetFamily struct {
+	Name string
+	Type string
+}
+
+// fleetFamilies mirrors agent-platform-mcps' muster.families.
+var fleetFamilies = []fleetFamily{
+	{Name: "kubernetes", Type: "mcp-kubernetes"},
+	{Name: "capi", Type: "mcp-capi"},
+	{Name: "prometheus", Type: "mcp-observability"},
+}
+
+// fleetFixtureServer is one member the template renders.
+type fleetFixtureServer struct {
+	Name    string
+	Family  string
+	Type    string
+	Cluster string
+}
+
+// fleetFixtureServers lists every member, family-major, in render order.
+func fleetFixtureServers() []fleetFixtureServer {
+	out := make([]fleetFixtureServer, 0, len(fleetFamilies)*len(fleetFixtureClusters))
+	for _, f := range fleetFamilies {
+		for _, c := range fleetFixtureClusters {
+			out = append(out, fleetFixtureServer{Name: f.Name + "-" + c, Family: f.Name, Type: f.Type, Cluster: c})
+		}
+	}
+	return out
+}
+
+// fleetFixtureNames is the member names, sorted.
+func fleetFixtureNames() []string {
+	names := make([]string, 0, len(fleetFamilies)*len(fleetFixtureClusters))
+	for _, s := range fleetFixtureServers() {
+		names = append(names, s.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ensureFleetFixture applies the fixture, removes members of an earlier
+// shape (a cluster or family dropped from the lists above — the label
+// selector must keep listing exactly the fixture) and waits until muster
+// reports every member Auth Required. After the umbrella install for the
+// same reason as the OAuth fixture: the MCPServer CRD ships with muster.
+func ensureFleetFixture(cfg *config.Config) error {
+	names := fleetFixtureNames()
+	step("Creating the fake-fleet fixture (%d MCPServers: %s × %s)", len(names),
+		strings.Join(familyNames(), "/"), strings.Join(fleetFixtureClusters, ", "))
+	_, path, err := renderManifest(cfg, "fleet-fixture.yaml.tmpl")
+	if err != nil {
+		return err
+	}
+	if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
+		return err
+	}
+	existing, err := outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io",
+		"-l", fleetFixtureLabel+"="+fleetFixtureValue, "-o", "jsonpath={.items[*].metadata.name}")
+	if err != nil {
+		return err
+	}
+	for _, name := range strings.Fields(existing) {
+		if !slices.Contains(names, name) {
+			note("removing stale fixture member %s", name)
+			if err := runQuiet("kubectl", "-n", platformNamespace, "delete", "mcpservers.muster.giantswarm.io", name); err != nil {
+				return err
+			}
+		}
+	}
+	for _, name := range names {
+		if err := waitMCPServerState(name, mcpServerStateAuthRequired); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func familyNames() []string {
+	names := make([]string, 0, len(fleetFamilies))
+	for _, f := range fleetFamilies {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+// labelledServer is what the tool-group proof reads off every MCPServer CR
+// that carries the label, plus the OAuth fixture.
+type labelledServer struct {
+	Namespace string
+	Name      string
+	Labels    map[string]string
+}
+
+func (s labelledServer) key() string { return s.Namespace + "/" + s.Name }
+
+// proveToolGroupLabels is the platform-test step for the label: kubectl -l
+// with the infrastructure value lists every fake-fleet member and, of the
+// lab's own CRs, nothing else; every value in the cluster is one of the two
+// the contract knows; the OAuth fixture is unlabelled (a Registered server).
+// Servers the vendored charts label (Helm-managed) are reported, not judged:
+// they appear as the charts bump to the releases that stamp the label.
+func proveToolGroupLabels() error {
+	step("Tool-group label: %s=%s selects the fake-fleet fixture", toolGroupLabel, toolGroupInfrastructure)
+	labelled, err := listMCPServers("-A", "-l", toolGroupLabel)
+	if err != nil {
+		return err
+	}
+	oauth, err := listMCPServers("-n", platformNamespace, "--field-selector", "metadata.name="+oauthFixtureServer)
+	if err != nil {
+		return err
+	}
+	if len(oauth) != 1 {
+		return fmt.Errorf("MCPServer %s is missing — the sign-in fixture `agentlab platform` creates", oauthFixtureServer)
+	}
+	chartLabelled, err := checkToolGroupLabels(labelled, oauth[0])
+	if err != nil {
+		return err
+	}
+	note("%s=%s: %s", toolGroupLabel, toolGroupInfrastructure, strings.Join(fleetFixtureNames(), ", "))
+	if len(chartLabelled) > 0 {
+		note("labelled by the vendored charts: %s", strings.Join(chartLabelled, ", "))
+	}
+	note("%s carries no %s (Registered servers)", oauthFixtureServer, toolGroupLabel)
+	return nil
+}
+
+// checkToolGroupLabels is the pure half of proveToolGroupLabels: labelled is
+// every MCPServer carrying the tool-group label, oauth the OAuth fixture. It
+// returns the labelled servers the lab did not create (the charts' own).
+func checkToolGroupLabels(labelled []labelledServer, oauth labelledServer) ([]string, error) {
+	if v, ok := oauth.Labels[toolGroupLabel]; ok {
+		return nil, fmt.Errorf("MCPServer %s carries %s=%s — the OAuth fixture must stay unlabelled so the Registered servers group has a member",
+			oauth.Name, toolGroupLabel, v)
+	}
+	want := map[string]bool{}
+	for _, name := range fleetFixtureNames() {
+		want[platformNamespace+"/"+name] = false
+	}
+	var chartLabelled []string
+	for _, s := range labelled {
+		v := s.Labels[toolGroupLabel]
+		if v != toolGroupInfrastructure && v != toolGroupAgentPlatform {
+			return nil, fmt.Errorf("MCPServer %s carries %s=%q — the contract knows %s and %s only",
+				s.key(), toolGroupLabel, v, toolGroupInfrastructure, toolGroupAgentPlatform)
+		}
+		if _, isFixture := want[s.key()]; isFixture {
+			if v != toolGroupInfrastructure {
+				return nil, fmt.Errorf("fake-fleet member %s carries %s=%s, want %s", s.key(), toolGroupLabel, v, toolGroupInfrastructure)
+			}
+			want[s.key()] = true
+			continue
+		}
+		if s.Labels[managedByLabel] == managedByAgentlabValue {
+			return nil, fmt.Errorf("MCPServer %s is lab-created but carries %s=%s — only the fake-fleet fixture is labelled",
+				s.key(), toolGroupLabel, v)
+		}
+		chartLabelled = append(chartLabelled, s.key()+"="+v)
+	}
+	var missing []string
+	for key, seen := range want {
+		if !seen {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("fake-fleet members without %s=%s: %s (`agentlab platform` creates them)",
+			toolGroupLabel, toolGroupInfrastructure, strings.Join(missing, ", "))
+	}
+	sort.Strings(chartLabelled)
+	return chartLabelled, nil
+}
+
+// listMCPServers reads muster MCPServer CRs (fully qualified: kagent ships
+// its own mcpservers.kagent.dev) with the given kubectl selectors.
+func listMCPServers(selectors ...string) ([]labelledServer, error) {
+	args := append([]string{"get", "mcpservers.muster.giantswarm.io", "-o", "json"}, selectors...)
+	raw, err := outputQuiet("kubectl", args...)
+	if err != nil {
+		return nil, err
+	}
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Namespace string            `json:"namespace"`
+				Name      string            `json:"name"`
+				Labels    map[string]string `json:"labels"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(raw), &list); err != nil {
+		return nil, fmt.Errorf("parsing MCPServer list: %w", err)
+	}
+	out := make([]labelledServer, 0, len(list.Items))
+	for _, it := range list.Items {
+		out = append(out, labelledServer{Namespace: it.Metadata.Namespace, Name: it.Metadata.Name, Labels: it.Metadata.Labels})
+	}
+	return out, nil
+}

--- a/internal/lab/fleetfixture_test.go
+++ b/internal/lab/fleetfixture_test.go
@@ -1,0 +1,223 @@
+package lab
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// fixtureCR is the shape of one rendered MCPServer the tests decode into.
+type fixtureCR struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name        string            `yaml:"name"`
+		Namespace   string            `yaml:"namespace"`
+		Labels      map[string]string `yaml:"labels"`
+		Annotations map[string]string `yaml:"annotations"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Type      string `yaml:"type"`
+		URL       string `yaml:"url"`
+		AutoStart bool   `yaml:"autoStart"`
+		Family    struct {
+			Name        string `yaml:"name"`
+			InstanceArg string `yaml:"instanceArg"`
+		} `yaml:"family"`
+		Auth struct {
+			Type         string `yaml:"type"`
+			ForwardToken bool   `yaml:"forwardToken"`
+		} `yaml:"auth"`
+	} `yaml:"spec"`
+}
+
+func decodeCRs(t *testing.T, raw []byte) []fixtureCR {
+	t.Helper()
+	var out []fixtureCR
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	for {
+		var cr fixtureCR
+		err := dec.Decode(&cr)
+		if errors.Is(err, io.EOF) {
+			return out
+		}
+		if err != nil {
+			t.Fatalf("decoding rendered fixture: %v\n%s", err, raw)
+		}
+		if cr.Kind == "" {
+			continue // the leading comment-only document
+		}
+		out = append(out, cr)
+	}
+}
+
+// TestFleetFixtureTemplate pins the fake fleet to what its consumers read:
+// one MCPServer per family per fake cluster in the platform namespace, the
+// family block with muster's management_cluster argument, the
+// management-cluster label naming the member's cluster, the type label the
+// fleet charts stamp, the tool-group label with the infrastructure value,
+// the lab's fixture markers — and, like the OAuth fixture, muster's own
+// protected endpoint as target with an oauth auth block without SSO.
+func TestFleetFixtureTemplate(t *testing.T) {
+	raw, err := renderTemplate(config.Default(), "fleet-fixture.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	crs := decodeCRs(t, raw)
+	want := len(fleetFamilies) * len(fleetFixtureClusters)
+	if len(crs) != want {
+		t.Fatalf("want %d MCPServers (%d families × %d clusters), got %d:\n%s", want, len(fleetFamilies), len(fleetFixtureClusters), len(crs), raw)
+	}
+	if got := strings.Count(string(raw), "kind: MCPServer"); got != want {
+		t.Errorf("want %d `kind: MCPServer`, got %d", want, got)
+	}
+	var names []string
+	for _, cr := range crs {
+		names = append(names, cr.Metadata.Name)
+		fam, ok := familyByName(cr.Spec.Family.Name)
+		if !ok {
+			t.Errorf("%s: family %q is not one of the fleet families", cr.Metadata.Name, cr.Spec.Family.Name)
+			continue
+		}
+		cluster := cr.Metadata.Labels[managementClusterLabel]
+		if !slices.Contains(fleetFixtureClusters, cluster) {
+			t.Errorf("%s: %s=%q is not a fake cluster", cr.Metadata.Name, managementClusterLabel, cluster)
+		}
+		checks := map[string][2]string{
+			"apiVersion":              {cr.APIVersion, "muster.giantswarm.io/v1alpha1"},
+			"kind":                    {cr.Kind, "MCPServer"},
+			"name":                    {cr.Metadata.Name, fam.Name + "-" + cluster},
+			"namespace":               {cr.Metadata.Namespace, platformNamespace},
+			managedByLabel:            {cr.Metadata.Labels[managedByLabel], managedByAgentlabValue},
+			fleetFixtureLabel:         {cr.Metadata.Labels[fleetFixtureLabel], fleetFixtureValue},
+			"muster type label":       {cr.Metadata.Labels["muster.giantswarm.io/type"], fam.Type},
+			toolGroupLabel:            {cr.Metadata.Labels[toolGroupLabel], toolGroupInfrastructure},
+			"spec.type":               {cr.Spec.Type, "streamable-http"},
+			"spec.url":                {cr.Spec.URL, oauthFixtureURL},
+			"spec.family.instanceArg": {cr.Spec.Family.InstanceArg, familyInstanceArg},
+			"spec.auth.type":          {cr.Spec.Auth.Type, "oauth"},
+		}
+		for what, gw := range checks {
+			if gw[0] != gw[1] {
+				t.Errorf("%s: %s = %q, want %q", cr.Metadata.Name, what, gw[0], gw[1])
+			}
+		}
+		if !cr.Spec.AutoStart {
+			t.Errorf("%s: autoStart must be true", cr.Metadata.Name)
+		}
+		if cr.Spec.Auth.ForwardToken {
+			t.Errorf("%s: forwardToken must be off — the member is a manual-login oauth server, never SSO", cr.Metadata.Name)
+		}
+		if cr.Metadata.Annotations["agentlab.giantswarm.io/purpose"] == "" {
+			t.Errorf("%s: the purpose annotation is missing", cr.Metadata.Name)
+		}
+	}
+	slices.Sort(names)
+	if got := fleetFixtureNames(); !slices.Equal(names, got) {
+		t.Errorf("rendered names %v differ from fleetFixtureNames() %v", names, got)
+	}
+	if strings.Contains(string(raw), "tokenExchange") {
+		t.Errorf("the fixture must not be an SSO server (token exchange):\n%s", raw)
+	}
+}
+
+func familyByName(name string) (fleetFamily, bool) {
+	for _, f := range fleetFamilies {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return fleetFamily{}, false
+}
+
+// TestOAuthFixtureCarriesNoToolGroup: the OAuth fixture is the lab's
+// Registered server — the one group the label marks by absence.
+func TestOAuthFixtureCarriesNoToolGroup(t *testing.T) {
+	raw, err := renderTemplate(config.Default(), "oauth-fixture.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(string(raw), toolGroupLabel) {
+		t.Errorf("the OAuth fixture must not carry %s:\n%s", toolGroupLabel, raw)
+	}
+}
+
+// TestCheckToolGroupLabels covers the platform-test judgement: exactly the
+// fixture among the lab's own CRs, chart-labelled servers reported, the
+// contract's two values only, the OAuth fixture unlabelled.
+func TestCheckToolGroupLabels(t *testing.T) {
+	member := func(name string) labelledServer {
+		return labelledServer{Namespace: platformNamespace, Name: name, Labels: map[string]string{
+			managedByLabel: managedByAgentlabValue, fleetFixtureLabel: fleetFixtureValue, toolGroupLabel: toolGroupInfrastructure}}
+	}
+	fixture := func() []labelledServer {
+		var out []labelledServer
+		for _, name := range fleetFixtureNames() {
+			out = append(out, member(name))
+		}
+		return out
+	}
+	oauth := labelledServer{Namespace: platformNamespace, Name: oauthFixtureServer,
+		Labels: map[string]string{managedByLabel: managedByAgentlabValue, fleetFixtureLabel: "oauth-sign-in"}}
+	helm := func(name, group string) labelledServer {
+		return labelledServer{Namespace: platformNamespace, Name: name, Labels: map[string]string{managedByLabel: "Helm", toolGroupLabel: group}}
+	}
+
+	t.Run("exactly the fixture", func(t *testing.T) {
+		chart, err := checkToolGroupLabels(fixture(), oauth)
+		if err != nil || len(chart) != 0 {
+			t.Fatalf("want ok and no chart-labelled servers, got %v, %v", chart, err)
+		}
+	})
+	t.Run("chart-labelled servers are reported, not judged", func(t *testing.T) {
+		all := append(fixture(), helm("mcp-kubernetes", toolGroupInfrastructure), helm("agent-manager", toolGroupAgentPlatform))
+		chart, err := checkToolGroupLabels(all, oauth)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{platformNamespace + "/agent-manager=agent-platform", platformNamespace + "/mcp-kubernetes=infrastructure"}
+		if !slices.Equal(chart, want) {
+			t.Fatalf("want %v, got %v", want, chart)
+		}
+	})
+	t.Run("a missing member fails", func(t *testing.T) {
+		all := fixture()[1:]
+		if _, err := checkToolGroupLabels(all, oauth); err == nil || !strings.Contains(err.Error(), fleetFixtureNames()[0]) {
+			t.Fatalf("want the missing member named, got %v", err)
+		}
+	})
+	t.Run("a member with the wrong value fails", func(t *testing.T) {
+		all := fixture()
+		all[0].Labels[toolGroupLabel] = toolGroupAgentPlatform
+		if _, err := checkToolGroupLabels(all, oauth); err == nil || !strings.Contains(err.Error(), "want "+toolGroupInfrastructure) {
+			t.Fatalf("want the wrong value refused, got %v", err)
+		}
+	})
+	t.Run("an unknown value fails", func(t *testing.T) {
+		all := append(fixture(), helm("pro", "other"))
+		if _, err := checkToolGroupLabels(all, oauth); err == nil || !strings.Contains(err.Error(), `"other"`) {
+			t.Fatalf("want the unknown value refused, got %v", err)
+		}
+	})
+	t.Run("another lab-created labelled server fails", func(t *testing.T) {
+		stray := member("stray")
+		delete(stray.Labels, fleetFixtureLabel)
+		if _, err := checkToolGroupLabels(append(fixture(), stray), oauth); err == nil || !strings.Contains(err.Error(), "stray") {
+			t.Fatalf("want the stray lab server refused, got %v", err)
+		}
+	})
+	t.Run("a labelled OAuth fixture fails", func(t *testing.T) {
+		labelledOAuth := oauth
+		labelledOAuth.Labels = map[string]string{managedByLabel: managedByAgentlabValue, toolGroupLabel: toolGroupInfrastructure}
+		if _, err := checkToolGroupLabels(fixture(), labelledOAuth); err == nil || !strings.Contains(err.Error(), oauthFixtureServer) {
+			t.Fatalf("want the labelled OAuth fixture refused, got %v", err)
+		}
+	})
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -403,6 +403,11 @@ func platformUp(cfg *config.Config, chartReady <-chan error, header string) erro
 	if err := ensureOAuthFixture(cfg); err != nil {
 		return err
 	}
+	// The fake-fleet fixture (fleetfixture.go): the family MCPServers with
+	// the tool-group label the fleet charts stamp — same CRD reason.
+	if err := ensureFleetFixture(cfg); err != nil {
+		return err
+	}
 
 	// The agents' model key. The default ModelConfig (rendered by the kagent
 	// subchart from providers.anthropic) references this secret; agent pods

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -164,6 +164,14 @@ func PlatformTest(cfg *config.Config, email string) error {
 	}
 	verdict += "\nPASS: per-server OAuth sign-in -> muster (OAuth client) -> challenge on " + oauthProxyStartPath +
 		" (fixture " + oauthFixtureServer + ")"
+	// The tool-group label (fleetfixture.go): the infrastructure value
+	// selects the fake-fleet families and nothing else the lab created; the
+	// OAuth fixture stays a Registered server.
+	if err := proveToolGroupLabels(); err != nil {
+		return err
+	}
+	verdict += fmt.Sprintf("\nPASS: %s=%s selects the fake-fleet fixture (%d MCPServers); %s unlabelled (Registered servers)",
+		toolGroupLabel, toolGroupInfrastructure, len(fleetFixtureNames()), oauthFixtureServer)
 	if cfg.Platform.Observability {
 		// Same singleton prefixing as mcp-kubernetes: the lab's mcpServers
 		// entry deliberately keeps the server out of muster's families

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -65,6 +65,12 @@ type tmplData struct {
 	// name the proofs sign in to and the protected endpoint it points at.
 	OAuthFixtureServer string
 	OAuthFixtureURL    string
+	// The fake-fleet fixture (fleetfixture.go): its members, the family
+	// instance argument and the tool-group label they carry.
+	FleetFixtureServers     []fleetFixtureServer
+	FamilyInstanceArg       string
+	ToolGroupLabel          string
+	ToolGroupInfrastructure string
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -87,6 +93,10 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		ExtraModels:               cfg.Platform.ExtraModels,
 		OAuthFixtureServer:        oauthFixtureServer,
 		OAuthFixtureURL:           oauthFixtureURL,
+		FleetFixtureServers:       fleetFixtureServers(),
+		FamilyInstanceArg:         familyInstanceArg,
+		ToolGroupLabel:            toolGroupLabel,
+		ToolGroupInfrastructure:   toolGroupInfrastructure,
 		CertsDir:                  certsDir,
 		MusterNodePort:            config.MusterNodePort,
 		KagentUINodePort:          config.KagentUINodePort,
@@ -172,6 +182,7 @@ var manifests = map[string]struct {
 	"observability-route.yaml.tmpl":          {out: "observability-route.yaml"},
 	"demo-workflow.yaml.tmpl":                {out: "demo-workflow.yaml"},
 	"oauth-fixture.yaml.tmpl":                {out: "oauth-fixture.yaml"},
+	"fleet-fixture.yaml.tmpl":                {out: "fleet-fixture.yaml"},
 	"extra-models.yaml.tmpl":                 {out: "extra-models.yaml"},
 	"coredns.yaml.tmpl":                      {out: "coredns.yaml"},
 	"gateway-nodeport.yaml.tmpl":             {out: "gateway-nodeport.yaml"},

--- a/internal/lab/templates/fleet-fixture.yaml.tmpl
+++ b/internal/lab/templates/fleet-fixture.yaml.tmpl
@@ -1,0 +1,71 @@
+# A test fixture, not a real integration: the fake fleet (fleetfixture.go).
+#
+# A real installation federates many management clusters — agent-platform-mcps
+# renders one MCPServer per cluster and per infrastructure family (kubernetes,
+# capi, prometheus), each declaring spec.family so muster exposes the family
+# once (x_kubernetes_<tool> with a management_cluster argument) and labelled
+# with the cluster it serves. The lab has one cluster and its bundled
+# mcp-kubernetes declares no family, so nothing here looks like a fleet — yet
+# the portal's MCP servers page, its dashboard's fleet coverage and the agent
+# Tools step group servers by family and by the tool-group label. These CRs
+# fake the fleet: {{ len .FleetFixtureServers }} members, the family block, the management-cluster label
+# and the label the fleet charts stamp:
+#
+#   {{ .ToolGroupLabel }}: {{ .ToolGroupInfrastructure }}
+#
+# That label sorts MCP servers into the platform's three groups — agent-platform
+# (agent-manager, model-manager, muster core), infrastructure (these families)
+# and, for a server WITHOUT the label, Registered servers (whatever an
+# installation or a user registers). The chart that ships a server stamps it;
+# the portal groups by it, muster's shipped `infrastructure` / `agent-platform`
+# toolset presets select by it, `kubectl get mcpservers.muster.giantswarm.io
+# -A -l {{ .ToolGroupLabel }}={{ .ToolGroupInfrastructure }}` lists by it.
+# Orientation and preset membership, not authorization. The OAuth sign-in
+# fixture ({{ .OAuthFixtureServer }}) and anything registered by hand carry
+# no label on purpose: the Registered servers group needs members too.
+#
+# Every member points at muster's own protected /mcp with auth.type oauth, like
+# the OAuth fixture, and so reads "Auth Required" — what an unconnected
+# forwardToken fleet member shows on a real installation — at zero cost.
+# Pointing them at the lab's single mcp-kubernetes instead makes muster open
+# one connection per member per user session; a dozen of those rate-limited
+# mcp-kubernetes (429) and took the session's real mcp-kubernetes connection
+# down with them. The fixture exists to be grouped, listed and selected, not
+# to be called.
+{{- range .FleetFixtureServers }}
+---
+apiVersion: muster.giantswarm.io/v1alpha1
+kind: MCPServer
+metadata:
+  name: {{ .Name }}
+  namespace: agent-platform
+  labels:
+    app.kubernetes.io/managed-by: agentlab
+    agentlab.giantswarm.io/fixture: fake-fleet
+    muster.giantswarm.io/type: {{ .Type }}
+    muster.giantswarm.io/management-cluster: {{ .Cluster }}
+    {{ $.ToolGroupLabel }}: {{ $.ToolGroupInfrastructure }}
+  annotations:
+    agentlab.giantswarm.io/purpose: >-
+      Lab test fixture: one member of the fake fleet — the {{ .Family }} family
+      on the fake management cluster {{ .Cluster }} — carrying the family
+      block, the management-cluster label and the tool-group label the fleet
+      charts stamp, so the portal's server groups, fleet coverage and the
+      infrastructure toolset preset can be exercised on one kind cluster. Not
+      a real integration: it points at muster's own OAuth-protected /mcp and
+      stays Auth Required.
+spec:
+  description: >-
+    Lab fixture: the {{ .Family }} MCP server of the fake management cluster
+    {{ .Cluster }}. Stays Auth Required; exists to be grouped and listed, not
+    to be called.
+  type: streamable-http
+  url: {{ $.OAuthFixtureURL }}
+  autoStart: true
+  family:
+    name: {{ .Family }}
+    instanceArg: {{ $.FamilyInstanceArg }}
+  auth:
+    type: oauth
+    forwardToken: false
+{{- end }}


### PR DESCRIPTION
Part of #69 (the fixture half; the e2e half — the portal's three server groups and the unlabelled fallback — waits for giantswarm/backstage#2285 to be released and follows in a separate PR). Epic: giantswarm/giantswarm#37435, plan: [bumblebee-plans `agent-tool-access/PRD.md`](https://github.com/giantswarm/bumblebee-plans/blob/main/agent-tool-access/PRD.md) (D8).

## What

`agentlab platform` ships a **fake fleet**: three infrastructure families (`kubernetes`, `capi`, `prometheus`) × two fake management clusters (`lab-01`, `lab-02`) = six MCPServers `<family>-<cluster>` in `agent-platform`, each with the `spec.family` block (`instanceArg: management_cluster`), the `muster.giantswarm.io/management-cluster` label, the `muster.giantswarm.io/type` the fleet charts stamp, and the tier label

```yaml
agent-platform.giantswarm.io/tool-group: infrastructure
```

- `internal/lab/fleetfixture.go` + `templates/fleet-fixture.yaml.tmpl`: the members, apply, stale-member removal (the selector must keep listing exactly the fixture when the lists change), the Auth Required wait; a pure `checkToolGroupLabels` for the proof.
- `platform.go`: applied right after the OAuth fixture (same CRD-ships-with-muster reason).
- `platform-test`: a new step — the `infrastructure` selector lists every member and, of the lab's own CRs, nothing else; every tool-group value in the cluster is one of the contract's two; `lab-oauth-fixture` carries no label (Registered servers). Servers the vendored charts label (Helm-managed) are reported, not judged — they appear as agent-manager / model-manager / the umbrella bump to the releases that stamp the label.
- Unit tests for the render (count, names, family, labels, target, auth shape) and the judgement (exact set, chart-labelled reported, missing/wrong/unknown/stray/labelled-OAuth-fixture refused); the OAuth fixture render is pinned label-free.
- README: what the label is for (the three groups), the fixture, why the members point at muster's own protected `/mcp` (Auth Required at zero cost — a dozen members on the lab's single mcp-kubernetes rate-limited it, 429, and took the session's real connection down), deviations row, layout.

## Why

The lab has one cluster and its bundled `mcp-kubernetes` declares no family, so nothing looked like the federated fleet the portal's regrouped MCP servers page, dashboard fleet coverage and agent Tools step are built for. The label is inert until the portal reads it; a fixture that carries it is what lets the regroup be proven headlessly before the fleet charts roll out. `lab-oauth-fixture` and anything registered by hand stay unlabelled on purpose so the Registered servers group has members.

## Lab evidence (kind-agentlab, chart pins unchanged, lock held for the platform run and released)

`agentlab platform` with this binary (00:59 → 01:03):

```
==> Creating the fake-fleet fixture (6 MCPServers: kubernetes/capi/prometheus × lab-01, lab-02)
    MCPServer capi-lab-01: Auth Required … MCPServer prometheus-lab-02: Auth Required
```

```
$ kubectl get mcpservers.muster.giantswarm.io -A -l agent-platform.giantswarm.io/tool-group=infrastructure
agent-platform   capi-lab-01         streamable-http   …/mcp   true   Auth Required
agent-platform   capi-lab-02         …
agent-platform   kubernetes-lab-01   …
agent-platform   kubernetes-lab-02   …
agent-platform   prometheus-lab-01   …
agent-platform   prometheus-lab-02   …
```

agent-manager, model-manager, mcp-kubernetes, mcp-prometheus and lab-oauth-fixture carry no tool-group label (their charts have not been bumped yet; the fixture is unlabelled by design).

`agentlab platform-test`: all six PASS lines, including the new

```
PASS: agent-platform.giantswarm.io/tool-group=infrastructure selects the fake-fleet fixture (6 MCPServers); lab-oauth-fixture unlabelled (Registered servers)
```

`agentlab backstage-test`: PASS for admin/dev/viewer; the portal's `/servers` lists the six members as `Auth Required` next to the real servers. `go test ./...`, `pre-commit run --all-files` green.

Not verified here: the portal's grouping itself (needs giantswarm/backstage#2285 — the current Backstage lists the members in its family-based split).
