### PR TITLE
feat(lab): toolsets-test proves declared toolsets end to end; the OAuth fixture pins Dex so its sign-in completes

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -407,9 +407,14 @@ exposes none of mcp-oauth's knobs for a lab (`AllowPrivateIPClientMetadata`,
 `DisableDNSValidation`, `AllowPrivateIPRedirectURIs`), so no sign-in could
 complete against it and the fixture was a challenge generator only. **Fix in
 the lab:** the CR pins the lab Dex through `spec.auth.authorizationServer`
-(issuer, `clientCredentialsSecretRef` → the platform client's id/secret in the
-Secret `lab-oauth-fixture-client`, `scopes` — a pinned server gets no default
-scope and Dex refuses a request without `openid`), and `dex.yaml.tmpl` lists
+(Dex's `authorizationEndpoint`/`tokenEndpoint`, `clientCredentialsSecretRef` →
+the platform client's id/secret in the Secret `lab-oauth-fixture-client`,
+`scopes` — a pinned server gets no default scope and Dex refuses a request
+without `openid` — and as `issuer` muster's own public URL: the grant is filed
+under the issuer the endpoint's RFC 9728 metadata names, which is also the key
+the connection looks it up under; a pin naming Dex's URL as the issuer
+completes the sign-in but every call then fails with "no valid token
+available" — worth a muster issue, the CRD text does not say so), and `dex.yaml.tmpl` lists
 muster's proxy callback on that client. Dex matches redirect URIs exactly and
 the token it issues carries the platform client's audience, which the endpoint
 trusts, so `agentlab toolsets-test` completes the sign-in headlessly. Unblocks

--- a/HACKS.md
+++ b/HACKS.md
@@ -394,6 +394,29 @@ where the kernel refuses everything below
 `ChooseFreePorts` moves the edge to 8443. Resolves for a user who runs Podman
 as root or lowers the sysctl; nothing to fix in the lab.
 
+### U18. `oauth-fixture.yaml.tmpl`: the sign-in fixture pins Dex as its authorization server — BLOCKED UPSTREAM
+The fixture points muster at its own protected `/mcp`, whose RFC 9728 metadata
+names muster's own OAuth 2.1 server. That server identifies muster-as-client by
+Client ID Metadata Document, and mcp-oauth's SSRF guards refuse the metadata
+URL — `muster.127.0.0.1.nip.io` resolves to the edge's cluster IP in-cluster
+(the CoreDNS rewrite) and to loopback everywhere else (`client_id metadata URL
+resolves to private/internal IP address … (SSRF protection)`); dynamic
+registration is refused the same way for the proxy callback's redirect URI
+(`hostname resolves to private IP address (DNS rebinding protection)`). muster
+exposes none of mcp-oauth's knobs for a lab (`AllowPrivateIPClientMetadata`,
+`DisableDNSValidation`, `AllowPrivateIPRedirectURIs`), so no sign-in could
+complete against it and the fixture was a challenge generator only. **Fix in
+the lab:** the CR pins the lab Dex through `spec.auth.authorizationServer`
+(issuer, `clientCredentialsSecretRef` → the platform client's id/secret in the
+Secret `lab-oauth-fixture-client`, `scopes` — a pinned server gets no default
+scope and Dex refuses a request without `openid`), and `dex.yaml.tmpl` lists
+muster's proxy callback on that client. Dex matches redirect URIs exactly and
+the token it issues carries the platform client's audience, which the endpoint
+trusts, so `agentlab toolsets-test` completes the sign-in headlessly. Unblocks
+when muster exposes `allowPrivateIPClientMetadata` for its OAuth server — then
+the pin can go and the challenge chain becomes proxy start → muster
+`/oauth/authorize` → Dex again.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/README.md
+++ b/README.md
@@ -313,8 +313,11 @@ metadata at zero cost), so the CR sits at `Auth Required` until a session
 signs in and every `core_auth_login` yields a fresh challenge. The
 authorization server the sign-in walks through is **pinned to the lab Dex**
 (`spec.auth.authorizationServer`, the shape an operator uses for a GitHub App:
-issuer, the client from the Secret `lab-oauth-fixture-client`, the scopes)
-rather than discovered. Discovery would name muster's own OAuth 2.1 server,
+Dex's authorization and token endpoints, the client from the Secret
+`lab-oauth-fixture-client`, the scopes — and, as the `issuer`, muster's own
+public URL, the identity the grant is filed under: it must be the server the
+endpoint's RFC 9728 metadata names, or no call finds the token) rather than
+discovered. Discovery would name muster's own OAuth 2.1 server,
 which identifies clients by Client ID Metadata Document — and that server's
 SSRF guards refuse every lab hostname, for the metadata URL and for a
 registered redirect URI alike (`muster.127.0.0.1.nip.io` resolves to the

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ export ANTHROPIC_API_KEY=sk-ant-...   # optional: powers the agents + Backstage 
 ./agentlab platform-test   # headless proof: Dex -> muster -> mcp-kubernetes -> apiserver, + the per-server OAuth sign-in challenge
 ./agentlab models-test     # with an Ollama on the host: pull -> ModelConfig -> agent turn -> delete, through the platform
 ./agentlab agents-test     # agent-manager as the signed-in user: create -> ready -> update -> delete via muster; a viewer's create is Forbidden; the ServiceAccount holds no RBAC
+./agentlab toolsets-test   # declared toolsets end to end: agent-manager requires one, the Agent carries the header, muster resolves and refuses per request, agents see their toolset, a per-server sign-in scopes tools to the token, the portal's Tools step and apply path
 ```
 
 Then trust the lab CA once and point Claude Code at the platform (`.mcp.json`
@@ -307,36 +308,47 @@ Nothing the lab aggregates needs a per-user login, though — mcp-kubernetes,
 mcp-prometheus and model-manager are unauthenticated in-cluster — so
 `agentlab platform` ships one downstream that does: the MCPServer
 `lab-oauth-fixture` (`oauth-fixture.yaml.tmpl`, annotated as a fixture). It
-points muster at its **own** protected `/mcp` endpoint, which answers 401 with
-RFC 9728 metadata naming muster's own OAuth 2.1 server as the authorization
-server. The CR therefore sits at `Auth Required` for good, every
-`core_auth_login` yields a fresh challenge, and the challenge chain is the
-real one: proxy start → muster `/oauth/authorize` → Dex. A Dex-protected stub
-could not serve the same purpose (Dex knows only static clients; the proxy
-identifies itself by CIMD), and a dedicated OAuth-protected stub server would
-add a workload plus an authorization server that knows muster, for the same
-401. What the self-aggregation costs: right after a muster restart the CR
-reads `Failed` (muster dials itself before its listener is up) until the
-reconnect backoff flips it to `Auth Required`, about a minute — `agentlab
-platform` waits for that — and
-completing the sign-in connects muster to itself, surfacing its own tools
-under `x_lab-oauth-fixture_`. Harmless and per session; the fixture is there
-to be signed in *to*.
+points muster at its **own** protected `/mcp` endpoint (a 401 with RFC 9728
+metadata at zero cost), so the CR sits at `Auth Required` until a session
+signs in and every `core_auth_login` yields a fresh challenge. The
+authorization server the sign-in walks through is **pinned to the lab Dex**
+(`spec.auth.authorizationServer`, the shape an operator uses for a GitHub App:
+issuer, the client from the Secret `lab-oauth-fixture-client`, the scopes)
+rather than discovered. Discovery would name muster's own OAuth 2.1 server,
+which identifies clients by Client ID Metadata Document — and that server's
+SSRF guards refuse every lab hostname, for the metadata URL and for a
+registered redirect URI alike (`muster.127.0.0.1.nip.io` resolves to the
+edge's cluster IP in-cluster and to loopback outside; muster exposes no knob
+for mcp-oauth's `AllowPrivateIPClientMetadata`, HACKS.md U18), so no sign-in
+could ever complete there. Dex matches redirect URIs exactly: the platform
+client lists muster's proxy callback `/oauth/proxy/callback` next to its
+server-role callback (`dex.yaml.tmpl`), and the token Dex issues carries the
+platform client's audience, which the endpoint trusts. Completing the sign-in
+therefore connects muster to itself and surfaces its own tools under
+`x_lab-oauth-fixture_` — harmless, per session, and exactly what the toolset
+proof needs (a toolset naming the server resolves to its tools only for the
+session that signed in). What the self-aggregation costs: right after a muster
+restart the CR reads `Failed` (muster dials itself before its listener is up)
+until the reconnect backoff flips it to `Auth Required`, about a minute —
+`agentlab platform` waits for that.
 
 `agentlab platform-test` proves the path headlessly on a fresh MCP session
 (the shape of one portal user's session): `list_tools` flags the fixture under
 `servers_requiring_auth`; `core_auth_login` answers a challenge on
 `/oauth/proxy/start` with a state; a second call answers a **fresh** state (a
 re-clicked Sign in gets its own challenge, giantswarm/backstage#2203); and the
-URL redeems — GET-ing it redirects to the authorization server rather than
-rejecting the state. `agentlab backstage-test` proves the portal hop for every
-user: the fixture is listed `Auth Required` and `POST /api/muster/auth/login`
-answers `status: auth_required` with the same URL shape, on that user's own
-forwarded token.
+URL redeems — GET-ing it redirects to the pinned authorization server (Dex,
+client `agent-platform`) rather than rejecting the state. `agentlab
+backstage-test` proves the portal hop for every user: the fixture is listed
+`Auth Required` and `POST /api/muster/auth/login` answers `status:
+auth_required` with the same URL shape, on that user's own forwarded token.
+`agentlab toolsets-test` completes the sign-in headlessly (the Dex login form,
+then muster's proxy callback) and proves what it unlocks — see
+[Toolsets](#toolsets-declared-tool-access).
 
 To drive the UI: **Agent Platform → MCP Servers**, expand `lab-oauth-fixture`,
-**Sign in** — the popup lands on muster's authorization page, then Dex. After a
-muster pod roll the row reads `Failed` for about a minute (Reconnect, or wait).
+**Sign in** — the popup lands on Dex directly. After a muster pod roll the row
+reads `Failed` for about a minute (Reconnect, or wait).
 
 ### The fake fleet and the tool-group label
 
@@ -387,6 +399,83 @@ called. `agentlab platform-test` asserts the label: the `infrastructure`
 selector lists every member and, of the lab's own CRs, nothing else; every
 value in the cluster is one of the two the contract knows; `lab-oauth-fixture`
 is unlabelled. Servers the vendored charts label are reported, not judged.
+
+### Toolsets (declared tool access)
+
+A **toolset** is the selector list an agent declares — the `agent` chart's
+`toolset` value, rendered as the `X-Muster-Toolset` header on the agent's
+muster tool entry (`spec.declarative.tools[0].headersFrom`), agent-manager's
+`toolset` argument, the portal's Tools step — that bounds which of the
+gateway's tools the agent's meta-tools can see and call. Selectors:
+`preset:<name>`, `server:<name>`, `workflow:<name>`, `tool:<name>`; built-in
+presets `read-only`, `none`, `full`; the platform chart ships `infrastructure`
+and `agent-platform`, defined by the tool-group label above. muster evaluates
+the header **per request** on the caller's own catalogue, so the invoking
+human's identity and the backends' authorization stay the boundary: a toolset
+is composition, not authorization, and it never widens what the person could
+reach.
+
+`agentlab toolsets-test` proves the feature end to end against the released
+components, as the admin, and leaves nothing behind (its agents are named
+`agentlab-toolset-*`, its workflows likewise):
+
+1. **agent-manager's contract** through muster: `create_agent` without a
+   toolset is refused naming the shipped presets and `preset:none`; the removed
+   `toolNames` argument is refused with the explaining error; four agents are
+   created with `preset:read-only`, `preset:none`, `preset:full` and
+   `server:lab-oauth-fixture`.
+2. **What was rendered**: the header on each Agent CR with the joined
+   selectors, the value on each HelmRelease, `get_agent` reporting the same;
+   the `preset:none` agent has **no** muster tool entry at all; a HelmRelease
+   applied without the value (every agent that predates toolsets) renders a
+   header-less entry and `list_agents` reports `implicitFullAccess: true`.
+3. **muster's resolution**, in sessions of the same user carrying the header
+   an agent's runtime sends: two workflows are created (`core_workflow_create`
+   as the caller), one query-only and one with a destructive step, and
+   `describe_tool` shows the derived `readOnlyHint` on the first only;
+   `preset:read-only` resolves to read-only tools only — the query-only
+   workflows included (the lab's `lab-cluster-overview` among them), the
+   mutating one and `core_*` excluded; the read-only Kubernetes call succeeds
+   and the destructive call (agent-manager's `delete_agent` — the lab's
+   mcp-kubernetes runs non-destructive and registers no writers) and the
+   mutating workflow are refused with `tool "…" is outside the toolset
+   [preset:read-only]`; `preset:none` sees and gets
+   nothing; `preset:full` equals the unscoped catalogue; header errors (an
+   unknown preset, the reserved `toolset:`, an inline `label:`) are error
+   results, never a fall-back; two toolsets on one token — request by request
+   in one session and from two sessions in parallel — each see their own
+   tools; when the platform chart shipped `infrastructure` / `agent-platform`,
+   each resolves to the tools of the servers carrying that label (the latter
+   plus `core_*`).
+4. **The runtime path** (skip with `--skip-chat`): through kagent's A2A
+   endpoint behind the edge, as the user, the read-only agent lists read-only
+   tools only (so kagent sends the header and the user's token), and the
+   `preset:none` agent answers a chat turn. The agents run on
+   `default-model-config` (`--model-config` to pick another).
+5. **The sign-in claim (ground-truth G6)**: before any sign-in,
+   `server:lab-oauth-fixture` resolves to nothing for everyone
+   (`toolset_unmatched` names the selector); the portal's Sign in (`POST
+   /api/muster/auth/login` with the portal's own forwarded Dex id_token) yields
+   the challenge, which the proof completes as the browser would; an
+   agent-shaped session on the **same** id_token then resolves the fixture's
+   tools and calls one; the real agent, driven through kagent with that token,
+   reports them too. A second user, and the same user under a **fresh**
+   id_token, still resolve nothing: muster keys a forwarded bearer's session by
+   the token (`ext-<hash>`), the grant belongs to that session
+   (`grantScope: session`), and the portal forwards one and the same
+   id_token to muster and to kagent — which is why the claim holds in the
+   portal and only there.
+6. **The portal**: the Tools step's backend calls (`/api/muster/tools/filter`
+   with `include_presets`, a `toolset=` resolution, an unmatched selector, an
+   unknown preset relayed as muster's error), and the composer's apply path —
+   the same hidden scaffolder template the wizard's Deploy drives, with the
+   composer's manifest and the user's OIDC token as the secret — landing the
+   `toolset` value on the HelmRelease and the header on the Agent.
+
+`agentlab agents-test` declares `preset:read-only` for its agent and asserts
+the refusal without one (agent-manager ≥ 0.4.0 requires a toolset), and
+`agentlab backstage-test` proves the MCP servers page's three groups from the
+data the page reads — see [The muster plugin](#the-muster-plugin).
 
 ### Agents (kagent)
 
@@ -894,6 +983,18 @@ The browser forwards the signed-in user's Dex id_token in a
 muster accepts the token because its `aud` carries `muster` — see
 [`trustedPeers` points the other way round](#trustedpeers-points-the-other-way-round).
 
+The MCP servers page groups servers into **Agent Platform**,
+**Infrastructure** and **Registered servers** by the tool-group label the
+shipping chart stamps on the CR (see [The fake fleet and the tool-group
+label](#the-fake-fleet-and-the-tool-group-label)); a family's members
+(`spec.family.name`) collapse into one row. The page reads the MCPServer CRs
+through Backstage's Kubernetes proxy with the user's own token, and
+`agentlab backstage-test` asserts the grouping from that same data with the
+plugin's arithmetic: the fake-fleet families under Infrastructure, the OAuth
+fixture under Registered servers, every chart-labelled server under the group
+its label names, and — with every label removed from the same data — one
+Registered servers list with all sections present, never an empty page.
+
 `agentlab backstage-test` drives the whole sign-in headlessly for every
 configured user and then proves the muster hop with that user's own token —
 including the per-server **Sign in** path (`/api/muster/auth/login`) against
@@ -906,10 +1007,15 @@ the lab's `Auth Required` fixture:
   backstage user  user:default/dev
   ownership refs  [user:default/dev]
   muster servers  [(agent-manager, Connected), (capi-lab-01, Auth Required), (capi-lab-02, Auth Required), (kubernetes-lab-01, Auth Required), (kubernetes-lab-02, Auth Required), (lab-oauth-fixture, Auth Required), (mcp-kubernetes, Connected), (mcp-prometheus, Connected), (model-manager, Connected), (prometheus-lab-01, Auth Required), (prometheus-lab-02, Auth Required)]
-  sign-in challenge lab-oauth-fixture -> https://muster.127.0.0.1.nip.io/oauth/proxy/start?state=… (client id via cimd)
+  sign-in challenge lab-oauth-fixture -> https://muster.127.0.0.1.nip.io/oauth/proxy/start?state=… (client id via preregistered)
   muster workflows [lab-cluster-overview]
   muster core tools 28 exposed
   agent deploy template registered (template:default/agent-deployment)
+  MCP servers page groups (11 CRs via /api/kubernetes/proxy):
+    Agent Platform      2 rows: agent-manager, model-manager
+    Infrastructure      4 rows: capi, kubernetes, prometheus, mcp-kubernetes
+    Registered servers  2 rows: lab-oauth-fixture, mcp-prometheus
+  fallback without any agent-platform.giantswarm.io/tool-group label: 8 rows, all under Registered servers; 9 of 11 CRs carry the label today
 ```
 
 ### The agent create flow

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -14,6 +14,10 @@ import (
 // deletes through agent-manager.
 const agentsTestAgent = "agentlab-agents-test"
 
+// agentsTestToolset is the toolset the proof declares: the read-only preset,
+// the smallest one that still gives the agent tools.
+const agentsTestToolset = "preset:read-only"
+
 // agentManagerServiceAccount is the ServiceAccount the umbrella's agent-manager
 // Deployment runs with (fullnameOverride: agent-manager).
 const agentManagerServiceAccount = "system:serviceaccount:" + platformNamespace + ":" + agentManagerMCPServer
@@ -116,7 +120,25 @@ func AgentsTest(cfg *config.Config, email string) error {
 		}
 	}
 
-	step("%screate_agent %s as %s", toolPrefix, agentsTestAgent, user.Email)
+	// Every agent declares a toolset (agent-manager ≥ 0.4.0 refuses a create
+	// without one, naming the shipped presets); agents-test is the platform
+	// path, so it declares the read-only preset and asserts the refusal.
+	createArgs := map[string]any{
+		nameKey: agentsTestAgent, "modelConfig": modelConfig, "displayName": "agentlab agents-test",
+		"description":   "Throwaway agent of `agentlab agents-test`; deleted by the same run.",
+		"systemMessage": "Reply with exactly the word pong and nothing else.",
+	}
+	step("%screate_agent %s without a toolset — expecting the refusal naming the presets", toolPrefix, agentsTestAgent)
+	if text, err := session.callServerTool(toolPrefix+"create_agent", createArgs); err == nil {
+		return fmt.Errorf("create_agent without a toolset was accepted (%.200s); agent-manager ≥ 0.4.0 requires one", text)
+	} else if !strings.Contains(err.Error(), "toolset") || !strings.Contains(err.Error(), "preset:none") {
+		return fmt.Errorf("the refusal does not name the toolset contract: %w", err)
+	} else {
+		note("refused: %s", excerpt(err.Error(), 200))
+	}
+
+	step("%screate_agent %s as %s with toolset [%s]", toolPrefix, agentsTestAgent, user.Email, agentsTestToolset)
+	createArgs["toolset"] = []string{agentsTestToolset}
 	var created struct {
 		RequestedBy string `json:"requestedBy"`
 		Created     struct {
@@ -124,11 +146,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 			OCIRepository bool `json:"ociRepository"`
 		} `json:"created"`
 	}
-	if err := session.callServerJSON(toolPrefix+"create_agent", map[string]any{
-		nameKey: agentsTestAgent, "modelConfig": modelConfig, "displayName": "agentlab agents-test",
-		"description":   "Throwaway agent of `agentlab agents-test`; deleted by the same run.",
-		"systemMessage": "Reply with exactly the word pong and nothing else.",
-	}, &created); err != nil {
+	if err := session.callServerJSON(toolPrefix+"create_agent", createArgs, &created); err != nil {
 		return err
 	}
 	if !created.Created.HelmRelease {
@@ -170,6 +188,17 @@ func AgentsTest(cfg *config.Config, email string) error {
 		return fmt.Errorf("%s never reached ready (last: %s — %s);\ncheck `kubectl -n %s get helmrelease,agents.kagent.dev,pods`", agentsTestAgent, status.Verdict, status.Summary, kagentNamespace)
 	}
 	note("ready: %s", excerpt(status.Summary, 120))
+	var got struct {
+		Toolset            []string `json:"toolset"`
+		ImplicitFullAccess bool     `json:"implicitFullAccess"`
+	}
+	if err := session.callServerJSON(toolPrefix+"get_agent", map[string]any{nameKey: agentsTestAgent}, &got); err != nil {
+		return err
+	}
+	if len(got.Toolset) != 1 || got.Toolset[0] != agentsTestToolset || got.ImplicitFullAccess {
+		return fmt.Errorf("get_agent reports toolset=%v implicitFullAccess=%v, wanted [%s]/false", got.Toolset, got.ImplicitFullAccess, agentsTestToolset)
+	}
+	note("get_agent reports toolset %v", got.Toolset)
 
 	step("%supdate_agent as %s", toolPrefix, user.Email)
 	var updated struct {
@@ -202,7 +231,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 		if err != nil {
 			return err
 		}
-		text, err := viewerSession.callServerTool(toolPrefix+"create_agent", map[string]any{nameKey: agentsTestAgent + "-viewer", "modelConfig": modelConfig})
+		text, err := viewerSession.callServerTool(toolPrefix+"create_agent", map[string]any{nameKey: agentsTestAgent + "-viewer", "modelConfig": modelConfig, "toolset": []string{agentsTestToolset}})
 		switch {
 		case err == nil:
 			return fmt.Errorf("%s created an agent through agent-manager although the view role cannot write HelmReleases — agent-manager is not acting as the caller (ServiceAccount fallback?): %.200s", viewer.Email, text)
@@ -260,7 +289,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 
 	fmt.Println()
 	fmt.Printf("PASS: muster aggregates %s* and agent-manager reports identity caller\n", toolPrefix)
-	fmt.Printf("PASS: %s created -> ready -> updated -> deleted %s through call_tool, every write requestedBy=%s and logged with caller=\n", user.Email, agentsTestAgent, user.Email)
+	fmt.Printf("PASS: create_agent without a toolset is refused naming the presets; with [%s] %s created -> ready -> updated -> deleted %s through call_tool, every write requestedBy=%s and logged with caller=\n", agentsTestToolset, user.Email, agentsTestAgent, user.Email)
 	if viewer != nil {
 		fmt.Printf("PASS: %s's create is Forbidden by the apiserver as User \"oidc:%s\" (user RBAC, not the ServiceAccount's)\n", viewer.Email, viewer.Email)
 	}

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -124,8 +124,8 @@ func AgentsTest(cfg *config.Config, email string) error {
 	// without one, naming the shipped presets); agents-test is the platform
 	// path, so it declares the read-only preset and asserts the refusal.
 	createArgs := map[string]any{
-		nameKey: agentsTestAgent, "modelConfig": modelConfig, "displayName": "agentlab agents-test",
-		"description":   "Throwaway agent of `agentlab agents-test`; deleted by the same run.",
+		nameKey: agentsTestAgent, modelConfigKey: modelConfig, "displayName": "agentlab agents-test",
+		descriptionKey:  "Throwaway agent of `agentlab agents-test`; deleted by the same run.",
 		"systemMessage": "Reply with exactly the word pong and nothing else.",
 	}
 	step("%screate_agent %s without a toolset — expecting the refusal naming the presets", toolPrefix, agentsTestAgent)
@@ -205,7 +205,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 		RequestedBy string   `json:"requestedBy"`
 		Changed     []string `json:"changed"`
 	}
-	if err := session.callServerJSON(toolPrefix+"update_agent", map[string]any{nameKey: agentsTestAgent, "description": "Updated by agentlab agents-test."}, &updated); err != nil {
+	if err := session.callServerJSON(toolPrefix+"update_agent", map[string]any{nameKey: agentsTestAgent, descriptionKey: "Updated by agentlab agents-test."}, &updated); err != nil {
 		return err
 	}
 	if updated.RequestedBy != user.Email || !slices.Contains(updated.Changed, "agent.description") {
@@ -231,7 +231,7 @@ func AgentsTest(cfg *config.Config, email string) error {
 		if err != nil {
 			return err
 		}
-		text, err := viewerSession.callServerTool(toolPrefix+"create_agent", map[string]any{nameKey: agentsTestAgent + "-viewer", "modelConfig": modelConfig, "toolset": []string{agentsTestToolset}})
+		text, err := viewerSession.callServerTool(toolPrefix+"create_agent", map[string]any{nameKey: agentsTestAgent + "-viewer", modelConfigKey: modelConfig, "toolset": []string{agentsTestToolset}})
 		switch {
 		case err == nil:
 			return fmt.Errorf("%s created an agent through agent-manager although the view role cannot write HelmReleases — agent-manager is not acting as the caller (ServiceAccount fallback?): %.200s", viewer.Email, text)

--- a/internal/lab/backstagetest.go
+++ b/internal/lab/backstagetest.go
@@ -93,11 +93,11 @@ func backstageSignIn(cfg *config.Config, user *config.User) error {
 			fixtureState = fmt.Sprintf("%v", m["state"])
 		}
 	}
-	if !isAuthRequiredState(fixtureState) {
-		return fmt.Errorf("MCPServer %s is %q, not Auth Required — the sign-in fixture is missing or broken (`agentlab platform` creates it)",
+	if !isAuthRequiredState(fixtureState) && !strings.EqualFold(fixtureState, "connected") {
+		return fmt.Errorf("MCPServer %s is %q, not Auth Required (or Connected for a signed-in session) — the sign-in fixture is missing or broken (`agentlab platform` creates it)",
 			oauthFixtureServer, fixtureState)
 	}
-	status, raw, err := musterPost("/auth/login"+installation, map[string]any{"server": oauthFixtureServer})
+	status, raw, err := musterPost("/auth/login"+installation, map[string]any{serverKey: oauthFixtureServer})
 	if err != nil {
 		return err
 	}

--- a/internal/lab/backstagetest.go
+++ b/internal/lab/backstagetest.go
@@ -3,13 +3,9 @@ package lab
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"net/http/cookiejar"
-	"net/url"
 	"regexp"
 	"strings"
-	"time"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -30,7 +26,7 @@ func BackstageTest(cfg *config.Config, emails []string) error {
 			emails = append(emails, u.Email)
 		}
 	}
-	for _, email := range emails {
+	for i, email := range emails {
 		user := cfg.FindUser(email)
 		if user == nil {
 			return fmt.Errorf("no user %q in %s", email, config.File)
@@ -39,6 +35,16 @@ func BackstageTest(cfg *config.Config, emails []string) error {
 		if err := backstageSignIn(cfg, user); err != nil {
 			return fmt.Errorf("%s: %w", email, err)
 		}
+		if i == 0 {
+			// The grouping does not depend on the viewer; once is enough.
+			ps, err := backstageLogin(cfg, user)
+			if err != nil {
+				return fmt.Errorf("%s: %w", email, err)
+			}
+			if err := proveServerGroups(ps); err != nil {
+				return fmt.Errorf("%s: %w", email, err)
+			}
+		}
 		fmt.Println()
 	}
 	fmt.Println("all sign-ins resolved and reached muster")
@@ -46,169 +52,19 @@ func BackstageTest(cfg *config.Config, emails []string) error {
 }
 
 func backstageSignIn(cfg *config.Config, user *config.User) error {
-	transport, err := labTLSTransport()
+	ps, err := backstageLogin(cfg, user)
 	if err != nil {
 		return err
 	}
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		return err
-	}
-	follow := &http.Client{Jar: jar, Transport: transport, Timeout: 60 * time.Second}
-	noFollow := &http.Client{Jar: jar, Transport: transport, Timeout: 60 * time.Second,
-		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+	fmt.Printf("  dex asserted    groups=%v email=%v\n", ps.claims["groups"], ps.claims["email"])
+	fmt.Printf("  token audience  %v\n", ps.claims["aud"])
+	fmt.Printf("  backstage user  %s\n", ps.identity.UserEntityRef)
+	fmt.Printf("  ownership refs  %v\n", ps.identity.OwnershipEntityRefs)
 
-	// 1. Backstage redirects to Dex and sets its own session cookie. The
-	//    provider name (oidc-agent-platform) and the auth.environment
-	//    (production) both come from the umbrella's app-config and must match,
-	//    or this 404s. The scope list is passed explicitly because only the
-	//    BROWSER app applies plugins/gs/src/apis/auth/scopes.ts (BASE_SCOPES +
-	//    gs.auth.extraScopes); hitting /start directly would otherwise get a
-	//    bare token with no groups and aud=["agent-platform"] alone.
-	scope := "openid profile email groups offline_access" +
-		" audience:server:client_id:" + config.KubernetesClientID +
-		" audience:server:client_id:dex-k8s-authenticator"
-	startURL := cfg.BackstageBaseURL() + "/api/auth/oidc-agent-platform/start?env=production&scope=" +
-		url.QueryEscape(scope)
-	resp, err := noFollow.Get(startURL)
-	if err != nil {
-		return err
-	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
-	dexURL := resp.Header.Get("Location")
-	if dexURL == "" {
-		return fmt.Errorf("no redirect to Dex (status %d)", resp.StatusCode)
-	}
+	muster := ps.musterGet
+	musterPost := ps.musterPost
 
-	// 2. Follow to Dex's login form.
-	resp, err = follow.Get(dexURL)
-	if err != nil {
-		return err
-	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
-	loginURL := resp.Request.URL.String()
-
-	// 3. Submit lab credentials; Dex redirects back through the Backstage
-	//    handler, whose response embeds the authorization result.
-	form := url.Values{"login": {user.Email}, passwordParam: {user.Password}}
-	resp, err = follow.PostForm(loginURL, form)
-	if err != nil {
-		return err
-	}
-	body, _ := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-
-	// 4. The handler page hands the result to the opener via postMessage;
-	//    headlessly, the payload is regex'd out of the inline script. There is
-	//    no API that returns this payload cleanly — inherent to the test's job.
-	m := handlerPayloadRe.FindSubmatch(body)
-	if m == nil {
-		return fmt.Errorf("could not parse the handler response")
-	}
-	// PathUnescape, not QueryUnescape: '+' inside the JSON payload (JWTs,
-	// base64) must survive, matching Python's urllib.parse.unquote.
-	decoded, err := url.PathUnescape(string(m[1]))
-	if err != nil {
-		return err
-	}
-	var probe struct {
-		Type     string         `json:"type"`
-		Response map[string]any `json:"response"`
-	}
-	if err := json.Unmarshal([]byte(decoded), &probe); err != nil {
-		return fmt.Errorf("parsing authorization response: %w", err)
-	}
-	if probe.Type != "authorization_response" {
-		return fmt.Errorf("unexpected response type %q", probe.Type)
-	}
-	if errVal, ok := probe.Response["error"]; ok {
-		raw, _ := json.Marshal(errVal)
-		return fmt.Errorf("SIGN-IN FAILED: %.400s", string(raw))
-	}
-	var auth struct {
-		Response struct {
-			ProviderInfo struct {
-				IDToken string `json:"idToken"`
-			} `json:"providerInfo"`
-			BackstageIdentity struct {
-				Token    string `json:"token"`
-				Identity struct {
-					UserEntityRef       string   `json:"userEntityRef"`
-					OwnershipEntityRefs []string `json:"ownershipEntityRefs"`
-				} `json:"identity"`
-			} `json:"backstageIdentity"`
-		} `json:"response"`
-	}
-	if err := json.Unmarshal([]byte(decoded), &auth); err != nil {
-		return err
-	}
-	dexIDToken := auth.Response.ProviderInfo.IDToken
-	bsToken := auth.Response.BackstageIdentity.Token
-	identity := auth.Response.BackstageIdentity.Identity
-
-	claims, err := decodeJWTClaims(dexIDToken)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("  dex asserted    groups=%v email=%v\n", claims["groups"], claims["email"])
-	fmt.Printf("  token audience  %v\n", claims["aud"])
-	fmt.Printf("  backstage user  %s\n", identity.UserEntityRef)
-	fmt.Printf("  ownership refs  %v\n", identity.OwnershipEntityRefs)
-
-	// The muster plugin forwards the Dex id_token in its own header; the
-	// backend promotes it to Authorization: Bearer on the MCP session to
-	// muster.
-	muster := func(path string) (int, any, error) {
-		req, err := http.NewRequest(http.MethodGet, cfg.BackstageBaseURL()+"/api/muster"+path, nil)
-		if err != nil {
-			return 0, nil, err
-		}
-		req.Header.Set("Authorization", "Bearer "+bsToken)
-		req.Header.Set("backstage-muster-authorization", dexIDToken)
-		resp, err := follow.Do(req)
-		if err != nil {
-			return 0, nil, err
-		}
-		defer func() { _ = resp.Body.Close() }()
-		raw, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode != http.StatusOK {
-			return resp.StatusCode, strings.TrimSpace(string(raw)), nil
-		}
-		var payload any
-		if err := json.Unmarshal(raw, &payload); err != nil {
-			return resp.StatusCode, strings.TrimSpace(string(raw)), nil
-		}
-		return resp.StatusCode, payload, nil
-	}
-
-	// musterPost is the mutation shape of the same hop: a JSON body, the raw
-	// answer back (the routes normalise muster's tool results themselves).
-	musterPost := func(path string, body any) (int, []byte, error) {
-		payload, err := json.Marshal(body)
-		if err != nil {
-			return 0, nil, err
-		}
-		req, err := http.NewRequest(http.MethodPost, cfg.BackstageBaseURL()+"/api/muster"+path, strings.NewReader(string(payload)))
-		if err != nil {
-			return 0, nil, err
-		}
-		req.Header.Set("Authorization", "Bearer "+bsToken)
-		req.Header.Set("backstage-muster-authorization", dexIDToken)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := follow.Do(req)
-		if err != nil {
-			return 0, nil, err
-		}
-		defer func() { _ = resp.Body.Close() }()
-		raw, _ := io.ReadAll(resp.Body)
-		return resp.StatusCode, raw, nil
-	}
-
-	// The umbrella's app-config names the muster installation after the Helm
-	// release, not the kind cluster.
-	installation := "?installation=" + platformRelease
+	installation := installationQuery
 
 	status, payload, err := muster("/servers" + installation)
 	if err != nil {
@@ -303,22 +159,56 @@ func backstageSignIn(cfg *config.Config, user *config.User) error {
 	// template:default/agent-deployment; without the catalog entity every
 	// deploy dies with a scaffolder 404. Assert the lab registered it (the
 	// embedded copy in backstage.yaml.tmpl).
-	req, err := http.NewRequest(http.MethodGet,
-		cfg.BackstageBaseURL()+"/api/catalog/entities/by-name/template/default/agent-deployment", nil)
+	status, _, err = ps.backstageGet("/api/catalog/entities/by-name/template/default/agent-deployment")
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+bsToken)
-	resp, err = follow.Do(req)
-	if err != nil {
-		return err
-	}
-	_, _ = io.Copy(io.Discard, resp.Body)
-	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("agent-deployment template not in the catalog (%d) — the create flow's deploy would 404", resp.StatusCode)
+	if status != http.StatusOK {
+		return fmt.Errorf("agent-deployment template not in the catalog (%d) — the create flow's deploy would 404", status)
 	}
 	fmt.Printf("  agent deploy template registered (template:default/agent-deployment)\n")
+	return nil
+}
+
+// proveServerGroups is the MCP servers page's grouping, asserted from the
+// data the page reads: the MCPServer CRs through Backstage's Kubernetes proxy
+// as this user, partitioned by the tool-group label with the released
+// plugin's arithmetic (servergroups.go). The lab's fixtures pin the three
+// groups — the fake-fleet families under Infrastructure, the OAuth fixture
+// under Registered servers — and the chart-shipped servers are judged by the
+// label their chart stamps (agent-manager and model-manager under Agent
+// Platform once their charts carry it, the bundled mcp-kubernetes under
+// Infrastructure). The fallback is proven on the same data with every
+// tool-group label removed: one Registered servers list, every section still
+// present, never an empty page.
+func proveServerGroups(ps *portalSession) error {
+	servers, err := ps.listMCPServerCRs()
+	if err != nil {
+		return err
+	}
+	if len(servers) == 0 {
+		return fmt.Errorf("the Kubernetes proxy lists no MCPServer CRs for %s — the servers page would be empty", ps.user.Email)
+	}
+	groups := partitionServers(servers)
+	fmt.Printf("  MCP servers page groups (%d CRs via /api/kubernetes/proxy):\n%s\n", len(servers), describeGroups(groups))
+	if err := assertServerGroups(servers, groups); err != nil {
+		return fmt.Errorf("servers page grouping: %w", err)
+	}
+	labelled := 0
+	for _, s := range servers {
+		if s.toolGroup() != "" {
+			labelled++
+		}
+	}
+	fallback := partitionServers(stripToolGroupLabels(servers))
+	if n := len(fallback[groupAgentPlatform]) + len(fallback[groupInfrastructure]); n != 0 {
+		return fmt.Errorf("without labels %d rows still land outside Registered servers", n)
+	}
+	if len(fallback[groupRegistered]) == 0 || len(fallback) != len(toolGroupOrder) {
+		return fmt.Errorf("without labels the page would be empty (%d Registered rows, %d sections)", len(fallback[groupRegistered]), len(fallback))
+	}
+	fmt.Printf("  fallback without any %s label: %d rows, all under %s; %d of %d CRs carry the label today\n",
+		toolGroupLabel, len(fallback[groupRegistered]), toolGroupTitles[groupRegistered], labelled, len(servers))
 	return nil
 }
 

--- a/internal/lab/mcpsession.go
+++ b/internal/lab/mcpsession.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -22,6 +23,25 @@ type musterSession struct {
 	token  string
 	id     string
 	seq    int
+	// headers are sent on every request of the session on top of the MCP
+	// ones — the way an agent's kagent runtime sends the X-Muster-Toolset
+	// header its Agent CR declares (headersFrom). Set per request through
+	// setHeader; muster reads the header on each request, never binds it to
+	// the session.
+	headers map[string]string
+}
+
+// setHeader adds (or, with an empty value, removes) a header the session
+// sends on every following request.
+func (s *musterSession) setHeader(name, value string) {
+	if s.headers == nil {
+		s.headers = map[string]string{}
+	}
+	if value == "" {
+		delete(s.headers, name)
+		return
+	}
+	s.headers[name] = value
 }
 
 // openMusterSession initializes an MCP session and returns it ready for
@@ -60,6 +80,9 @@ func (s *musterSession) post(sessionID, payload string) (*http.Response, error) 
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	if sessionID != "" {
 		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	for name, value := range s.headers {
+		req.Header.Set(name, value)
 	}
 	return s.client.Do(req)
 }
@@ -159,4 +182,141 @@ func (s *musterSession) callServerTool(name string, args map[string]any) (string
 		return "", fmt.Errorf("%s failed: %.300s", name, env.Content[0].Text)
 	}
 	return env.Content[0].Text, nil
+}
+
+// toolAnnotations are the MCP tool annotations muster forwards from the
+// serving MCPServer (or derives, for a workflow whose step tools are all
+// read-only). Pointers: an absent hint is not a false one.
+type toolAnnotations struct {
+	ReadOnlyHint    *bool `json:"readOnlyHint,omitempty"`
+	DestructiveHint *bool `json:"destructiveHint,omitempty"`
+	IdempotentHint  *bool `json:"idempotentHint,omitempty"`
+	OpenWorldHint   *bool `json:"openWorldHint,omitempty"`
+}
+
+// readOnly reports whether the tool is annotated read-only.
+func (a *toolAnnotations) readOnly() bool {
+	return a != nil && a.ReadOnlyHint != nil && *a.ReadOnlyHint
+}
+
+// toolInfo is one entry of list_tools / filter_tools (muster's ToolInfo):
+// the exposed name, the owning server (empty for core tools and workflows),
+// the kind (tool | workflow | core) and the annotations, when any.
+type toolInfo struct {
+	Name        string           `json:"name"`
+	Server      string           `json:"server,omitempty"`
+	Kind        string           `json:"kind,omitempty"`
+	Annotations *toolAnnotations `json:"annotations,omitempty"`
+}
+
+// presetInfo is one entry of filter_tools' presets list.
+type presetInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	BuiltIn     bool   `json:"built_in"`
+}
+
+// filterToolsResponse is muster's FilterToolsResponse as the toolset feature
+// extended it: the tools resolved for the caller, the selectors echoed back,
+// the selectors that matched nothing for this caller, the presets when asked
+// for, and the size of the catalogue the filter ran over (within the
+// toolset, when one applies).
+type filterToolsResponse struct {
+	Tools            []toolInfo   `json:"tools"`
+	Toolset          []string     `json:"toolset"`
+	ToolsetUnmatched []string     `json:"toolset_unmatched"`
+	Presets          []presetInfo `json:"presets"`
+	TotalTools       int          `json:"total_tools"`
+	FilteredCount    int          `json:"filtered_count"`
+	Truncated        bool         `json:"truncated"`
+}
+
+// names returns the tool names, sorted.
+func (r *filterToolsResponse) names() []string {
+	out := make([]string, 0, len(r.Tools))
+	for _, t := range r.Tools {
+		out = append(out, t.Name)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// filterTools runs muster's filter_tools meta-tool with the given arguments
+// (plus a limit high enough to never truncate — the default is 5) and
+// decodes the response. A toolset error (unknown preset, reserved selector,
+// empty header) is an error result and comes back as err.
+func (s *musterSession) filterTools(args map[string]any) (*filterToolsResponse, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	if _, ok := args["limit"]; !ok {
+		args["limit"] = 1000
+	}
+	res, err := s.callTool("filter_tools", args)
+	if err != nil {
+		return nil, err
+	}
+	result, _ := res["result"].(map[string]any)
+	if isErr, _ := result["isError"].(bool); isErr {
+		return nil, fmt.Errorf("filter_tools: %s", strings.TrimSpace(innerText(res)))
+	}
+	var out filterToolsResponse
+	if err := json.Unmarshal([]byte(innerText(res)), &out); err != nil {
+		return nil, fmt.Errorf("parsing filter_tools payload: %w\n%.300s", err, innerText(res))
+	}
+	return &out, nil
+}
+
+// describeToolResponse is the part of muster's DescribeToolResponse the
+// proofs read: the name, the owning server, the kind and the annotations.
+type describeToolResponse struct {
+	Name        string           `json:"name"`
+	Server      string           `json:"server,omitempty"`
+	Kind        string           `json:"kind,omitempty"`
+	Annotations *toolAnnotations `json:"annotations,omitempty"`
+}
+
+// describeTool runs muster's describe_tool meta-tool. A tool outside the
+// request's toolset is an error result and comes back as err.
+func (s *musterSession) describeTool(name string) (*describeToolResponse, error) {
+	res, err := s.callTool("describe_tool", map[string]any{"name": name})
+	if err != nil {
+		return nil, err
+	}
+	result, _ := res["result"].(map[string]any)
+	if isErr, _ := result["isError"].(bool); isErr {
+		return nil, fmt.Errorf("describe_tool %s: %s", name, strings.TrimSpace(innerText(res)))
+	}
+	var out describeToolResponse
+	if err := json.Unmarshal([]byte(innerText(res)), &out); err != nil {
+		return nil, fmt.Errorf("parsing describe_tool payload: %w\n%.300s", err, innerText(res))
+	}
+	return &out, nil
+}
+
+// listToolInfos is listTools with the full entries (server, kind,
+// annotations) and the servers muster reports as requiring a sign-in.
+func (s *musterSession) listToolInfos() ([]toolInfo, []string, error) {
+	res, err := s.callTool("list_tools", nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	result, _ := res["result"].(map[string]any)
+	if isErr, _ := result["isError"].(bool); isErr {
+		return nil, nil, fmt.Errorf("list_tools: %s", strings.TrimSpace(innerText(res)))
+	}
+	var listing struct {
+		Tools                []toolInfo `json:"tools"`
+		ServersRequiringAuth []struct {
+			Name string `json:"name"`
+		} `json:"servers_requiring_auth"`
+	}
+	if err := json.Unmarshal([]byte(innerText(res)), &listing); err != nil {
+		return nil, nil, fmt.Errorf("parsing list_tools payload: %w", err)
+	}
+	var requiring []string
+	for _, srv := range listing.ServersRequiringAuth {
+		requiring = append(requiring, srv.Name)
+	}
+	return listing.Tools, requiring, nil
 }

--- a/internal/lab/mcpsession.go
+++ b/internal/lab/mcpsession.go
@@ -12,6 +12,30 @@ import (
 	"github.com/giantswarm/agentlab/internal/config"
 )
 
+// JSON keys the proofs pass to and read from the platform's tools, named once
+// so the same word is not spelled in a dozen places (nameKey lives in
+// kubeconfig.go).
+const (
+	modelConfigKey  = "modelConfig"
+	descriptionKey  = "description"
+	serverKey       = "server"
+	resourceTypeKey = "resourceType"
+	argsKey         = "args"
+	// presetFullName is the built-in preset that resolves to the whole
+	// catalogue; presetFull (toolsetstest.go) is its selector.
+	presetFullName     = "full"
+	presetNoneName     = "none"
+	presetReadOnlyName = "read-only"
+	// toolKey names a tool: a workflow step's, a ToolInfo kind.
+	toolKey = "tool"
+	// resourceNamespaces is the mcp-kubernetes resourceType the proofs list:
+	// every user may, and the answer names the platform namespace.
+	resourceNamespaces = "namespaces"
+	// taskStateFailed is the terminal failure state of a model-manager job
+	// and of a scaffolder task alike.
+	taskStateFailed = "failed"
+)
+
 // musterSession is one MCP Streamable-HTTP session against the lab muster
 // through the edge, authenticated with a Dex id_token as Bearer (muster lists
 // the agent-platform client under trustedAudiences). The same path Claude
@@ -95,7 +119,7 @@ func (s *musterSession) callTool(name string, args map[string]any) (map[string]a
 	s.seq++
 	payload, err := json.Marshal(map[string]any{
 		"jsonrpc": "2.0", "id": s.seq, "method": "tools/call",
-		"params": map[string]any{"name": name, "arguments": args},
+		"params": map[string]any{nameKey: name, "arguments": args},
 	})
 	if err != nil {
 		return nil, err
@@ -157,13 +181,24 @@ func (s *musterSession) callToolEnvelope(name string, args map[string]any) (*too
 	if args == nil {
 		args = map[string]any{}
 	}
-	res, err := s.callTool("call_tool", map[string]any{"name": name, "arguments": args})
+	res, err := s.callTool("call_tool", map[string]any{nameKey: name, "arguments": args})
 	if err != nil {
 		return nil, err
 	}
 	var env toolEnvelope
 	inner := innerText(res)
 	if err := json.Unmarshal([]byte(inner), &env); err != nil || len(env.Content) == 0 {
+		// A refusal by muster itself — a tool outside the request's toolset,
+		// an unknown tool — is call_tool's own error result: plain text, no
+		// inner envelope. Hand it back as one so callers judge isError alike.
+		result, _ := res["result"].(map[string]any)
+		if isErr, _ := result["isError"].(bool); isErr && strings.TrimSpace(inner) != "" {
+			env = toolEnvelope{IsError: true}
+			env.Content = append(env.Content, struct {
+				Text string `json:"text"`
+			}{Text: inner})
+			return &env, nil
+		}
 		return nil, fmt.Errorf("unexpected call_tool payload shape for %s: %.300s", name, inner)
 	}
 	return &env, nil
@@ -279,7 +314,7 @@ type describeToolResponse struct {
 // describeTool runs muster's describe_tool meta-tool. A tool outside the
 // request's toolset is an error result and comes back as err.
 func (s *musterSession) describeTool(name string) (*describeToolResponse, error) {
-	res, err := s.callTool("describe_tool", map[string]any{"name": name})
+	res, err := s.callTool("describe_tool", map[string]any{nameKey: name})
 	if err != nil {
 		return nil, err
 	}
@@ -292,31 +327,4 @@ func (s *musterSession) describeTool(name string) (*describeToolResponse, error)
 		return nil, fmt.Errorf("parsing describe_tool payload: %w\n%.300s", err, innerText(res))
 	}
 	return &out, nil
-}
-
-// listToolInfos is listTools with the full entries (server, kind,
-// annotations) and the servers muster reports as requiring a sign-in.
-func (s *musterSession) listToolInfos() ([]toolInfo, []string, error) {
-	res, err := s.callTool("list_tools", nil)
-	if err != nil {
-		return nil, nil, err
-	}
-	result, _ := res["result"].(map[string]any)
-	if isErr, _ := result["isError"].(bool); isErr {
-		return nil, nil, fmt.Errorf("list_tools: %s", strings.TrimSpace(innerText(res)))
-	}
-	var listing struct {
-		Tools                []toolInfo `json:"tools"`
-		ServersRequiringAuth []struct {
-			Name string `json:"name"`
-		} `json:"servers_requiring_auth"`
-	}
-	if err := json.Unmarshal([]byte(innerText(res)), &listing); err != nil {
-		return nil, nil, fmt.Errorf("parsing list_tools payload: %w", err)
-	}
-	var requiring []string
-	for _, srv := range listing.ServersRequiringAuth {
-		requiring = append(requiring, srv.Name)
-	}
-	return listing.Tools, requiring, nil
 }

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -510,7 +510,7 @@ spec:
 	var reply string
 	var lastErr error
 	answered := waitFor(6, 5*time.Second, func() bool {
-		reply, lastErr = a2aSend(client, a2aURL, payload, prompt)
+		reply, lastErr = a2aSend(client, a2aURL, "", payload, prompt)
 		return lastErr == nil
 	})
 	if !answered {
@@ -521,13 +521,18 @@ spec:
 
 // a2aSend posts one JSON-RPC message/send and returns the agent's text: the
 // last text part that is not the prompt, wherever the Task/Message shape put
-// it (status.message, artifacts, history).
-func a2aSend(client *http.Client, url, payload, prompt string) (string, error) {
+// it (status.message, artifacts, history). A non-empty token goes out as
+// Authorization: Bearer — the user's Dex id_token the portal forwards to
+// kagent, which the agent's runtime propagates to muster (KAGENT_PROPAGATE_TOKEN).
+func a2aSend(client *http.Client, url, token, payload, prompt string) (string, error) {
 	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(payload))
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/internal/lab/oauthfixture.go
+++ b/internal/lab/oauthfixture.go
@@ -282,3 +282,21 @@ func completeSignIn(challengeURL string, user *config.User) error {
 	}
 	return nil
 }
+
+// restartOAuthFixture asks muster for a one-shot restart of the fixture's
+// service (spec.restartRequestedAt, acted on once per value), which closes
+// every pooled connection and returns the CR to Auth Required. Best effort:
+// the lab's state is not the proof's verdict.
+func restartOAuthFixture() {
+	stamp := time.Now().UTC().Format(time.RFC3339)
+	if err := runQuiet("kubectl", "-n", platformNamespace, "patch", "mcpservers.muster.giantswarm.io", oauthFixtureServer,
+		"--type", "merge", "-p", fmt.Sprintf(`{"spec":{"restartRequestedAt":%q}}`, stamp)); err != nil {
+		note("could not request a restart of %s (%v); it reads Connected until the signed-in session's token expires", oauthFixtureServer, err)
+		return
+	}
+	if err := waitMCPServerState(oauthFixtureServer, mcpServerStateAuthRequired); err != nil {
+		note("%s did not return to Auth Required after the restart request: %v", oauthFixtureServer, err)
+		return
+	}
+	note("%s back to Auth Required", oauthFixtureServer)
+}

--- a/internal/lab/oauthfixture.go
+++ b/internal/lab/oauthfixture.go
@@ -77,8 +77,15 @@ func ensureOAuthFixture(cfg *config.Config) error {
 	if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
 		return err
 	}
-	return waitMCPServerState(oauthFixtureServer, mcpServerStateAuthRequired)
+	return waitMCPServerState(oauthFixtureServer, oauthFixtureHealthyStates...)
 }
+
+// oauthFixtureHealthyStates are the CR states of a reachable fixture: Auth
+// Required while no session is signed in, Connected while one is — a
+// completed sign-in (toolsets-test, the portal's Sign in) connects muster to
+// the endpoint for that session, and the connection outlives the session's
+// sign-out until its next use. Failed is the state that means trouble.
+var oauthFixtureHealthyStates = []string{mcpServerStateAuthRequired, "Connected"}
 
 // isAuthRequiredState accepts both spellings of muster's auth-required state:
 // the CRD's "Auth Required" and the service-state token "auth_required".
@@ -102,7 +109,7 @@ func signInChallenge(cfg *config.Config, s *musterSession) (*authChallenge, erro
 	// core_auth_login is a core tool: reachable only through muster's
 	// call_tool meta-tool, whose envelope carries the challenge's
 	// structuredContent — the same envelope the portal's backend unwraps.
-	env, err := s.callToolEnvelope("core_auth_login", map[string]any{"server": oauthFixtureServer})
+	env, err := s.callToolEnvelope("core_auth_login", map[string]any{serverKey: oauthFixtureServer})
 	if err != nil {
 		return nil, err
 	}
@@ -142,8 +149,10 @@ func proveOAuthSignIn(cfg *config.Config, token string) error {
 	step("Per-server OAuth sign-in: core_auth_login for the %s fixture", oauthFixtureServer)
 	// The challenge itself does not depend on the CR state, but right after a
 	// muster restart the CR reads Failed until muster's retry finds its own
-	// listener — and a Failed fixture is what the portal would show.
-	if err := waitMCPServerState(oauthFixtureServer, mcpServerStateAuthRequired); err != nil {
+	// listener — and a Failed fixture is what the portal would show. Connected
+	// (another session signed in) is as healthy as Auth Required: sign-ins
+	// are per session, and this session has none.
+	if err := waitMCPServerState(oauthFixtureServer, oauthFixtureHealthyStates...); err != nil {
 		return err
 	}
 	s, err := openMusterSession(cfg, token, "platform-test-oauth")

--- a/internal/lab/oauthfixture.go
+++ b/internal/lab/oauthfixture.go
@@ -224,11 +224,21 @@ func proveOAuthSignIn(cfg *config.Config, token string) error {
 	if err != nil {
 		return fmt.Errorf("proxy start redirect %q: %w", location, err)
 	}
-	if !strings.HasPrefix(location, cfg.Issuer()+"/auth") {
-		return fmt.Errorf("the proxy start endpoint redirected to %s, not to the pinned authorization server's endpoint (%s/auth…)", location, cfg.Issuer())
+	// The fixture applied by this binary pins Dex (the browser lands on Dex's
+	// authorization endpoint); one applied by an older `agentlab platform`
+	// discovers muster's own authorization server instead. Both are the
+	// authorization server's endpoint; the pinned one is the one a sign-in
+	// can complete against (oauth-fixture.yaml.tmpl).
+	switch {
+	case strings.HasPrefix(location, cfg.Issuer()+"/auth"):
+		note("proxy start redirects to %s://%s%s (the pinned authorization server, client %s)",
+			target.Scheme, target.Host, target.Path, target.Query().Get("client_id"))
+	case strings.Contains(target.Path, "authorize"):
+		note("proxy start redirects to %s://%s%s (the discovered authorization server — the fixture is not pinned to Dex: re-run `agentlab platform` with this binary for a sign-in that completes)",
+			target.Scheme, target.Host, target.Path)
+	default:
+		return fmt.Errorf("the proxy start endpoint redirected to %s, not to an authorization endpoint", location)
 	}
-	note("proxy start redirects to %s://%s%s (the pinned authorization server, client %s)",
-		target.Scheme, target.Host, target.Path, target.Query().Get("client_id"))
 	return nil
 }
 

--- a/internal/lab/oauthfixture.go
+++ b/internal/lab/oauthfixture.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"strings"
 	"time"
@@ -19,13 +20,27 @@ import (
 // (auth.forwardToken), so nothing exercises muster's OAuth *client* role: the
 // proxy behind core_auth_login and the portal's per-server "Sign in" button,
 // which hands the user a challenge URL, walks the browser through the
-// downstream's own authorization server and keeps the token per session. The lab turns that role on (muster.muster.oauth.mcpClient in
+// downstream's authorization server and keeps the token per session. The lab
+// turns that role on (muster.muster.oauth.mcpClient in
 // agent-platform-values.yaml.tmpl — the umbrella leaves it off, real
 // installations turn it on) and ships one downstream that declares auth.type
-// oauth and stays Auth Required, so the path can be driven and proven
-// headlessly. Why the fixture targets muster's own protected endpoint is
-// explained in templates/oauth-fixture.yaml.tmpl.
-
+// oauth and reads Auth Required until a session signs in, so the path can be
+// driven and proven headlessly — challenge AND completed sign-in.
+//
+// The downstream is muster's own protected /mcp (a 401 with RFC 9728 metadata
+// at zero cost); the authorization server is PINNED to the lab Dex with the
+// platform client (spec.auth.authorizationServer, the GitHub-App shape), not
+// discovered. Discovery would name muster's own authorization server, which
+// identifies clients by Client ID Metadata Document, and its SSRF guards
+// refuse every lab hostname — the metadata URL and a registered redirect URI
+// alike resolve to the edge's cluster IP in-cluster and to loopback outside —
+// so no sign-in could ever complete there. Dex matches redirect URIs exactly
+// (dex.yaml.tmpl lists muster's proxy callback on the client), and the token
+// it issues carries the platform client's audience, which the endpoint
+// trusts: signing in connects muster to itself and surfaces its own tools
+// under x_lab-oauth-fixture_ for that session. Harmless, per session, and
+// exactly what the toolset proof needs (toolsetstest.go: a toolset naming
+// the server resolves to its tools only for the session that signed in).
 const (
 	// oauthFixtureServer is the fixture MCPServer's name — what the proofs
 	// sign in to and what the portal lists.
@@ -37,6 +52,10 @@ const (
 	// every sign-in challenge points the browser at (muster's
 	// DefaultOAuthProxyStartPath; the chart renders no override).
 	oauthProxyStartPath = "/oauth/proxy/start"
+	// oauthProxyCallbackPath is where the authorization server sends the
+	// browser back (the chart's callbackPath default); registered on the
+	// platform client in dex.yaml.tmpl.
+	oauthProxyCallbackPath = "/oauth/proxy/callback"
 	// mcpServerStateAuthRequired is the CRD status.state of a reachable remote
 	// server that answered 401 — muster's api.StateAuthRequired, spelled the
 	// CRD way.
@@ -172,7 +191,9 @@ func proveOAuthSignIn(cfg *config.Config, token string) error {
 	}
 	note("a second core_auth_login answers a fresh state")
 
-	// Redeem the URL the way the browser would, minus following the redirect.
+	// Redeem the URL the way the browser would, minus following the redirect:
+	// the proxy start endpoint sends the browser to the pinned authorization
+	// server's authorization endpoint — the lab Dex.
 	transport, err := labTLSTransport()
 	if err != nil {
 		return err
@@ -194,9 +215,51 @@ func proveOAuthSignIn(cfg *config.Config, token string) error {
 	if err != nil {
 		return fmt.Errorf("proxy start redirect %q: %w", location, err)
 	}
-	if !strings.Contains(target.Path, "authorize") {
-		return fmt.Errorf("the proxy start endpoint redirected to %s, not to an authorization endpoint", location)
+	if !strings.HasPrefix(location, cfg.Issuer()+"/auth") {
+		return fmt.Errorf("the proxy start endpoint redirected to %s, not to the pinned authorization server's endpoint (%s/auth…)", location, cfg.Issuer())
 	}
-	note("proxy start redirects to %s://%s%s (the authorization server)", target.Scheme, target.Host, target.Path)
+	note("proxy start redirects to %s://%s%s (the pinned authorization server, client %s)",
+		target.Scheme, target.Host, target.Path, target.Query().Get("client_id"))
+	return nil
+}
+
+// completeSignIn finishes a per-server sign-in the way the browser does after
+// the portal (or core_auth_login) handed it the challenge URL: follow the
+// proxy start endpoint to the authorization server's login form, submit the
+// user's credentials, and follow Dex back through muster's proxy callback to
+// its "Authentication Successful" page. The session that produced the
+// challenge — identified by the state — then holds the server's token.
+func completeSignIn(challengeURL string, user *config.User) error {
+	transport, err := labTLSTransport()
+	if err != nil {
+		return err
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return err
+	}
+	browser := &http.Client{Jar: jar, Transport: transport, Timeout: 60 * time.Second}
+	resp, err := browser.Get(challengeURL)
+	if err != nil {
+		return err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	landed := resp.Request.URL.String()
+	if resp.StatusCode != http.StatusOK || !strings.Contains(landed, "/auth/local") {
+		return fmt.Errorf("the sign-in did not reach Dex's login form (landed on %s with %d):\n%.300s",
+			landed, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	resp, err = browser.PostForm(landed, url.Values{"login": {user.Email}, passwordParam: {user.Password}})
+	if err != nil {
+		return err
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	final := resp.Request.URL.String()
+	if resp.StatusCode != http.StatusOK || !strings.Contains(final, oauthProxyCallbackPath) || !strings.Contains(string(body), "Authentication Successful") {
+		return fmt.Errorf("the sign-in did not end on muster's proxy callback success page (ended on %s with %d):\n%.300s",
+			final, resp.StatusCode, excerpt(string(body), 300))
+	}
 	return nil
 }

--- a/internal/lab/oidc.go
+++ b/internal/lab/oidc.go
@@ -116,6 +116,12 @@ func labHTTPClient(timeout time.Duration) (*http.Client, error) {
 // OAuth presents a token the apiserver answers with 401.
 const musterLoginScopes = "openid email groups profile audience:server:client_id:" + config.KubernetesClientID
 
+// musterWriterScopes adds the audience muster's own Kubernetes writes (a
+// workflow created through core_workflow_create, as the caller) require —
+// the one Backstage's sign-in requests too (components.backstage.extraScopes)
+// and the dex-k8s-authenticator client trusts agent-platform to ask for.
+const musterWriterScopes = musterLoginScopes + " audience:server:client_id:dex-k8s-authenticator"
+
 func dexToken(cfg *config.Config, clientID, clientSecret string, form url.Values) (string, error) {
 	client, err := labHTTPClient(30 * time.Second)
 	if err != nil {
@@ -170,6 +176,12 @@ func passwordGrant(cfg *config.Config, clientID, clientSecret, email, password, 
 		return "", fmt.Errorf("dex login failed for %s: %w", email, err)
 	}
 	return token, nil
+}
+
+// base64URLDecode decodes base64url with or without padding.
+func base64URLDecode(s string) ([]byte, error) {
+	s = strings.TrimRight(s, "=")
+	return base64.RawURLEncoding.DecodeString(s)
 }
 
 // decodeJWTClaims returns the (unverified) payload of a JWT as a JSON object.

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -355,20 +355,36 @@ func innerText(rpc map[string]any) string {
 }
 
 // parseMCPResponse handles both plain-JSON and SSE-framed (`data: {...}`)
-// MCP responses.
+// MCP responses. A streamed answer can carry notifications (progress,
+// logging) ahead of the response to the request; the frame with a `result`
+// or `error` is the answer, the last frame the fallback.
 func parseMCPResponse(raw []byte) (map[string]any, error) {
 	trimmed := bytes.TrimSpace(raw)
 	var out map[string]any
 	if json.Unmarshal(trimmed, &out) == nil {
 		return out, nil
 	}
+	var last map[string]any
 	for line := range strings.SplitSeq(string(trimmed), "\n") {
 		line = strings.TrimSpace(line)
-		if data, ok := strings.CutPrefix(line, "data:"); ok {
-			if json.Unmarshal([]byte(strings.TrimSpace(data)), &out) == nil {
-				return out, nil
-			}
+		data, ok := strings.CutPrefix(line, "data:")
+		if !ok {
+			continue
 		}
+		var frame map[string]any
+		if json.Unmarshal([]byte(strings.TrimSpace(data)), &frame) != nil {
+			continue
+		}
+		if _, isResult := frame["result"]; isResult {
+			return frame, nil
+		}
+		if _, isError := frame["error"]; isError {
+			return frame, nil
+		}
+		last = frame
+	}
+	if last != nil {
+		return last, nil
 	}
 	return nil, fmt.Errorf("neither JSON nor SSE data frame")
 }

--- a/internal/lab/portal.go
+++ b/internal/lab/portal.go
@@ -1,0 +1,274 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// portalSession is one user's signed-in Backstage session, driven headlessly
+// (backstageLogin): the Backstage identity token and the Dex id_token the
+// portal minted for the installation, plus the calls the portal's plugins
+// make with them — the muster backend (`/api/muster/*`, the Dex token in
+// backstage-muster-authorization), the Kubernetes proxy the MCP servers page
+// lists CRs through, and the scaffolder the agent create flow deploys with.
+type portalSession struct {
+	cfg        *config.Config
+	user       *config.User
+	client     *http.Client
+	bsToken    string
+	dexIDToken string
+	identity   struct {
+		UserEntityRef       string   `json:"userEntityRef"`
+		OwnershipEntityRefs []string `json:"ownershipEntityRefs"`
+	}
+	claims map[string]any
+}
+
+// backstageLogin drives the full Backstage <-> Dex sign-in for a user and
+// returns the session. The steps are the browser's: /start redirects to Dex,
+// the login form is submitted, Dex sends the browser back through Backstage's
+// handler, whose page hands the authorization result to the opener via
+// postMessage — headlessly, the payload is parsed out of that inline script
+// (there is no API returning it cleanly; inherent to the job).
+func backstageLogin(cfg *config.Config, user *config.User) (*portalSession, error) {
+	transport, err := labTLSTransport()
+	if err != nil {
+		return nil, err
+	}
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, err
+	}
+	follow := &http.Client{Jar: jar, Transport: transport, Timeout: 60 * time.Second}
+	noFollow := &http.Client{Jar: jar, Transport: transport, Timeout: 60 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }}
+
+	// 1. Backstage redirects to Dex and sets its own session cookie. The
+	//    provider name (oidc-agent-platform) and the auth.environment
+	//    (production) both come from the umbrella's app-config and must match,
+	//    or this 404s. The scope list is passed explicitly because only the
+	//    BROWSER app applies plugins/gs/src/apis/auth/scopes.ts (BASE_SCOPES +
+	//    gs.auth.extraScopes); hitting /start directly would otherwise get a
+	//    bare token with no groups and aud=["agent-platform"] alone.
+	scope := "openid profile email groups offline_access" +
+		" audience:server:client_id:" + config.KubernetesClientID +
+		" audience:server:client_id:dex-k8s-authenticator"
+	startURL := cfg.BackstageBaseURL() + "/api/auth/oidc-agent-platform/start?env=production&scope=" +
+		url.QueryEscape(scope)
+	resp, err := noFollow.Get(startURL)
+	if err != nil {
+		return nil, err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	dexURL := resp.Header.Get("Location")
+	if dexURL == "" {
+		return nil, fmt.Errorf("no redirect to Dex (status %d)", resp.StatusCode)
+	}
+
+	// 2. Follow to Dex's login form.
+	resp, err = follow.Get(dexURL)
+	if err != nil {
+		return nil, err
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	loginURL := resp.Request.URL.String()
+
+	// 3. Submit lab credentials; Dex redirects back through the Backstage
+	//    handler, whose response embeds the authorization result.
+	form := url.Values{"login": {user.Email}, passwordParam: {user.Password}}
+	resp, err = follow.PostForm(loginURL, form)
+	if err != nil {
+		return nil, err
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	// 4. The handler page hands the result to the opener via postMessage.
+	m := handlerPayloadRe.FindSubmatch(body)
+	if m == nil {
+		return nil, fmt.Errorf("could not parse the handler response")
+	}
+	// PathUnescape, not QueryUnescape: '+' inside the JSON payload (JWTs,
+	// base64) must survive, matching Python's urllib.parse.unquote.
+	decoded, err := url.PathUnescape(string(m[1]))
+	if err != nil {
+		return nil, err
+	}
+	var probe struct {
+		Type     string         `json:"type"`
+		Response map[string]any `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(decoded), &probe); err != nil {
+		return nil, fmt.Errorf("parsing authorization response: %w", err)
+	}
+	if probe.Type != "authorization_response" {
+		return nil, fmt.Errorf("unexpected response type %q", probe.Type)
+	}
+	if errVal, ok := probe.Response["error"]; ok {
+		raw, _ := json.Marshal(errVal)
+		return nil, fmt.Errorf("SIGN-IN FAILED: %.400s", string(raw))
+	}
+	var auth struct {
+		Response struct {
+			ProviderInfo struct {
+				IDToken string `json:"idToken"`
+			} `json:"providerInfo"`
+			BackstageIdentity struct {
+				Token    string `json:"token"`
+				Identity struct {
+					UserEntityRef       string   `json:"userEntityRef"`
+					OwnershipEntityRefs []string `json:"ownershipEntityRefs"`
+				} `json:"identity"`
+			} `json:"backstageIdentity"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(decoded), &auth); err != nil {
+		return nil, err
+	}
+	ps := &portalSession{cfg: cfg, user: user, client: follow,
+		bsToken: auth.Response.BackstageIdentity.Token, dexIDToken: auth.Response.ProviderInfo.IDToken}
+	ps.identity = auth.Response.BackstageIdentity.Identity
+	if ps.claims, err = decodeJWTClaims(ps.dexIDToken); err != nil {
+		return nil, err
+	}
+	return ps, nil
+}
+
+// musterGet is the muster plugin's read hop: the backend promotes the Dex
+// id_token from backstage-muster-authorization to Authorization: Bearer on
+// its MCP session to muster. Returns the status and the JSON payload (or the
+// raw text when the answer is not JSON / not 200).
+func (ps *portalSession) musterGet(path string) (int, any, error) {
+	req, err := http.NewRequest(http.MethodGet, ps.cfg.BackstageBaseURL()+"/api/muster"+path, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+ps.bsToken)
+	req.Header.Set("backstage-muster-authorization", ps.dexIDToken)
+	resp, err := ps.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return resp.StatusCode, strings.TrimSpace(string(raw)), nil
+	}
+	var payload any
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return resp.StatusCode, strings.TrimSpace(string(raw)), nil
+	}
+	return resp.StatusCode, payload, nil
+}
+
+// musterPost is the mutation shape of the same hop: a JSON body, the raw
+// answer back (the routes normalise muster's tool results themselves).
+func (ps *portalSession) musterPost(path string, body any) (int, []byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, ps.cfg.BackstageBaseURL()+"/api/muster"+path, strings.NewReader(string(payload)))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+ps.bsToken)
+	req.Header.Set("backstage-muster-authorization", ps.dexIDToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ps.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw, nil
+}
+
+// kubeProxyGet reads a Kubernetes API path through Backstage's Kubernetes
+// backend the way the muster plugin's useResources does: the installation in
+// Backstage-Kubernetes-Cluster and the user's own Dex id_token in the
+// provider-specific authorization header (authProvider oidc, oidcTokenProvider
+// oidc-agent-platform in the umbrella's app-config), so the apiserver sees
+// the person, not Backstage.
+func (ps *portalSession) kubeProxyGet(path string) (int, []byte, error) {
+	req, err := http.NewRequest(http.MethodGet, ps.cfg.BackstageBaseURL()+"/api/kubernetes/proxy"+path, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+ps.bsToken)
+	req.Header.Set("Backstage-Kubernetes-Cluster", platformRelease)
+	req.Header.Set("Backstage-Kubernetes-Authorization-oidc-oidc-agent-platform", "Bearer "+ps.dexIDToken)
+	resp, err := ps.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw, nil
+}
+
+// backstageGet is a plain authenticated read of a Backstage backend path.
+func (ps *portalSession) backstageGet(path string) (int, []byte, error) {
+	req, err := http.NewRequest(http.MethodGet, ps.cfg.BackstageBaseURL()+path, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+ps.bsToken)
+	resp, err := ps.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw, nil
+}
+
+// backstagePostJSON is a plain authenticated JSON POST to a Backstage
+// backend path.
+func (ps *portalSession) backstagePostJSON(path string, body any) (int, []byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, ps.cfg.BackstageBaseURL()+path, strings.NewReader(string(payload)))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+ps.bsToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := ps.client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, raw, nil
+}
+
+// installationQuery is the `?installation=` parameter every muster-backend
+// route takes. The umbrella's app-config names the muster installation after
+// the Helm release, not the kind cluster.
+const installationQuery = "?installation=" + platformRelease
+
+// listMCPServerCRs reads the MCPServer CRs the way the portal's MCP servers
+// page does (useResources(MCPServer) over the Kubernetes proxy), as the user.
+func (ps *portalSession) listMCPServerCRs() ([]mcpServerCR, error) {
+	status, raw, err := ps.kubeProxyGet("/apis/muster.giantswarm.io/v1alpha1/mcpservers")
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("Kubernetes proxy list of MCPServers answered %d: %.300s", status, raw)
+	}
+	return decodeMCPServerList(raw)
+}

--- a/internal/lab/portal.go
+++ b/internal/lab/portal.go
@@ -268,7 +268,7 @@ func (ps *portalSession) listMCPServerCRs() ([]mcpServerCR, error) {
 		return nil, err
 	}
 	if status != http.StatusOK {
-		return nil, fmt.Errorf("Kubernetes proxy list of MCPServers answered %d: %.300s", status, raw)
+		return nil, fmt.Errorf("the Kubernetes proxy list of MCPServers answered %d: %.300s", status, raw)
 	}
 	return decodeMCPServerList(raw)
 }

--- a/internal/lab/portal.go
+++ b/internal/lab/portal.go
@@ -207,7 +207,8 @@ func (ps *portalSession) kubeProxyGet(path string) (int, []byte, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+ps.bsToken)
 	req.Header.Set("Backstage-Kubernetes-Cluster", platformRelease)
-	req.Header.Set("Backstage-Kubernetes-Authorization-oidc-oidc-agent-platform", "Bearer "+ps.dexIDToken)
+	// The raw token: the backend's OIDC strategy prefixes "Bearer " itself.
+	req.Header.Set("Backstage-Kubernetes-Authorization-oidc-oidc-agent-platform", ps.dexIDToken)
 	resp, err := ps.client.Do(req)
 	if err != nil {
 		return 0, nil, err

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -48,6 +48,7 @@ type tmplData struct {
 	DomainRegex           string // Platform.Domain with dots escaped, for the CoreDNS rewrite
 	AllGroups             []string
 	KubernetesClientSecret,
+	AgentPlatformClientID,
 	AgentPlatformClientSecret string
 	// ModelManagerEnabled mirrors cfg.ModelManagerEnabled(); Backends is
 	// platform.modelManager.backends (the first is model-manager's default
@@ -106,6 +107,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		DomainRegex:               strings.ReplaceAll(cfg.Platform.Domain, ".", `\.`),
 		AllGroups:                 config.Groups,
 		KubernetesClientSecret:    config.KubernetesClientSecret,
+		AgentPlatformClientID:     config.AgentPlatformClientID,
 		AgentPlatformClientSecret: config.AgentPlatformClientSecret,
 	}, nil
 }

--- a/internal/lab/servergroups.go
+++ b/internal/lab/servergroups.go
@@ -1,0 +1,238 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// The portal's MCP servers page groups servers by the tool-group label into
+// three sections — Agent Platform, Infrastructure, Registered servers — and
+// collapses the members of a family (spec.family.name) into one row. This is
+// the same arithmetic the released plugin runs (plugins/muster
+// serverGrouping.ts: partitionServers, familyToolGroup), ported so the lab
+// can assert what the page shows from the data the page reads: the MCPServer
+// CRs, fetched through Backstage's Kubernetes proxy with the user's own
+// token. The label contract (D8): agent-platform | infrastructure; absent (or
+// unknown) = Registered servers. Orientation, not authorization.
+
+// Tool groups in display order, and their titles on the page.
+const (
+	groupAgentPlatform  = "agent-platform"
+	groupInfrastructure = "infrastructure"
+	groupRegistered     = "registered"
+)
+
+var toolGroupOrder = []string{groupAgentPlatform, groupInfrastructure, groupRegistered}
+
+var toolGroupTitles = map[string]string{
+	groupAgentPlatform:  "Agent Platform",
+	groupInfrastructure: "Infrastructure",
+	groupRegistered:     "Registered servers",
+}
+
+// mcpServerCR is the part of an MCPServer resource the grouping reads.
+type mcpServerCR struct {
+	Metadata struct {
+		Name      string            `json:"name"`
+		Namespace string            `json:"namespace"`
+		Labels    map[string]string `json:"labels"`
+	} `json:"metadata"`
+	Spec struct {
+		Family *struct {
+			Name string `json:"name"`
+		} `json:"family"`
+	} `json:"spec"`
+	Status struct {
+		State string `json:"state"`
+	} `json:"status"`
+}
+
+func (s mcpServerCR) name() string { return s.Metadata.Name }
+
+func (s mcpServerCR) family() string {
+	if s.Spec.Family == nil {
+		return ""
+	}
+	return s.Spec.Family.Name
+}
+
+// toolGroup is MCPServer.getToolGroup(): the declared group, or "" for a
+// server without (or with an unknown) label.
+func (s mcpServerCR) toolGroup() string {
+	switch v := s.Metadata.Labels[toolGroupLabel]; v {
+	case groupAgentPlatform, groupInfrastructure:
+		return v
+	}
+	return ""
+}
+
+// toolGroupKey is MCPServer.getToolGroupKey(): the group the server is
+// rendered under.
+func (s mcpServerCR) toolGroupKey() string {
+	if g := s.toolGroup(); g != "" {
+		return g
+	}
+	return groupRegistered
+}
+
+// serverRow is one row of the page: a family (one row for all its members)
+// or a singular server.
+type serverRow struct {
+	Family  string
+	Servers []mcpServerCR
+}
+
+// rowName is the family name for a family row, the server name otherwise.
+func (r serverRow) rowName() string {
+	if r.Family != "" {
+		return r.Family
+	}
+	return r.Servers[0].name()
+}
+
+// familyToolGroup is the plugin's familyToolGroup: the labelled members
+// decide (most common declared group, ties broken by display order); a family
+// no member has labelled is a Registered server.
+func familyToolGroup(members []mcpServerCR) string {
+	votes := map[string]int{}
+	for _, m := range members {
+		if g := m.toolGroup(); g != "" {
+			votes[g]++
+		}
+	}
+	if len(votes) == 0 {
+		return groupRegistered
+	}
+	best := ""
+	for _, g := range toolGroupOrder {
+		if n, ok := votes[g]; ok && (best == "" || n > votes[best]) {
+			best = g
+		}
+	}
+	return best
+}
+
+// partitionServers is the plugin's partitionServers: every group present (in
+// display order, possibly empty), family rows first (alphabetical), then
+// singular servers (alphabetical).
+func partitionServers(servers []mcpServerCR) map[string][]serverRow {
+	families := map[string][]mcpServerCR{}
+	var singular []mcpServerCR
+	for _, s := range servers {
+		if f := s.family(); f != "" {
+			families[f] = append(families[f], s)
+		} else {
+			singular = append(singular, s)
+		}
+	}
+	out := map[string][]serverRow{}
+	for _, g := range toolGroupOrder {
+		out[g] = []serverRow{}
+	}
+	familyNamesSorted := make([]string, 0, len(families))
+	for f := range families {
+		familyNamesSorted = append(familyNamesSorted, f)
+	}
+	sort.Strings(familyNamesSorted)
+	for _, f := range familyNamesSorted {
+		g := familyToolGroup(families[f])
+		out[g] = append(out[g], serverRow{Family: f, Servers: families[f]})
+	}
+	sort.Slice(singular, func(i, j int) bool { return singular[i].name() < singular[j].name() })
+	for _, s := range singular {
+		g := s.toolGroupKey()
+		out[g] = append(out[g], serverRow{Servers: []mcpServerCR{s}})
+	}
+	return out
+}
+
+// rowNames lists a group's rows by name, in display order.
+func rowNames(rows []serverRow) []string {
+	names := make([]string, 0, len(rows))
+	for _, r := range rows {
+		names = append(names, r.rowName())
+	}
+	return names
+}
+
+// stripToolGroupLabels returns the servers without the tool-group label —
+// what an installation whose charts stamp no labels looks like.
+func stripToolGroupLabels(servers []mcpServerCR) []mcpServerCR {
+	out := make([]mcpServerCR, 0, len(servers))
+	for _, s := range servers {
+		c := s
+		c.Metadata.Labels = map[string]string{}
+		for k, v := range s.Metadata.Labels {
+			if k != toolGroupLabel {
+				c.Metadata.Labels[k] = v
+			}
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// decodeMCPServerList parses a Kubernetes list of MCPServer resources.
+func decodeMCPServerList(raw []byte) ([]mcpServerCR, error) {
+	var list struct {
+		Items []mcpServerCR `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parsing the MCPServer list: %w", err)
+	}
+	return list.Items, nil
+}
+
+// describeGroups renders the partition the way the page lays it out, for the
+// proof's output.
+func describeGroups(groups map[string][]serverRow) string {
+	var b strings.Builder
+	for _, g := range toolGroupOrder {
+		names := rowNames(groups[g])
+		fmt.Fprintf(&b, "    %-19s %d rows: %s\n", toolGroupTitles[g], len(names), strings.Join(names, ", "))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// assertServerGroups judges the partition against the lab's own fixtures —
+// the fake-fleet families under Infrastructure, the OAuth fixture under
+// Registered servers — and reports the chart-shipped servers: those whose
+// chart already stamps the label must sit under the group it names, the
+// rest under Registered servers (the fallback). Every server the CR list
+// carries must be in exactly one group.
+func assertServerGroups(servers []mcpServerCR, groups map[string][]serverRow) error {
+	infra := rowNames(groups[groupInfrastructure])
+	for _, f := range familyNames() {
+		if !slices.Contains(infra, f) {
+			return fmt.Errorf("the fake-fleet family %s is not under %s (rows: %v)", f, toolGroupTitles[groupInfrastructure], infra)
+		}
+	}
+	registered := rowNames(groups[groupRegistered])
+	if !slices.Contains(registered, oauthFixtureServer) {
+		return fmt.Errorf("%s (unlabelled) is not under %s (rows: %v)", oauthFixtureServer, toolGroupTitles[groupRegistered], registered)
+	}
+	seen := map[string]int{}
+	for _, g := range toolGroupOrder {
+		for _, row := range groups[g] {
+			for _, s := range row.Servers {
+				seen[s.name()]++
+			}
+		}
+	}
+	for _, s := range servers {
+		if seen[s.name()] != 1 {
+			return fmt.Errorf("server %s appears in %d groups, wanted exactly one", s.name(), seen[s.name()])
+		}
+		want := s.toolGroupKey()
+		if s.family() != "" {
+			continue // families are judged by their members' vote above
+		}
+		if !slices.Contains(rowNames(groups[want]), s.name()) {
+			return fmt.Errorf("server %s carries %s=%q but is not under %s", s.name(), toolGroupLabel, s.Metadata.Labels[toolGroupLabel], toolGroupTitles[want])
+		}
+	}
+	return nil
+}

--- a/internal/lab/servergroups_test.go
+++ b/internal/lab/servergroups_test.go
@@ -1,0 +1,104 @@
+package lab
+
+import (
+	"reflect"
+	"testing"
+)
+
+func fakeServer(name, family, group string) mcpServerCR {
+	var s mcpServerCR
+	s.Metadata.Name = name
+	s.Metadata.Namespace = platformNamespace
+	s.Metadata.Labels = map[string]string{}
+	if group != "" {
+		s.Metadata.Labels[toolGroupLabel] = group
+	}
+	if family != "" {
+		s.Spec.Family = &struct {
+			Name string `json:"name"`
+		}{Name: family}
+	}
+	return s
+}
+
+// The lab's own shape: the fake fleet (labelled infrastructure, two members
+// per family), the chart-shipped managers (agent-platform), the bundled
+// mcp-kubernetes (infrastructure), an unlabelled prometheus and the OAuth
+// fixture (Registered servers).
+func labServers() []mcpServerCR {
+	var out []mcpServerCR
+	for _, s := range fleetFixtureServers() {
+		out = append(out, fakeServer(s.Name, s.Family, toolGroupInfrastructure))
+	}
+	out = append(out,
+		fakeServer("model-manager", "", toolGroupAgentPlatform),
+		fakeServer(agentManagerMCPServer, "", toolGroupAgentPlatform),
+		fakeServer("mcp-kubernetes", "", toolGroupInfrastructure),
+		fakeServer("mcp-prometheus", "", ""),
+		fakeServer(oauthFixtureServer, "", ""),
+	)
+	return out
+}
+
+func TestPartitionServersGroupsByLabelAndFamily(t *testing.T) {
+	groups := partitionServers(labServers())
+	want := map[string][]string{
+		groupAgentPlatform:  {agentManagerMCPServer, "model-manager"},
+		groupInfrastructure: {"capi", "kubernetes", "prometheus", "mcp-kubernetes"},
+		groupRegistered:     {oauthFixtureServer, "mcp-prometheus"},
+	}
+	for _, g := range toolGroupOrder {
+		if got := rowNames(groups[g]); !reflect.DeepEqual(got, want[g]) {
+			t.Errorf("%s rows = %v, want %v", g, got, want[g])
+		}
+	}
+	if err := assertServerGroups(labServers(), groups); err != nil {
+		t.Fatalf("assertServerGroups: %v", err)
+	}
+}
+
+func TestPartitionServersFallbackWithoutLabels(t *testing.T) {
+	groups := partitionServers(stripToolGroupLabels(labServers()))
+	if len(groups) != len(toolGroupOrder) {
+		t.Fatalf("every group must be present, got %d", len(groups))
+	}
+	if n := len(groups[groupAgentPlatform]) + len(groups[groupInfrastructure]); n != 0 {
+		t.Errorf("unlabelled servers landed outside Registered servers: %d rows", n)
+	}
+	want := []string{"capi", "kubernetes", "prometheus", agentManagerMCPServer, oauthFixtureServer, "mcp-kubernetes", "mcp-prometheus", "model-manager"}
+	if got := rowNames(groups[groupRegistered]); !reflect.DeepEqual(got, want) {
+		t.Errorf("Registered rows = %v, want %v", got, want)
+	}
+}
+
+func TestFamilyToolGroupVotes(t *testing.T) {
+	cases := []struct {
+		name    string
+		members []mcpServerCR
+		want    string
+	}{
+		{"unlabelled family", []mcpServerCR{fakeServer("a-1", "a", ""), fakeServer("a-2", "a", "")}, groupRegistered},
+		{"rollout in flight: one labelled member decides", []mcpServerCR{fakeServer("a-1", "a", ""), fakeServer("a-2", "a", toolGroupInfrastructure)}, groupInfrastructure},
+		{"majority wins", []mcpServerCR{fakeServer("a-1", "a", toolGroupAgentPlatform), fakeServer("a-2", "a", toolGroupInfrastructure), fakeServer("a-3", "a", toolGroupInfrastructure)}, groupInfrastructure},
+		{"tie breaks by display order", []mcpServerCR{fakeServer("a-1", "a", toolGroupInfrastructure), fakeServer("a-2", "a", toolGroupAgentPlatform)}, groupAgentPlatform},
+		{"unknown label value is no label", []mcpServerCR{fakeServer("a-1", "a", "other")}, groupRegistered},
+	}
+	for _, tc := range cases {
+		if got := familyToolGroup(tc.members); got != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestAssertServerGroupsCatchesMisplacedFixture(t *testing.T) {
+	servers := labServers()
+	// The OAuth fixture wrongly labelled: the fixture contract says unlabelled.
+	for i := range servers {
+		if servers[i].name() == oauthFixtureServer {
+			servers[i].Metadata.Labels[toolGroupLabel] = toolGroupAgentPlatform
+		}
+	}
+	if err := assertServerGroups(servers, partitionServers(servers)); err == nil {
+		t.Fatal("a labelled OAuth fixture must fail the Registered servers assertion")
+	}
+}

--- a/internal/lab/templates/dex.yaml.tmpl
+++ b/internal/lab/templates/dex.yaml.tmpl
@@ -95,6 +95,13 @@ stringData:
         redirectURIs:
           - {{ .MusterBaseURL }}/oauth/callback
           - {{ .BackstageBaseURL }}/api/auth/oidc-agent-platform/handler/frame
+          # muster's OAuth *proxy* callback (its client role): the sign-in
+          # fixture pins Dex as its authorization server with this very
+          # client (oauth-fixture.yaml.tmpl), so a per-server sign-in can
+          # complete headlessly in the lab. Dex matches redirect URIs
+          # exactly, no DNS lookups -- unlike muster's own authorization
+          # server, whose SSRF guards reject every lab hostname.
+          - {{ .MusterBaseURL }}/oauth/proxy/callback
       # Cross-client audience target. Backstage's GS auth provider requests
       # the scope audience:server:client_id:dex-k8s-authenticator by default
       # (components.backstage.extraScopes); Dex only honors that when the

--- a/internal/lab/templates/oauth-fixture.yaml.tmpl
+++ b/internal/lab/templates/oauth-fixture.yaml.tmpl
@@ -46,3 +46,38 @@ spec:
   auth:
     type: oauth
     forwardToken: false
+    # The authorization server muster signs the user in to, pinned (the
+    # GitHub-App shape of spec.auth.authorizationServer): the lab Dex, with
+    # the platform client registered out of band -- Dex lists muster's proxy
+    # callback on it (dex.yaml.tmpl). Without the pin muster would discover
+    # the endpoint's own authorization server (muster itself) and identify
+    # with its Client ID Metadata Document; that server's SSRF guards refuse
+    # every lab hostname (they resolve to the edge's cluster IP in-cluster,
+    # to loopback outside) for the metadata URL and for a registered redirect
+    # URI alike, so no sign-in could ever complete. Dex matches redirect URIs
+    # exactly, and the token it issues carries the platform client's
+    # audience, which the endpoint trusts -- so the sign-in completes and the
+    # fixture connects, as `agentlab toolsets-test` proves.
+    authorizationServer:
+      issuer: {{ .Issuer }}
+      clientCredentialsSecretRef:
+        name: {{ .OAuthFixtureServer }}-client
+      # A pinned authorization server gets no default scope; Dex refuses a
+      # request without openid (invalid_scope), and offline_access is what
+      # lets muster refresh the grant.
+      scopes: openid profile email offline_access
+---
+# The client the pin above names: the lab's platform client, the one Dex
+# registration that carries muster's proxy callback.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .OAuthFixtureServer }}-client
+  namespace: agent-platform
+  labels:
+    app.kubernetes.io/managed-by: agentlab
+    agentlab.giantswarm.io/fixture: oauth-sign-in
+type: Opaque
+stringData:
+  client-id: {{ .AgentPlatformClientID }}
+  client-secret: {{ .AgentPlatformClientSecret }}

--- a/internal/lab/templates/oauth-fixture.yaml.tmpl
+++ b/internal/lab/templates/oauth-fixture.yaml.tmpl
@@ -47,19 +47,28 @@ spec:
     type: oauth
     forwardToken: false
     # The authorization server muster signs the user in to, pinned (the
-    # GitHub-App shape of spec.auth.authorizationServer): the lab Dex, with
-    # the platform client registered out of band -- Dex lists muster's proxy
-    # callback on it (dex.yaml.tmpl). Without the pin muster would discover
-    # the endpoint's own authorization server (muster itself) and identify
-    # with its Client ID Metadata Document; that server's SSRF guards refuse
-    # every lab hostname (they resolve to the edge's cluster IP in-cluster,
-    # to loopback outside) for the metadata URL and for a registered redirect
-    # URI alike, so no sign-in could ever complete. Dex matches redirect URIs
-    # exactly, and the token it issues carries the platform client's
-    # audience, which the endpoint trusts -- so the sign-in completes and the
-    # fixture connects, as `agentlab toolsets-test` proves.
+    # GitHub-App shape of spec.auth.authorizationServer): the lab Dex's
+    # endpoints, with the platform client registered out of band -- Dex lists
+    # muster's proxy callback on it (dex.yaml.tmpl). Without the pin muster
+    # would discover the endpoint's own authorization server (muster itself)
+    # and identify with its Client ID Metadata Document; that server's SSRF
+    # guards refuse every lab hostname (they resolve to the edge's cluster IP
+    # in-cluster, to loopback outside) for the metadata URL and for a
+    # registered redirect URI alike, so no sign-in could ever complete. Dex
+    # matches redirect URIs exactly, and the token it issues carries the
+    # platform client's audience, which the endpoint trusts -- so the sign-in
+    # completes and the fixture connects, as `agentlab toolsets-test` proves.
+    #
+    # The issuer is the identity the grant is filed under, not where the
+    # browser goes: it must be the authorization server the endpoint's own
+    # RFC 9728 metadata names (muster's public URL), because that is the key
+    # muster looks the session's token up under when it calls the server.
+    # Pinning Dex's URL as the issuer completes the sign-in but files the
+    # grant where no call finds it ("no valid token available").
     authorizationServer:
-      issuer: {{ .Issuer }}
+      issuer: {{ .MusterBaseURL }}
+      authorizationEndpoint: {{ .Issuer }}/auth
+      tokenEndpoint: {{ .Issuer }}/token
       clientCredentialsSecretRef:
         name: {{ .OAuthFixtureServer }}-client
       # A pinned authorization server gets no default scope; Dex refuses a

--- a/internal/lab/toolsetstest.go
+++ b/internal/lab/toolsetstest.go
@@ -89,12 +89,20 @@ func ToolsetsTest(cfg *config.Config, email string, opts ToolsetsTestOptions) er
 	if user == nil {
 		return fmt.Errorf("no user %q in %s", email, config.File)
 	}
-	other := cfg.FindUserInGroup("developers")
-	if other == nil || other.Email == user.Email {
-		other = cfg.FindUserInGroup("viewers")
+	// The second person of the sign-in proof: anyone but the first, a
+	// developer preferred (the lab admin is a developer too).
+	var other *config.User
+	for i := range cfg.Users {
+		u := &cfg.Users[i]
+		if u.Email == user.Email {
+			continue
+		}
+		if other == nil || (slices.Contains(u.Groups, "developers") && !slices.Contains(other.Groups, "developers")) {
+			other = u
+		}
 	}
-	if other == nil || other.Email == user.Email {
-		return fmt.Errorf("%s needs a second user (developers or viewers group) for the per-user sign-in proof", config.File)
+	if other == nil {
+		return fmt.Errorf("%s needs a second user for the per-user sign-in proof", config.File)
 	}
 	if opts.ModelConfig == "" {
 		opts.ModelConfig = toolsetTestDefaultModel
@@ -226,8 +234,8 @@ func proveAgentManagerToolset(s *musterSession, toolPrefix, modelConfig string) 
 	step("%screate_agent without a toolset — expecting the refusal", toolPrefix)
 	base := func(name string) map[string]any {
 		return map[string]any{
-			nameKey: name, "modelConfig": modelConfig, "displayName": "agentlab toolset proof: " + strings.TrimPrefix(name, toolsetsTestPrefix+"-"),
-			"description":   "Throwaway agent of `agentlab toolsets-test`; deleted by the same run.",
+			nameKey: name, modelConfigKey: modelConfig, "displayName": "agentlab toolset proof: " + strings.TrimPrefix(name, toolsetsTestPrefix+"-"),
+			descriptionKey:  "Throwaway agent of `agentlab toolsets-test`; deleted by the same run.",
 			"systemMessage": toolsetTestAgentSystemMsg,
 		}
 	}
@@ -235,7 +243,7 @@ func proveAgentManagerToolset(s *musterSession, toolPrefix, modelConfig string) 
 	if err == nil {
 		return fmt.Errorf("create_agent without a toolset was accepted (%.200s) — agent-manager predates the toolset contract (needs ≥ 0.4.0)", text)
 	}
-	for _, want := range []string{"toolset", "read-only", "none", "infrastructure", "agent-platform", "full", presetNone} {
+	for _, want := range []string{"toolset", presetReadOnlyName, presetNoneName, "infrastructure", "agent-platform", presetFullName, presetNone} {
 		if !strings.Contains(err.Error(), want) {
 			return fmt.Errorf("the refusal does not mention %q: %v", want, err)
 		}
@@ -315,7 +323,7 @@ func waitAgentCR(name string) (*agentCR, error) {
 	}
 	var cr agentCR
 	if err := json.Unmarshal([]byte(raw), &cr); err != nil {
-		return nil, fmt.Errorf("parsing Agent %s: %w", name, err)
+		return nil, fmt.Errorf("parsing agent %s: %w", name, err)
 	}
 	return &cr, nil
 }
@@ -370,16 +378,16 @@ func proveRenderedToolsets(s *musterSession, toolPrefix, modelConfig string) err
 		switch {
 		case a.name == toolsetsAgentNone:
 			if err == nil {
-				return fmt.Errorf("Agent %s (toolset %v) still has a muster tool entry (header %q); the chart must omit it", a.name, a.toolset, header)
+				return fmt.Errorf("agent %s (toolset %v) still has a muster tool entry (header %q); the chart must omit it", a.name, a.toolset, header)
 			}
 			if len(cr.Spec.Declarative.Tools) != 0 {
-				return fmt.Errorf("Agent %s has %d tool entries, wanted none", a.name, len(cr.Spec.Declarative.Tools))
+				return fmt.Errorf("agent %s has %d tool entries, wanted none", a.name, len(cr.Spec.Declarative.Tools))
 			}
 			note("no tool entry at all (spec.declarative.tools empty)")
 		case err != nil:
-			return fmt.Errorf("Agent %s: %w", a.name, err)
+			return fmt.Errorf("agent %s: %w", a.name, err)
 		case header != want:
-			return fmt.Errorf("Agent %s carries %s=%q on spec.declarative.tools[0].headersFrom, wanted %q", a.name, toolsetHeader, header, want)
+			return fmt.Errorf("agent %s carries %s=%q on spec.declarative.tools[0].headersFrom, wanted %q", a.name, toolsetHeader, header, want)
 		default:
 			note("spec.declarative.tools[0].headersFrom: %s=%s (mcpServer %s/%s)", toolsetHeader, header, cr.Spec.Declarative.Tools[0].MCPServer.Kind, cr.Spec.Declarative.Tools[0].MCPServer.Name)
 		}
@@ -435,10 +443,10 @@ spec:
 	}
 	header, err := toolsetHeaderOf(cr)
 	if err != nil {
-		return fmt.Errorf("Agent %s: %w", toolsetsAgentLegacy, err)
+		return fmt.Errorf("agent %s: %w", toolsetsAgentLegacy, err)
 	}
 	if header != "" {
-		return fmt.Errorf("Agent %s declares no toolset but carries %s=%q", toolsetsAgentLegacy, toolsetHeader, header)
+		return fmt.Errorf("agent %s declares no toolset but carries %s=%q", toolsetsAgentLegacy, toolsetHeader, header)
 	}
 	var list struct {
 		Agents []struct {
@@ -496,18 +504,18 @@ func proveMusterToolsets(cfg *config.Config, token string) (*musterToolsetResult
 	step("Workflows: a query-only one and one with a destructive step (core_workflow_create)")
 	for _, wf := range []map[string]any{
 		{
-			nameKey:       toolsetsWorkflowQuery,
-			"description": "agentlab toolsets-test: read-only steps only (deleted by the same run)",
+			nameKey:        toolsetsWorkflowQuery,
+			descriptionKey: "agentlab toolsets-test: read-only steps only (deleted by the same run)",
 			"steps": []map[string]any{
-				{"id": "namespaces", "tool": listTool, "args": map[string]any{"resourceType": "namespaces"}, "store": true},
+				{"id": resourceNamespaces, toolKey: listTool, argsKey: map[string]any{resourceTypeKey: resourceNamespaces}, "store": true},
 			},
 		},
 		{
-			nameKey:       toolsetsWorkflowMutating,
-			"description": "agentlab toolsets-test: a destructive step, never executed (deleted by the same run)",
+			nameKey:        toolsetsWorkflowMutating,
+			descriptionKey: "agentlab toolsets-test: a destructive step, never executed (deleted by the same run)",
 			"steps": []map[string]any{
-				{"id": "namespaces", "tool": listTool, "args": map[string]any{"resourceType": "namespaces"}},
-				{"id": "purge", "tool": deleteTool, "args": deleteArgs},
+				{"id": resourceNamespaces, toolKey: listTool, argsKey: map[string]any{resourceTypeKey: resourceNamespaces}},
+				{"id": "purge", toolKey: deleteTool, argsKey: deleteArgs},
 			},
 		},
 	} {
@@ -589,7 +597,7 @@ func proveMusterToolsets(cfg *config.Config, token string) (*musterToolsetResult
 	note("%d tools, all readOnlyHint (%d workflows, no core_*)", len(ro.Tools), countKind(ro.Tools, "workflow"))
 
 	step("Under %s: the read-only Kubernetes call succeeds, the destructive call and the mutating workflow are refused naming the toolset", presetReadOnly)
-	text, err := s.callServerTool(listTool, map[string]any{"resourceType": "namespaces"})
+	text, err := s.callServerTool(listTool, map[string]any{resourceTypeKey: resourceNamespaces})
 	if err != nil {
 		return nil, fmt.Errorf("%s under %s: %w", listTool, presetReadOnly, err)
 	}
@@ -627,7 +635,7 @@ func proveMusterToolsets(cfg *config.Config, token string) (*musterToolsetResult
 	if len(none.Tools) != 0 {
 		return nil, fmt.Errorf("%s resolved to %d tools", presetNone, len(none.Tools))
 	}
-	env, err := s.callToolEnvelope(listTool, map[string]any{"resourceType": "namespaces"})
+	env, err := s.callToolEnvelope(listTool, map[string]any{resourceTypeKey: resourceNamespaces})
 	if err != nil {
 		return nil, err
 	}
@@ -732,7 +740,7 @@ func proveMusterToolsets(cfg *config.Config, token string) (*musterToolsetResult
 	for _, p := range withPresets.Presets {
 		presetNames = append(presetNames, p.Name)
 	}
-	for _, builtIn := range []string{"read-only", "none", "full"} {
+	for _, builtIn := range []string{presetReadOnlyName, presetNoneName, presetFullName} {
 		if !slices.Contains(presetNames, builtIn) {
 			return nil, fmt.Errorf("filter_tools presets lack the built-in %s: %v", builtIn, presetNames)
 		}

--- a/internal/lab/toolsetstest.go
+++ b/internal/lab/toolsetstest.go
@@ -1,0 +1,926 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The toolset proof.
+//
+// A toolset is the selector list an agent declares — chart value `toolset`,
+// header `X-Muster-Toolset`, agent-manager argument `toolset` — that bounds
+// which of the gateway's tools its meta-tools can see and call. muster
+// evaluates it per request, statelessly, on the caller's own catalogue, so
+// the invoking human's identity and the backends' authorization stay the
+// boundary; the toolset is composition. This proof drives the released
+// components in the lab through every seam the plan names: agent-manager's
+// contract, the manifests it renders, muster's resolution and refusal under
+// the header the agent's runtime sends, the runtime actually sending it, the
+// per-server sign-in the toolset resolution depends on (the one uncertain
+// claim of the plan), and the portal's Tools step and composer path.
+
+// Names of what the proof creates; every one of them is deleted by the same
+// run (and a leftover of an aborted run is removed first).
+const (
+	toolsetsTestPrefix        = "agentlab-toolset"
+	toolsetsAgentReadOnly     = toolsetsTestPrefix + "-ro"
+	toolsetsAgentNone         = toolsetsTestPrefix + "-none"
+	toolsetsAgentFull         = toolsetsTestPrefix + "-full"
+	toolsetsAgentOAuth        = toolsetsTestPrefix + "-oauth"
+	toolsetsAgentLegacy       = toolsetsTestPrefix + "-legacy"
+	toolsetsAgentPortal       = toolsetsTestPrefix + "-portal"
+	toolsetsWorkflowQuery     = toolsetsTestPrefix + "-query"
+	toolsetsWorkflowMutating  = toolsetsTestPrefix + "-mutating"
+	toolsetHeader             = "X-Muster-Toolset"
+	presetReadOnly            = "preset:read-only"
+	presetNone                = "preset:none"
+	presetFull                = "preset:full"
+	presetInfrastructure      = "preset:infrastructure"
+	presetAgentPlatform       = "preset:agent-platform"
+	toolsetFixtureSelector    = "server:" + oauthFixtureServer
+	toolsetTestDefaultModel   = "default-model-config"
+	toolsetTestAgentSystemMsg = "You are a test agent of the agentlab toolset proof. Do exactly what the message asks, tersely."
+)
+
+// ToolsetsTestOptions tunes the proof.
+type ToolsetsTestOptions struct {
+	// ModelConfig is the kagent ModelConfig the throwaway agents run on
+	// (default: default-model-config, the Anthropic one the lab renders).
+	ModelConfig string
+	// SkipChat skips the turns that need the model to answer (the runtime
+	// path and the chat-only agent); the manifests, muster's resolution and
+	// the sign-in claim are proven regardless.
+	SkipChat bool
+}
+
+// toolsetsAgent is one throwaway agent the proof creates through agent-manager.
+type toolsetsAgent struct {
+	name    string
+	toolset []string
+}
+
+var toolsetsAgents = []toolsetsAgent{
+	{toolsetsAgentReadOnly, []string{presetReadOnly}},
+	{toolsetsAgentNone, []string{presetNone}},
+	{toolsetsAgentFull, []string{presetFull}},
+	{toolsetsAgentOAuth, []string{toolsetFixtureSelector}},
+}
+
+// ToolsetsTest is the headless end-to-end proof of declared toolsets against
+// the released components in the lab. See the file comment for what it
+// covers; it prints one PASS line per claim and leaves nothing behind.
+func ToolsetsTest(cfg *config.Config, email string, opts ToolsetsTestOptions) error {
+	if err := useClusterKubeconfig(cfg); err != nil {
+		return err
+	}
+	if !cfg.Platform.Enabled || !cfg.Platform.Agents {
+		return fmt.Errorf("platform.agents is off in %s — enable it and run `agentlab platform` first", config.File)
+	}
+	if !cfg.Backstage.Enabled {
+		return fmt.Errorf("backstage.enabled is off in %s — the portal half of the proof needs it", config.File)
+	}
+	user := cfg.FindUser(email)
+	if user == nil {
+		return fmt.Errorf("no user %q in %s", email, config.File)
+	}
+	other := cfg.FindUserInGroup("developers")
+	if other == nil || other.Email == user.Email {
+		other = cfg.FindUserInGroup("viewers")
+	}
+	if other == nil || other.Email == user.Email {
+		return fmt.Errorf("%s needs a second user (developers or viewers group) for the per-user sign-in proof", config.File)
+	}
+	if opts.ModelConfig == "" {
+		opts.ModelConfig = toolsetTestDefaultModel
+	}
+	toolPrefix := "x_" + agentManagerMCPServer + "_"
+	var verdicts []string
+	pass := func(format string, a ...any) { verdicts = append(verdicts, fmt.Sprintf("PASS: "+format, a...)) }
+
+	step("Logging in to Dex as %s (with the audience muster's own writes need)", user.Email)
+	token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+		user.Email, user.Password, musterWriterScopes)
+	if err != nil {
+		return err
+	}
+	admin, err := openMusterSession(cfg, token, "toolsets-test")
+	if err != nil {
+		return err
+	}
+	if err := admin.callServerJSON(toolPrefix+"get_info", nil, &struct{}{}); err != nil {
+		return fmt.Errorf("agent-manager is not reachable through muster (%w); check `kubectl -n %s get mcpservers.muster.giantswarm.io %s`", err, platformNamespace, agentManagerMCPServer)
+	}
+
+	// Leftovers of an aborted run first, and everything this run creates on
+	// every exit path.
+	cleanup := func() { toolsetsCleanup(admin, toolPrefix) }
+	cleanup()
+	defer cleanup()
+
+	// 1. agent-manager: the toolset is the contract's required argument.
+	if err := proveAgentManagerToolset(admin, toolPrefix, opts.ModelConfig); err != nil {
+		return err
+	}
+	pass("agent-manager refuses create_agent without a toolset (naming the presets and preset:none), refuses toolNames, and accepts a toolset")
+
+	// 2. What the platform rendered: the header on the Agent CR, the value on
+	//    the HelmRelease, agent-manager's own report — and the agent that
+	//    declares none.
+	if err := proveRenderedToolsets(admin, toolPrefix, opts.ModelConfig); err != nil {
+		return err
+	}
+	pass("%s carries headersFrom X-Muster-Toolset=%s on spec.declarative.tools[0] and toolset on its HelmRelease; %s has no muster tool entry; an agent without a toolset reports implicitFullAccess", toolsetsAgentReadOnly, presetReadOnly, toolsetsAgentNone)
+
+	// 3. muster resolves and refuses per request, under the header the
+	//    agents' runtimes send, in a session of the same user.
+	res, err := proveMusterToolsets(cfg, token)
+	if err != nil {
+		return err
+	}
+	pass("%s resolves to %d read-only tools incl. the query-only workflows %s and %s, not workflow_%s or core tools; the read-only Kubernetes call succeeds and the destructive call (x_%s_delete_agent) is refused naming the toolset",
+		presetReadOnly, res.readOnlyCount, "workflow_"+toolsetsWorkflowQuery, "workflow_lab-cluster-overview", toolsetsWorkflowMutating, agentManagerMCPServer)
+	pass("two toolsets on one token — in one session request by request and from two sessions in parallel — each see their own tools; %s sees nothing; %s equals the unscoped catalogue (%d tools) like an agent without a toolset", presetNone, presetFull, res.fullCount)
+	if res.presetsVerdict != "" {
+		pass("%s", res.presetsVerdict)
+	} else {
+		note("presets %s/%s are not configured on this muster (the fleet presets arrive with the platform chart that ships them); their resolution was skipped", presetInfrastructure, presetAgentPlatform)
+	}
+
+	// 4. The runtime actually sends the header: the read-only agent, asked
+	//    what tools it has, lists read-only tools only; the chat-only agent
+	//    answers without any tool entry.
+	if opts.SkipChat {
+		note("skipping the model turns (--skip-chat): the runtime path and the chat-only turn were not exercised")
+	} else {
+		if err := proveAgentRuntimeToolsets(cfg, token, opts.ModelConfig, toolPrefix, admin); err != nil {
+			return err
+		}
+		pass("through kagent (A2A as %s) %s lists read-only tools only — the runtime sends the header and the user's token — and %s answers a chat turn with no tool entry", user.Email, toolsetsAgentReadOnly, toolsetsAgentNone)
+	}
+
+	// 5. The OAuth fixture: the sign-in completed in the portal path is what
+	//    makes the server's tools resolve for the agent under the same
+	//    forwarded token (ground-truth v3, G6), and only for that token.
+	g6, err := proveSignInScopedToolset(cfg, user, other, toolPrefix, admin, opts)
+	if err != nil {
+		return err
+	}
+	verdicts = append(verdicts, g6...)
+
+	// 6. The portal: the Tools step's endpoints and the composer's apply path.
+	portal, err := proveToolsetPortal(cfg, user)
+	if err != nil {
+		return err
+	}
+	verdicts = append(verdicts, portal...)
+
+	fmt.Println()
+	fmt.Println(strings.Join(verdicts, "\n"))
+	return nil
+}
+
+// toolsetsCleanup removes everything the proof creates: the agents through
+// agent-manager (force: the legacy and portal releases have no agent-manager
+// provenance), the HelmReleases directly when agent-manager does not list
+// them, the workflows, and the fixture sign-in of the run.
+func toolsetsCleanup(s *musterSession, toolPrefix string) {
+	names := []string{toolsetsAgentReadOnly, toolsetsAgentNone, toolsetsAgentFull, toolsetsAgentOAuth, toolsetsAgentLegacy, toolsetsAgentPortal}
+	removed := false
+	for _, name := range names {
+		if _, err := s.callServerTool(toolPrefix+"get_agent", map[string]any{nameKey: name}); err != nil {
+			// Not known to agent-manager: a HelmRelease may still exist.
+			_ = runQuiet("kubectl", "-n", kagentNamespace, "delete", "helmrelease", name, "--ignore-not-found", "--wait=false")
+			continue
+		}
+		if _, err := s.callServerTool(toolPrefix+"delete_agent", map[string]any{nameKey: name, "force": true}); err != nil {
+			note("cleanup: delete_agent %s: %v", name, err)
+			_ = runQuiet("kubectl", "-n", kagentNamespace, "delete", "helmrelease", name, "--ignore-not-found", "--wait=false")
+		}
+		removed = true
+	}
+	for _, wf := range []string{toolsetsWorkflowQuery, toolsetsWorkflowMutating} {
+		env, err := s.callToolEnvelope("core_workflow_delete", map[string]any{nameKey: wf})
+		if err == nil && !env.IsError {
+			removed = true
+		}
+	}
+	if removed {
+		for _, name := range names {
+			_ = waitAgentGone(s, toolPrefix, name)
+		}
+		note("cleanup: %s* agents and workflows removed", toolsetsTestPrefix)
+	}
+}
+
+// proveAgentManagerToolset drives agent-manager's contract through muster:
+// create_agent without a toolset is refused naming the shipped presets and
+// pointing at preset:none; the removed toolNames argument is refused with the
+// explaining error; the four agents of the proof are created with theirs.
+func proveAgentManagerToolset(s *musterSession, toolPrefix, modelConfig string) error {
+	step("%screate_agent without a toolset — expecting the refusal", toolPrefix)
+	base := func(name string) map[string]any {
+		return map[string]any{
+			nameKey: name, "modelConfig": modelConfig, "displayName": "agentlab toolset proof: " + strings.TrimPrefix(name, toolsetsTestPrefix+"-"),
+			"description":   "Throwaway agent of `agentlab toolsets-test`; deleted by the same run.",
+			"systemMessage": toolsetTestAgentSystemMsg,
+		}
+	}
+	text, err := s.callServerTool(toolPrefix+"create_agent", base(toolsetsAgentReadOnly))
+	if err == nil {
+		return fmt.Errorf("create_agent without a toolset was accepted (%.200s) — agent-manager predates the toolset contract (needs ≥ 0.4.0)", text)
+	}
+	for _, want := range []string{"toolset", "read-only", "none", "infrastructure", "agent-platform", "full", presetNone} {
+		if !strings.Contains(err.Error(), want) {
+			return fmt.Errorf("the refusal does not mention %q: %v", want, err)
+		}
+	}
+	note("refused: %s", excerpt(err.Error(), 220))
+	if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", toolsetsAgentReadOnly); err == nil {
+		return fmt.Errorf("HelmRelease %s exists although the create was refused", toolsetsAgentReadOnly)
+	}
+
+	step("%screate_agent with the removed toolNames argument — expecting the explaining refusal", toolPrefix)
+	args := base(toolsetsAgentReadOnly)
+	args["toolset"] = []string{presetReadOnly}
+	args["toolNames"] = []string{"list_tools"}
+	if text, err := s.callServerTool(toolPrefix+"create_agent", args); err == nil {
+		return fmt.Errorf("create_agent accepted toolNames (%.200s); the inert knob must be refused", text)
+	} else if !strings.Contains(err.Error(), "toolNames") || !strings.Contains(err.Error(), "toolset") {
+		return fmt.Errorf("the toolNames refusal does not explain itself: %v", err)
+	} else {
+		note("refused: %s", excerpt(err.Error(), 200))
+	}
+
+	for _, a := range toolsetsAgents {
+		step("%screate_agent %s with toolset %v", toolPrefix, a.name, a.toolset)
+		args := base(a.name)
+		args["toolset"] = a.toolset
+		var created struct {
+			RequestedBy string `json:"requestedBy"`
+			Created     struct {
+				HelmRelease bool `json:"helmRelease"`
+			} `json:"created"`
+		}
+		if err := s.callServerJSON(toolPrefix+"create_agent", args, &created); err != nil {
+			return err
+		}
+		if !created.Created.HelmRelease {
+			return fmt.Errorf("create_agent %s reported no HelmRelease written", a.name)
+		}
+		note("HelmRelease written, requestedBy=%s", created.RequestedBy)
+	}
+	return nil
+}
+
+// agentCR is the part of a kagent Agent the proof reads.
+type agentCR struct {
+	Spec struct {
+		Declarative struct {
+			Tools []struct {
+				Type        string `json:"type"`
+				HeadersFrom []struct {
+					Name  string `json:"name"`
+					Value string `json:"value"`
+				} `json:"headersFrom"`
+				MCPServer *struct {
+					Name string `json:"name"`
+					Kind string `json:"kind"`
+				} `json:"mcpServer"`
+			} `json:"tools"`
+		} `json:"declarative"`
+	} `json:"spec"`
+}
+
+// waitAgentCR waits for helm-controller to render the Agent behind a
+// HelmRelease and returns it.
+func waitAgentCR(name string) (*agentCR, error) {
+	var raw string
+	found := waitFor(40, 3*time.Second, func() bool {
+		out, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "agents.kagent.dev", name, "-o", "json")
+		if err != nil {
+			return false
+		}
+		raw = out
+		return true
+	})
+	if !found {
+		status, _ := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", name, "-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].message}")
+		return nil, fmt.Errorf("no Agent %s rendered from its HelmRelease within 2 min (Ready: %s)", name, excerpt(status, 200))
+	}
+	var cr agentCR
+	if err := json.Unmarshal([]byte(raw), &cr); err != nil {
+		return nil, fmt.Errorf("parsing Agent %s: %w", name, err)
+	}
+	return &cr, nil
+}
+
+// toolsetHeaderOf returns the X-Muster-Toolset value on the agent's muster
+// tool entry, "" when the entry carries none, and an error when the Agent has
+// no muster tool entry at all.
+func toolsetHeaderOf(cr *agentCR) (string, error) {
+	for _, t := range cr.Spec.Declarative.Tools {
+		if t.MCPServer == nil {
+			continue
+		}
+		for _, h := range t.HeadersFrom {
+			if h.Name == toolsetHeader {
+				return h.Value, nil
+			}
+		}
+		return "", nil
+	}
+	return "", fmt.Errorf("no McpServer tool entry")
+}
+
+// helmReleaseToolset reads the top-level toolset value of a HelmRelease.
+func helmReleaseToolset(name string) ([]string, bool, error) {
+	out, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", name, "-o", "jsonpath={.spec.values.toolset}")
+	if err != nil {
+		return nil, false, err
+	}
+	if strings.TrimSpace(out) == "" {
+		return nil, false, nil
+	}
+	var toolset []string
+	if err := json.Unmarshal([]byte(out), &toolset); err != nil {
+		return nil, false, fmt.Errorf("HelmRelease %s values.toolset is not a string list: %q", name, out)
+	}
+	return toolset, true, nil
+}
+
+// proveRenderedToolsets asserts the manifests behind the created agents and
+// agent-manager's report of them, and the shape of an agent that declares no
+// toolset (a HelmRelease applied without the value, like every agent that
+// predates toolsets).
+func proveRenderedToolsets(s *musterSession, toolPrefix, modelConfig string) error {
+	for _, a := range toolsetsAgents {
+		step("Agent %s: the rendered header and the HelmRelease value", a.name)
+		cr, err := waitAgentCR(a.name)
+		if err != nil {
+			return err
+		}
+		want := strings.Join(a.toolset, ",")
+		header, err := toolsetHeaderOf(cr)
+		switch {
+		case a.name == toolsetsAgentNone:
+			if err == nil {
+				return fmt.Errorf("Agent %s (toolset %v) still has a muster tool entry (header %q); the chart must omit it", a.name, a.toolset, header)
+			}
+			if len(cr.Spec.Declarative.Tools) != 0 {
+				return fmt.Errorf("Agent %s has %d tool entries, wanted none", a.name, len(cr.Spec.Declarative.Tools))
+			}
+			note("no tool entry at all (spec.declarative.tools empty)")
+		case err != nil:
+			return fmt.Errorf("Agent %s: %w", a.name, err)
+		case header != want:
+			return fmt.Errorf("Agent %s carries %s=%q on spec.declarative.tools[0].headersFrom, wanted %q", a.name, toolsetHeader, header, want)
+		default:
+			note("spec.declarative.tools[0].headersFrom: %s=%s (mcpServer %s/%s)", toolsetHeader, header, cr.Spec.Declarative.Tools[0].MCPServer.Kind, cr.Spec.Declarative.Tools[0].MCPServer.Name)
+		}
+		values, set, err := helmReleaseToolset(a.name)
+		if err != nil {
+			return err
+		}
+		if !set || !slices.Equal(values, a.toolset) {
+			return fmt.Errorf("HelmRelease %s values.toolset = %v (set: %v), wanted %v", a.name, values, set, a.toolset)
+		}
+		var got struct {
+			Toolset            []string `json:"toolset"`
+			ImplicitFullAccess bool     `json:"implicitFullAccess"`
+		}
+		if err := s.callServerJSON(toolPrefix+"get_agent", map[string]any{nameKey: a.name}, &got); err != nil {
+			return err
+		}
+		if !slices.Equal(got.Toolset, a.toolset) || got.ImplicitFullAccess {
+			return fmt.Errorf("get_agent %s reports toolset=%v implicitFullAccess=%v, wanted %v/false", a.name, got.Toolset, got.ImplicitFullAccess, a.toolset)
+		}
+		note("HelmRelease values.toolset %v; get_agent reports the same", values)
+	}
+
+	step("An agent without a toolset (HelmRelease applied without the value): no header, implicit full access")
+	hr := fmt.Sprintf(`apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    app.kubernetes.io/managed-by: agentlab
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: agent
+    namespace: %s
+  values:
+    agent:
+      name: %s
+      displayName: "agentlab toolset proof: legacy"
+      description: "Throwaway agent of agentlab toolsets-test without a toolset; deleted by the same run."
+      systemMessage: %q
+    modelConfig:
+      name: %s
+`, toolsetsAgentLegacy, kagentNamespace, kagentNamespace, toolsetsAgentLegacy, toolsetTestAgentSystemMsg, modelConfig)
+	if err := pipeInto([]byte(hr), "kubectl", "apply", "-f", "-"); err != nil {
+		return err
+	}
+	cr, err := waitAgentCR(toolsetsAgentLegacy)
+	if err != nil {
+		return err
+	}
+	header, err := toolsetHeaderOf(cr)
+	if err != nil {
+		return fmt.Errorf("Agent %s: %w", toolsetsAgentLegacy, err)
+	}
+	if header != "" {
+		return fmt.Errorf("Agent %s declares no toolset but carries %s=%q", toolsetsAgentLegacy, toolsetHeader, header)
+	}
+	var list struct {
+		Agents []struct {
+			Name               string   `json:"name"`
+			Toolset            []string `json:"toolset"`
+			ImplicitFullAccess bool     `json:"implicitFullAccess"`
+		} `json:"agents"`
+	}
+	if err := s.callServerJSON(toolPrefix+"list_agents", nil, &list); err != nil {
+		return err
+	}
+	seen := false
+	for _, a := range list.Agents {
+		if a.Name != toolsetsAgentLegacy {
+			continue
+		}
+		seen = true
+		if !a.ImplicitFullAccess || len(a.Toolset) != 0 {
+			return fmt.Errorf("list_agents reports %s with toolset=%v implicitFullAccess=%v, wanted none/true", a.Name, a.Toolset, a.ImplicitFullAccess)
+		}
+	}
+	if !seen {
+		return fmt.Errorf("list_agents does not list %s", toolsetsAgentLegacy)
+	}
+	note("muster tool entry without a header; list_agents: implicitFullAccess=true")
+	return nil
+}
+
+// musterToolsetResults is what proveMusterToolsets learned, for the verdicts.
+type musterToolsetResults struct {
+	readOnlyCount  int
+	fullCount      int
+	presetsVerdict string
+}
+
+// proveMusterToolsets is the request-level proof: sessions of the user
+// carrying the header an agent's runtime would send.
+func proveMusterToolsets(cfg *config.Config, token string) (*musterToolsetResults, error) {
+	out := &musterToolsetResults{}
+	k8sPrefix := "x_" + cfg.MCPServerName() + "_"
+	// The lab's mcp-kubernetes runs non-destructive, so its writers do not
+	// exist as tools; the destructive call of the proof is agent-manager's
+	// delete_agent, a platform writer annotated as such. Under the read-only
+	// toolset muster refuses it before agent-manager ever sees it.
+	listTool, deleteTool := k8sPrefix+"list", "x_"+agentManagerMCPServer+"_delete_agent"
+	deleteArgs := map[string]any{nameKey: toolsetsTestPrefix + "-nothing"}
+	queryTool, mutatingTool := "workflow_"+toolsetsWorkflowQuery, "workflow_"+toolsetsWorkflowMutating
+	demoTool := "workflow_lab-cluster-overview"
+
+	s, err := openMusterSession(cfg, token, "toolsets-test-muster")
+	if err != nil {
+		return nil, err
+	}
+
+	step("Workflows: a query-only one and one with a destructive step (core_workflow_create)")
+	for _, wf := range []map[string]any{
+		{
+			nameKey:       toolsetsWorkflowQuery,
+			"description": "agentlab toolsets-test: read-only steps only (deleted by the same run)",
+			"steps": []map[string]any{
+				{"id": "namespaces", "tool": listTool, "args": map[string]any{"resourceType": "namespaces"}, "store": true},
+			},
+		},
+		{
+			nameKey:       toolsetsWorkflowMutating,
+			"description": "agentlab toolsets-test: a destructive step, never executed (deleted by the same run)",
+			"steps": []map[string]any{
+				{"id": "namespaces", "tool": listTool, "args": map[string]any{"resourceType": "namespaces"}},
+				{"id": "purge", "tool": deleteTool, "args": deleteArgs},
+			},
+		},
+	} {
+		env, err := s.callToolEnvelope("core_workflow_create", wf)
+		if err != nil {
+			return nil, err
+		}
+		if env.IsError {
+			return nil, fmt.Errorf("core_workflow_create %s: %s", wf[nameKey], excerpt(env.Content[0].Text, 300))
+		}
+	}
+	for _, tc := range []struct {
+		tool     string
+		readOnly bool
+	}{{queryTool, true}, {mutatingTool, false}, {demoTool, true}} {
+		var desc *describeToolResponse
+		ready := waitFor(10, 2*time.Second, func() bool {
+			d, err := s.describeTool(tc.tool)
+			if err != nil {
+				return false
+			}
+			desc = d
+			return true
+		})
+		if !ready {
+			return nil, fmt.Errorf("describe_tool %s never answered after the workflow was created", tc.tool)
+		}
+		if desc.Kind != "workflow" || desc.Annotations.readOnly() != tc.readOnly {
+			return nil, fmt.Errorf("describe_tool %s: kind=%q readOnlyHint=%v, wanted workflow/%v (the derived hint)", tc.tool, desc.Kind, desc.Annotations.readOnly(), tc.readOnly)
+		}
+		note("%s: kind %s, derived readOnlyHint=%v", tc.tool, desc.Kind, tc.readOnly)
+	}
+
+	step("Unscoped catalogue (no header) and %s", presetFull)
+	unscoped, err := s.filterTools(nil)
+	if err != nil {
+		return nil, err
+	}
+	s.setHeader(toolsetHeader, presetFull)
+	full, err := s.filterTools(nil)
+	if err != nil {
+		return nil, err
+	}
+	if !slices.Equal(unscoped.names(), full.names()) {
+		return nil, fmt.Errorf("%s (%d tools) differs from the unscoped catalogue (%d tools)", presetFull, len(full.Tools), len(unscoped.Tools))
+	}
+	if !slices.Contains(unscoped.names(), deleteTool) || !slices.Contains(unscoped.names(), mutatingTool) {
+		return nil, fmt.Errorf("the unscoped catalogue lacks %s or %s — agent-manager or the workflows are not aggregated", deleteTool, mutatingTool)
+	}
+	out.fullCount = len(full.Tools)
+	note("%d tools either way", out.fullCount)
+
+	step("%s: only read-only tools, the query-only workflows included, the mutating one and core tools excluded", presetReadOnly)
+	s.setHeader(toolsetHeader, presetReadOnly)
+	ro, err := s.filterTools(nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(ro.Tools) == 0 || len(ro.Tools) >= out.fullCount {
+		return nil, fmt.Errorf("%s resolved to %d of %d tools", presetReadOnly, len(ro.Tools), out.fullCount)
+	}
+	for _, t := range ro.Tools {
+		if t.Kind == "core" || !t.Annotations.readOnly() {
+			return nil, fmt.Errorf("%s includes %s (kind %s, readOnlyHint=%v)", presetReadOnly, t.Name, t.Kind, t.Annotations.readOnly())
+		}
+	}
+	names := ro.names()
+	for _, want := range []string{listTool, queryTool, demoTool} {
+		if !slices.Contains(names, want) {
+			return nil, fmt.Errorf("%s lacks %s", presetReadOnly, want)
+		}
+	}
+	for _, unwanted := range []string{deleteTool, mutatingTool} {
+		if slices.Contains(names, unwanted) {
+			return nil, fmt.Errorf("%s includes %s", presetReadOnly, unwanted)
+		}
+	}
+	out.readOnlyCount = len(ro.Tools)
+	note("%d tools, all readOnlyHint (%d workflows, no core_*)", len(ro.Tools), countKind(ro.Tools, "workflow"))
+
+	step("Under %s: the read-only Kubernetes call succeeds, the destructive call and the mutating workflow are refused naming the toolset", presetReadOnly)
+	text, err := s.callServerTool(listTool, map[string]any{"resourceType": "namespaces"})
+	if err != nil {
+		return nil, fmt.Errorf("%s under %s: %w", listTool, presetReadOnly, err)
+	}
+	if !strings.Contains(text, platformNamespace) {
+		return nil, fmt.Errorf("%s answered without the %s namespace: %.200s", listTool, platformNamespace, text)
+	}
+	note("%s listed the namespaces", listTool)
+	for _, refused := range []struct {
+		tool string
+		args map[string]any
+	}{
+		{deleteTool, deleteArgs},
+		{mutatingTool, map[string]any{}},
+	} {
+		env, err := s.callToolEnvelope(refused.tool, refused.args)
+		if err != nil {
+			return nil, err
+		}
+		want := fmt.Sprintf("tool %q is outside the toolset [%s]", refused.tool, presetReadOnly)
+		if !env.IsError || !strings.Contains(env.Content[0].Text, want) {
+			return nil, fmt.Errorf("%s under %s: wanted the refusal %q, got isError=%v %.200s", refused.tool, presetReadOnly, want, env.IsError, env.Content[0].Text)
+		}
+		note("%s", excerpt(env.Content[0].Text, 120))
+	}
+	if _, err := s.describeTool(deleteTool); err == nil || !strings.Contains(err.Error(), "outside the toolset") {
+		return nil, fmt.Errorf("describe_tool %s under %s should say outside the toolset, got %v", deleteTool, presetReadOnly, err)
+	}
+
+	step("%s: nothing visible, everything refused", presetNone)
+	s.setHeader(toolsetHeader, presetNone)
+	none, err := s.filterTools(nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(none.Tools) != 0 {
+		return nil, fmt.Errorf("%s resolved to %d tools", presetNone, len(none.Tools))
+	}
+	env, err := s.callToolEnvelope(listTool, map[string]any{"resourceType": "namespaces"})
+	if err != nil {
+		return nil, err
+	}
+	if !env.IsError || !strings.Contains(env.Content[0].Text, "outside the toolset ["+presetNone+"]") {
+		return nil, fmt.Errorf("%s under %s was not refused: %.200s", listTool, presetNone, env.Content[0].Text)
+	}
+	note("0 tools; %s", excerpt(env.Content[0].Text, 100))
+
+	step("Header errors are error results, never a fall-back")
+	for _, tc := range []struct{ header, want string }{
+		{"preset:agentlab-no-such-preset", `unknown preset "agentlab-no-such-preset"`},
+		{"toolset:shared", "reserved"},
+		{"label:" + toolGroupLabel + "=" + toolGroupInfrastructure, "presets only"},
+	} {
+		s.setHeader(toolsetHeader, tc.header)
+		if _, err := s.filterTools(nil); err == nil || !strings.Contains(err.Error(), tc.want) {
+			return nil, fmt.Errorf("header %q: wanted an error containing %q, got %v", tc.header, tc.want, err)
+		}
+		note("%s -> %s", tc.header, tc.want)
+	}
+
+	step("Two toolsets on one token: request by request in one session, and two sessions in parallel")
+	narrow := "tool:" + listTool + ",workflow:" + toolsetsWorkflowQuery
+	narrowWant := []string{listTool, queryTool}
+	slices.Sort(narrowWant)
+	for i := 0; i < 3; i++ {
+		s.setHeader(toolsetHeader, presetReadOnly)
+		a, err := s.filterTools(nil)
+		if err != nil {
+			return nil, err
+		}
+		s.setHeader(toolsetHeader, narrow)
+		b, err := s.filterTools(nil)
+		if err != nil {
+			return nil, err
+		}
+		s.setHeader(toolsetHeader, "")
+		c, err := s.filterTools(nil)
+		if err != nil {
+			return nil, err
+		}
+		if len(a.Tools) != out.readOnlyCount || !slices.Equal(b.names(), narrowWant) || len(c.Tools) != out.fullCount {
+			return nil, fmt.Errorf("round %d: %s=%d tools (want %d), narrow=%v (want %v), unscoped=%d (want %d) — the header leaked between requests", i, presetReadOnly, len(a.Tools), out.readOnlyCount, b.names(), narrowWant, len(c.Tools), out.fullCount)
+		}
+	}
+	note("three rounds of read-only / narrow / unscoped on one session: each request got its own catalogue")
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, agent := range []struct {
+		header string
+		check  func(*filterToolsResponse) error
+	}{
+		{presetReadOnly, func(r *filterToolsResponse) error {
+			if len(r.Tools) != out.readOnlyCount || slices.Contains(r.names(), deleteTool) {
+				return fmt.Errorf("%s saw %d tools (delete: %v)", presetReadOnly, len(r.Tools), slices.Contains(r.names(), deleteTool))
+			}
+			return nil
+		}},
+		{narrow, func(r *filterToolsResponse) error {
+			if !slices.Equal(r.names(), narrowWant) {
+				return fmt.Errorf("narrow toolset saw %v", r.names())
+			}
+			return nil
+		}},
+	} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sess, err := openMusterSession(cfg, token, "toolsets-test-parallel")
+			if err != nil {
+				errs <- err
+				return
+			}
+			sess.setHeader(toolsetHeader, agent.header)
+			for i := 0; i < 5; i++ {
+				r, err := sess.filterTools(nil)
+				if err != nil {
+					errs <- err
+					return
+				}
+				if err := agent.check(r); err != nil {
+					errs <- fmt.Errorf("parallel round %d: %w", i, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		return nil, err
+	}
+	note("two sessions on the same token, five interleaved rounds each: every request saw its own toolset")
+
+	// The shipped presets, when the platform chart configured them.
+	s.setHeader(toolsetHeader, "")
+	withPresets, err := s.filterTools(map[string]any{"include_presets": true, "limit": 1})
+	if err != nil {
+		return nil, err
+	}
+	presetNames := make([]string, 0, len(withPresets.Presets))
+	for _, p := range withPresets.Presets {
+		presetNames = append(presetNames, p.Name)
+	}
+	for _, builtIn := range []string{"read-only", "none", "full"} {
+		if !slices.Contains(presetNames, builtIn) {
+			return nil, fmt.Errorf("filter_tools presets lack the built-in %s: %v", builtIn, presetNames)
+		}
+	}
+	note("presets: %s", strings.Join(presetNames, ", "))
+	if slices.Contains(presetNames, "infrastructure") && slices.Contains(presetNames, "agent-platform") {
+		step("The shipped presets resolve by the tool-group label: %s and %s", presetInfrastructure, presetAgentPlatform)
+		s.setHeader(toolsetHeader, presetInfrastructure)
+		infra, err := s.filterTools(nil)
+		if err != nil {
+			return nil, err
+		}
+		s.setHeader(toolsetHeader, presetAgentPlatform)
+		platform, err := s.filterTools(nil)
+		if err != nil {
+			return nil, err
+		}
+		s.setHeader(toolsetHeader, "")
+		labels, err := mcpServerToolGroups()
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range infra.Tools {
+			if labels[t.Server] != toolGroupInfrastructure {
+				return nil, fmt.Errorf("%s includes %s of server %q (label %q)", presetInfrastructure, t.Name, t.Server, labels[t.Server])
+			}
+		}
+		coreSeen := false
+		for _, t := range platform.Tools {
+			if t.Kind == "core" {
+				coreSeen = true
+				continue
+			}
+			if labels[t.Server] != toolGroupAgentPlatform {
+				return nil, fmt.Errorf("%s includes %s of server %q (label %q)", presetAgentPlatform, t.Name, t.Server, labels[t.Server])
+			}
+		}
+		if !coreSeen {
+			return nil, fmt.Errorf("%s lacks muster's core tools", presetAgentPlatform)
+		}
+		if labels[cfg.MCPServerName()] == toolGroupInfrastructure && !slices.Contains(infra.names(), listTool) {
+			return nil, fmt.Errorf("%s lacks %s although %s carries the infrastructure label", presetInfrastructure, listTool, cfg.MCPServerName())
+		}
+		if labels[agentManagerMCPServer] == toolGroupAgentPlatform && !slices.Contains(platform.names(), "x_"+agentManagerMCPServer+"_create_agent") {
+			return nil, fmt.Errorf("%s lacks agent-manager's tools although its CR carries the agent-platform label", presetAgentPlatform)
+		}
+		note("%s: %d tools, all from infrastructure-labelled servers; %s: %d tools, all from agent-platform-labelled servers plus core_*", presetInfrastructure, len(infra.Tools), presetAgentPlatform, len(platform.Tools))
+		out.presetsVerdict = fmt.Sprintf("the shipped presets resolve by the tool-group label: %s -> %d tools of infrastructure servers, %s -> %d tools of agent-platform servers plus core tools", presetInfrastructure, len(infra.Tools), presetAgentPlatform, len(platform.Tools))
+	}
+	return out, nil
+}
+
+func countKind(tools []toolInfo, kind string) int {
+	n := 0
+	for _, t := range tools {
+		if t.Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// mcpServerToolGroups maps every MCPServer of the platform namespace to its
+// tool-group label ("" when unlabelled).
+func mcpServerToolGroups() (map[string]string, error) {
+	out, err := outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io", "-o",
+		"jsonpath={range .items[*]}{.metadata.name}={.metadata.labels['agent-platform\\.giantswarm\\.io/tool-group']}{\"\\n\"}{end}")
+	if err != nil {
+		return nil, err
+	}
+	labels := map[string]string{}
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		if name, value, ok := strings.Cut(line, "="); ok {
+			labels[name] = value
+		}
+	}
+	return labels, nil
+}
+
+// waitAgentReady polls agent-manager's get_agent_status until the verdict is
+// ready.
+func waitAgentReady(s *musterSession, toolPrefix, name string) error {
+	var status struct {
+		Verdict string `json:"verdict"`
+		Summary string `json:"summary"`
+	}
+	ready := waitFor(60, 3*time.Second, func() bool {
+		status.Verdict, status.Summary = "", ""
+		if err := s.callServerJSON(toolPrefix+"get_agent_status", map[string]any{nameKey: name}, &status); err != nil {
+			return false
+		}
+		return status.Verdict == "ready"
+	})
+	if !ready {
+		return fmt.Errorf("%s never reached ready (last: %s — %s);\ncheck `kubectl -n %s get helmrelease,agents.kagent.dev,pods`", name, status.Verdict, status.Summary, kagentNamespace)
+	}
+	return nil
+}
+
+// a2aURL is the agent's A2A endpoint the portal's backend posts to: kagent's
+// API behind the agentgateway edge (agentPlatform.kagent.installations.*.apiBaseUrl).
+func a2aURL(cfg *config.Config, name string) string {
+	return cfg.AgentgatewayBaseURL() + "/kagent/api/a2a/" + kagentNamespace + "/" + name
+}
+
+// agentTurnAs sends one A2A message/send to an agent as the user whose Dex
+// id_token is given — the way the portal's session chat does — and returns
+// the agent's text. The Ready condition can precede the runtime listening by
+// a moment, hence the retry.
+func agentTurnAs(cfg *config.Config, name, token, prompt string) (string, error) {
+	client, err := labHTTPClient(180 * time.Second)
+	if err != nil {
+		return "", err
+	}
+	payload := fmt.Sprintf(`{"jsonrpc":"2.0","id":"1","method":"message/send","params":{"message":{"kind":"message","role":"user","messageId":%q,"parts":[{"kind":"text","text":%q}]}}}`,
+		randHex(8), prompt)
+	var reply string
+	var lastErr error
+	answered := waitFor(4, 5*time.Second, func() bool {
+		reply, lastErr = a2aSend(client, a2aURL(cfg, name), token, payload, prompt)
+		return lastErr == nil
+	})
+	if !answered {
+		return "", fmt.Errorf("A2A turn against %s failed: %w", name, lastErr)
+	}
+	return reply, nil
+}
+
+// toolListingPrompt asks an agent to report what filter_tools returns, in a
+// shape the proof can parse: one tool name per line, or NO_TOOLS.
+const toolListingPrompt = "Call your filter_tools tool exactly once with the arguments {\"limit\": 500}. " +
+	"Then reply with ONLY the tool names from its result, one per line, no other words. " +
+	"If the result has no tools, or you have no tools to call at all, reply with exactly NO_TOOLS."
+
+// toolNamesInReply extracts the tool names an agent reported.
+func toolNamesInReply(reply string) []string {
+	var names []string
+	for _, field := range strings.FieldsFunc(reply, func(r rune) bool { return r == '\n' || r == ',' || r == ' ' || r == '`' || r == '*' || r == '\t' }) {
+		// List bullets and trailing punctuation around a name, not the
+		// dashes inside one (x_mcp-kubernetes_list).
+		field = strings.Trim(field, "-.;:()[]\"'")
+		if strings.HasPrefix(field, "x_") || strings.HasPrefix(field, "workflow_") || strings.HasPrefix(field, "core_") {
+			names = append(names, field)
+		}
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}
+
+// proveAgentRuntimeToolsets is the runtime path: the agents answer real A2A
+// turns as the user, and what they report seeing is what their header
+// resolves to — so kagent sends the header and the token.
+func proveAgentRuntimeToolsets(cfg *config.Config, token, modelConfig, toolPrefix string, s *musterSession) error {
+	for _, name := range []string{toolsetsAgentReadOnly, toolsetsAgentNone} {
+		step("Waiting for %s to be ready (ModelConfig %s)", name, modelConfig)
+		if err := waitAgentReady(s, toolPrefix, name); err != nil {
+			return err
+		}
+	}
+	step("A2A turn as the user: %s reports its tools", toolsetsAgentReadOnly)
+	reply, err := agentTurnAs(cfg, toolsetsAgentReadOnly, token, toolListingPrompt)
+	if err != nil {
+		return err
+	}
+	names := toolNamesInReply(reply)
+	k8sPrefix := "x_" + cfg.MCPServerName() + "_"
+	if len(names) == 0 {
+		return fmt.Errorf("%s reported no tools (reply: %s) — the runtime did not reach muster with the user's token, or the model did not follow the instruction", toolsetsAgentReadOnly, excerpt(reply, 300))
+	}
+	if !slices.Contains(names, k8sPrefix+"list") {
+		return fmt.Errorf("%s did not report %slist among %d tools: %v", toolsetsAgentReadOnly, k8sPrefix, len(names), names)
+	}
+	writer := "x_" + agentManagerMCPServer + "_delete_agent"
+	for _, n := range names {
+		if n == writer || strings.HasPrefix(n, "core_") || n == "workflow_"+toolsetsWorkflowMutating {
+			return fmt.Errorf("%s reported %s, which is outside %s: the runtime did not send the header (names: %v)", toolsetsAgentReadOnly, n, presetReadOnly, names)
+		}
+	}
+	note("%d tools reported, %slist among them, no %s, no core_*", len(names), k8sPrefix, writer)
+
+	step("A2A turn as the user: %s (no tool entry) answers a chat turn", toolsetsAgentNone)
+	reply, err = agentTurnAs(cfg, toolsetsAgentNone, token, "Reply with exactly the word pong and nothing else.")
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(strings.ToLower(reply), "pong") {
+		return fmt.Errorf("%s answered %q, not pong", toolsetsAgentNone, excerpt(reply, 200))
+	}
+	note("answered: %s", excerpt(reply, 60))
+	return nil
+}

--- a/internal/lab/toolsetstest_portal.go
+++ b/internal/lab/toolsetstest_portal.go
@@ -1,0 +1,458 @@
+package lab
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The sign-in half of the toolset proof, and the portal half.
+
+// signInChallengeViaPortal asks the portal's muster backend for the per-server
+// sign-in challenge (POST /api/muster/auth/login — what the Sign in button of
+// the servers page and of the Tools step calls), with the session's own
+// forwarded Dex id_token, and returns the challenge URL.
+func signInChallengeViaPortal(ps *portalSession, server string) (string, error) {
+	status, raw, err := ps.musterPost("/auth/login"+installationQuery, map[string]any{"server": server})
+	if err != nil {
+		return "", err
+	}
+	if status != http.StatusOK {
+		return "", fmt.Errorf("muster /auth/login for %s FAILED %d: %.200s", server, status, raw)
+	}
+	var login struct {
+		Status  string `json:"status"`
+		AuthURL string `json:"authUrl"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(raw, &login); err != nil {
+		return "", fmt.Errorf("parsing /auth/login answer: %w\n%.200s", err, raw)
+	}
+	if login.Status != "auth_required" || login.AuthURL == "" {
+		return "", fmt.Errorf("/auth/login for %s answered status %q, not auth_required: %.300s", server, login.Status, login.Message)
+	}
+	return login.AuthURL, nil
+}
+
+// fixtureToolsFor opens a fresh MCP session with the token and the header an
+// agent declaring the fixture would send, and returns what it resolves to
+// (the tool names) and the unmatched selectors.
+func fixtureToolsFor(cfg *config.Config, token, clientName string) ([]string, []string, error) {
+	s, err := openMusterSession(cfg, token, clientName)
+	if err != nil {
+		return nil, nil, err
+	}
+	s.setHeader(toolsetHeader, toolsetFixtureSelector)
+	r, err := s.filterTools(nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	return r.names(), r.ToolsetUnmatched, nil
+}
+
+// sessionIDInChallenge decodes the muster session the challenge's state is
+// bound to (the state is base64url JSON carrying session_id, the token-derived
+// `ext-…` identifier for a forwarded bearer).
+func sessionIDInChallenge(challengeURL string) string {
+	u, err := url.Parse(challengeURL)
+	if err != nil {
+		return ""
+	}
+	state := u.Query().Get("state")
+	raw, err := base64URLDecode(state)
+	if err != nil {
+		return ""
+	}
+	var payload struct {
+		SessionID string `json:"session_id"`
+	}
+	_ = json.Unmarshal(raw, &payload)
+	return payload.SessionID
+}
+
+// proveSignInScopedToolset settles ground-truth v3's G6: a sign-in the human
+// completes in the portal is what makes that server's tools available to an
+// agent request carrying the same forwarded token — because muster keys the
+// session of a forwarded bearer by the token itself, and the portal forwards
+// one id_token to muster and to kagent alike. Proven against the lab's OAuth
+// fixture, pinned to Dex so the sign-in can complete headlessly:
+//
+//   - before any sign-in, a toolset naming the fixture resolves to nothing for
+//     everyone (toolset_unmatched names the selector);
+//   - the portal's Sign in (POST /api/muster/auth/login with the portal's own
+//     Dex id_token) yields the challenge, completed as the browser would;
+//   - an agent-shaped session on the SAME id_token then resolves the fixture's
+//     tools and can call them; the real agent, driven through kagent with that
+//     token, reports them too;
+//   - a second user without the sign-in, and even the same user under a
+//     different id_token (a fresh login), still resolve nothing — the grant is
+//     the session's, and the session is the token's (grantScope: session).
+func proveSignInScopedToolset(cfg *config.Config, user, other *config.User, toolPrefix string, admin *musterSession, opts ToolsetsTestOptions) ([]string, error) {
+	var verdicts []string
+	step("The OAuth sign-in fixture %s, pinned to Dex so the sign-in can complete", oauthFixtureServer)
+	if err := ensureOAuthFixture(cfg); err != nil {
+		return nil, err
+	}
+
+	step("Before any sign-in: %s resolves to nothing for %s and %s", toolsetFixtureSelector, user.Email, other.Email)
+	otherToken, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+		other.Email, other.Password, musterLoginScopes)
+	if err != nil {
+		return nil, err
+	}
+	ps, err := backstageLogin(cfg, user)
+	if err != nil {
+		return nil, err
+	}
+	for _, tc := range []struct {
+		who   string
+		token string
+	}{{user.Email + " (portal token)", ps.dexIDToken}, {other.Email, otherToken}} {
+		names, unmatched, err := fixtureToolsFor(cfg, tc.token, "toolsets-test-g6-before")
+		if err != nil {
+			return nil, err
+		}
+		if len(names) != 0 || !slices.Contains(unmatched, toolsetFixtureSelector) {
+			return nil, fmt.Errorf("%s resolves %s to %d tools (unmatched %v) before any sign-in — a leftover grant? run core_auth_logout for %s", tc.who, toolsetFixtureSelector, len(names), unmatched, oauthFixtureServer)
+		}
+		note("%s: 0 tools, toolset_unmatched=%v", tc.who, unmatched)
+	}
+
+	step("The portal's Sign in for %s as %s, completed headlessly", oauthFixtureServer, user.Email)
+	challenge, err := signInChallengeViaPortal(ps, oauthFixtureServer)
+	if err != nil {
+		return nil, err
+	}
+	portalSessionID := sessionIDInChallenge(challenge)
+	note("challenge bound to muster session %s (the portal's forwarded token)", portalSessionID)
+	if err := completeSignIn(challenge, user); err != nil {
+		return nil, err
+	}
+	// Leave the lab as found: the grant is the session's; muster forgets it
+	// with the sign-out (or when the token expires).
+	defer func() {
+		s, err := openMusterSession(cfg, ps.dexIDToken, "toolsets-test-g6-logout")
+		if err == nil {
+			_, _ = s.callToolEnvelope("core_auth_logout", map[string]any{"server": oauthFixtureServer})
+		}
+	}()
+	note("Dex login completed; muster's proxy callback answered Authentication Successful")
+
+	step("An agent-shaped session on the same token: %s resolves to the fixture's tools and can call them", toolsetFixtureSelector)
+	var names []string
+	resolved := waitFor(10, 2*time.Second, func() bool {
+		var unmatched []string
+		names, unmatched, err = fixtureToolsFor(cfg, ps.dexIDToken, "toolsets-test-g6-agent")
+		return err == nil && len(names) > 0 && len(unmatched) == 0
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !resolved {
+		return nil, fmt.Errorf("after the sign-in, %s still resolves to nothing on the same token", toolsetFixtureSelector)
+	}
+	for _, n := range names {
+		if !strings.HasPrefix(n, "x_"+oauthFixtureServer+"_") {
+			return nil, fmt.Errorf("%s resolved to %s, a tool of another server", toolsetFixtureSelector, n)
+		}
+	}
+	agentSession, err := openMusterSession(cfg, ps.dexIDToken, "toolsets-test-g6-call")
+	if err != nil {
+		return nil, err
+	}
+	agentSession.setHeader(toolsetHeader, toolsetFixtureSelector)
+	agentChallenge, err := agentSession.callToolEnvelope("core_auth_login", map[string]any{"server": oauthFixtureServer})
+	if err != nil {
+		return nil, err
+	}
+	if agentChallenge.IsError || agentChallenge.StructuredContent["authUrl"] != nil {
+		// core_auth_login of a server the session is signed in to answers
+		// no challenge: the two MCP sessions are one muster session.
+		if authURL, _ := agentChallenge.StructuredContent["authUrl"].(string); authURL != "" {
+			if agentSID := sessionIDInChallenge(authURL); agentSID != portalSessionID {
+				return nil, fmt.Errorf("the agent-shaped session is muster session %s, the portal's was %s — the same token gave two sessions", agentSID, portalSessionID)
+			}
+		}
+	}
+	fixtureText, err := agentSession.callServerTool("x_"+oauthFixtureServer+"_list_core_tools", nil)
+	if err != nil {
+		return nil, fmt.Errorf("calling the fixture through the agent-shaped session after the portal's sign-in: %w", err)
+	}
+	note("%d tools (%s…); x_%s_list_core_tools answered (%s)", len(names), names[0], oauthFixtureServer, excerpt(fixtureText, 60))
+	verdicts = append(verdicts, fmt.Sprintf("PASS: G6 — the sign-in completed through the portal (POST /api/muster/auth/login, muster session %s) makes %s resolve to the fixture's %d tools for an agent-shaped request on the same forwarded id_token, callable through it", portalSessionID, toolsetFixtureSelector, len(names)))
+
+	step("The same user under a different id_token, and %s without a sign-in: nothing", other.Email)
+	freshToken, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
+		user.Email, user.Password, musterLoginScopes)
+	if err != nil {
+		return nil, err
+	}
+	for _, tc := range []struct {
+		who   string
+		token string
+	}{{user.Email + " (fresh id_token)", freshToken}, {other.Email, otherToken}} {
+		names, unmatched, err := fixtureToolsFor(cfg, tc.token, "toolsets-test-g6-other")
+		if err != nil {
+			return nil, err
+		}
+		if len(names) != 0 || !slices.Contains(unmatched, toolsetFixtureSelector) {
+			return nil, fmt.Errorf("%s resolves %s to %d tools (unmatched %v) although that token never signed in", tc.who, toolsetFixtureSelector, len(names), unmatched)
+		}
+		note("%s: 0 tools, toolset_unmatched=%v", tc.who, unmatched)
+	}
+	verdicts = append(verdicts, fmt.Sprintf("PASS: G6 boundary — %s lacks the fixture's tools (toolset_unmatched names %s), and so does %s under a fresh id_token: the grant is the token-derived session's, not the person's (grantScope: session)", other.Email, toolsetFixtureSelector, user.Email))
+
+	if opts.SkipChat {
+		note("skipping the model turns (--skip-chat): the real agent's view of the fixture was not exercised")
+		return verdicts, nil
+	}
+	step("The real agent %s through kagent: as %s (the portal's token) it reports the fixture's tools, as %s none", toolsetsAgentOAuth, user.Email, other.Email)
+	if err := waitAgentReady(admin, toolPrefix, toolsetsAgentOAuth); err != nil {
+		return nil, err
+	}
+	reply, err := agentTurnAs(cfg, toolsetsAgentOAuth, ps.dexIDToken, toolListingPrompt)
+	if err != nil {
+		return nil, err
+	}
+	reported := toolNamesInReply(reply)
+	fixtureTools := 0
+	for _, n := range reported {
+		if strings.HasPrefix(n, "x_"+oauthFixtureServer+"_") {
+			fixtureTools++
+		} else {
+			return nil, fmt.Errorf("%s reported %s, outside %s", toolsetsAgentOAuth, n, toolsetFixtureSelector)
+		}
+	}
+	if fixtureTools == 0 {
+		return nil, fmt.Errorf("%s as %s reported no fixture tools (reply: %s)", toolsetsAgentOAuth, user.Email, excerpt(reply, 300))
+	}
+	note("as %s: %d fixture tools reported", user.Email, fixtureTools)
+	reply, err = agentTurnAs(cfg, toolsetsAgentOAuth, otherToken, toolListingPrompt)
+	if err != nil {
+		return nil, err
+	}
+	if reported := toolNamesInReply(reply); len(reported) != 0 {
+		return nil, fmt.Errorf("%s as %s reported %v although %s never signed in to %s", toolsetsAgentOAuth, other.Email, reported, other.Email, oauthFixtureServer)
+	}
+	note("as %s: %s", other.Email, excerpt(reply, 80))
+	verdicts = append(verdicts, fmt.Sprintf("PASS: G6 end to end — the agent %s (toolset %s), driven through kagent with the portal's token, reports the fixture's tools; driven by %s it reports none", toolsetsAgentOAuth, toolsetFixtureSelector, other.Email))
+	return verdicts, nil
+}
+
+// portalFilterTools calls the muster backend route the Tools step uses:
+// GET /api/muster/tools/filter with one toolset= entry per selector and
+// include_presets, with the portal's forwarded token.
+func portalFilterTools(ps *portalSession, toolset []string, includePresets bool) (*filterToolsResponse, error) {
+	q := url.Values{"installation": {platformRelease}, "limit": {"1000"}}
+	for _, sel := range toolset {
+		q.Add("toolset", sel)
+	}
+	if includePresets {
+		q.Set("include_presets", "true")
+	}
+	status, payload, err := ps.musterGet("/tools/filter?" + q.Encode())
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("muster /tools/filter answered %d: %.300v", status, payload)
+	}
+	// The route relays muster's result; the tool payload sits in its
+	// content[0].text like every meta-tool answer, or is already unwrapped.
+	raw, _ := json.Marshal(payload)
+	var out filterToolsResponse
+	if err := json.Unmarshal(raw, &out); err == nil && (len(out.Tools) > 0 || len(out.Presets) > 0 || len(out.ToolsetUnmatched) > 0) {
+		return &out, nil
+	}
+	if text, ok := unwrapKey(payload, "text").(string); ok {
+		if err := json.Unmarshal([]byte(text), &out); err != nil {
+			return nil, fmt.Errorf("parsing /tools/filter payload: %w\n%.300s", err, text)
+		}
+		return &out, nil
+	}
+	if errText, ok := unwrapKey(payload, "error").(string); ok {
+		return nil, fmt.Errorf("muster /tools/filter: %s", errText)
+	}
+	return &out, nil
+}
+
+// proveToolsetPortal is the portal half: the Tools step's backend calls
+// (presets, live resolution, unmatched selectors) and the composer's apply
+// path (the same scaffolder template the wizard's Deploy drives, with the
+// manifest the composer emits, the user's own OIDC token as the secret) —
+// asserted on what lands: the HelmRelease value and the Agent's header.
+func proveToolsetPortal(cfg *config.Config, user *config.User) ([]string, error) {
+	var verdicts []string
+	ps, err := backstageLogin(cfg, user)
+	if err != nil {
+		return nil, err
+	}
+	image, _ := outputQuiet("kubectl", "-n", platformNamespace, "get", "deploy", "backstage", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
+	note("portal image %s", strings.TrimSpace(image))
+
+	step("The Tools step's backend calls: presets, live resolution, unmatched selectors (/api/muster/tools/filter)")
+	presets, err := portalFilterTools(ps, nil, true)
+	if err != nil {
+		return nil, err
+	}
+	presetNames := make([]string, 0, len(presets.Presets))
+	for _, p := range presets.Presets {
+		presetNames = append(presetNames, p.Name)
+	}
+	for _, want := range []string{"read-only", "none", "full"} {
+		if !slices.Contains(presetNames, want) {
+			return nil, fmt.Errorf("/tools/filter?include_presets=true lacks the built-in preset %s: %v", want, presetNames)
+		}
+	}
+	note("presets offered: %s", strings.Join(presetNames, ", "))
+	ro, err := portalFilterTools(ps, []string{presetReadOnly}, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(ro.Tools) == 0 {
+		return nil, fmt.Errorf("/tools/filter?toolset=%s resolved to nothing", presetReadOnly)
+	}
+	for _, t := range ro.Tools {
+		if !t.Annotations.readOnly() {
+			return nil, fmt.Errorf("/tools/filter?toolset=%s includes %s without readOnlyHint", presetReadOnly, t.Name)
+		}
+	}
+	unmatched, err := portalFilterTools(ps, []string{"server:agentlab-no-such-server"}, false)
+	if err != nil {
+		return nil, err
+	}
+	if !slices.Contains(unmatched.ToolsetUnmatched, "server:agentlab-no-such-server") || len(unmatched.Tools) != 0 {
+		return nil, fmt.Errorf("/tools/filter?toolset=server:agentlab-no-such-server: tools=%d unmatched=%v", len(unmatched.Tools), unmatched.ToolsetUnmatched)
+	}
+	if _, err := portalFilterTools(ps, []string{"preset:agentlab-no-such-preset"}, false); err == nil || !strings.Contains(err.Error(), "unknown preset") {
+		return nil, fmt.Errorf("/tools/filter with an unknown preset should relay muster's error, got %v", err)
+	}
+	note("%s -> %d read-only tools; an unknown server -> toolset_unmatched; an unknown preset -> muster's error relayed", presetReadOnly, len(ro.Tools))
+	verdicts = append(verdicts, fmt.Sprintf("PASS: the Tools step's backend (/api/muster/tools/filter) offers the presets [%s], resolves %s live (%d read-only tools) and reports unmatched selectors and unknown presets as muster does", strings.Join(presetNames, ", "), presetReadOnly, len(ro.Tools)))
+
+	step("The composer's apply path: template:default/agent-deployment with the composed manifest (toolset %s) as %s", presetReadOnly, user.Email)
+	manifest := composeAgentManifest(toolsetsAgentPortal, "default-model-config", []string{presetReadOnly})
+	taskID, err := scaffold(ps, manifest, toolsetsAgentPortal)
+	if err != nil {
+		return nil, err
+	}
+	note("scaffolder task %s completed (kube:apply as %s)", taskID, user.Email)
+	toolset, set, err := helmReleaseToolset(toolsetsAgentPortal)
+	if err != nil {
+		return nil, err
+	}
+	if !set || !slices.Equal(toolset, []string{presetReadOnly}) {
+		return nil, fmt.Errorf("HelmRelease %s applied by the portal path carries values.toolset=%v (set %v), wanted [%s]", toolsetsAgentPortal, toolset, set, presetReadOnly)
+	}
+	cr, err := waitAgentCR(toolsetsAgentPortal)
+	if err != nil {
+		return nil, err
+	}
+	header, err := toolsetHeaderOf(cr)
+	if err != nil {
+		return nil, fmt.Errorf("Agent %s: %w", toolsetsAgentPortal, err)
+	}
+	if header != presetReadOnly {
+		return nil, fmt.Errorf("Agent %s carries %s=%q, wanted %s", toolsetsAgentPortal, toolsetHeader, header, presetReadOnly)
+	}
+	note("HelmRelease values.toolset %v; Agent spec.declarative.tools[0].headersFrom %s=%s", toolset, toolsetHeader, header)
+	verdicts = append(verdicts, fmt.Sprintf("PASS: the portal's apply path (scaffolder template agent-deployment, kube:apply with the user's token) lands the composer's toolset on the HelmRelease and the header on the Agent (%s)", toolsetsAgentPortal))
+	return verdicts, nil
+}
+
+// composeAgentManifest is the composer's combinedManifest for a new agent
+// (plugins/agent-platform composeManifests.ts): the shared OCIRepository of
+// the chart, then the HelmRelease with the values — `agent`, `modelConfig`
+// and the top-level `toolset` exactly as the Tools step composed it.
+func composeAgentManifest(name, modelConfig string, toolset []string) string {
+	quoted := make([]string, 0, len(toolset))
+	for _, sel := range toolset {
+		quoted = append(quoted, fmt.Sprintf("%q", sel))
+	}
+	return fmt.Sprintf(`apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: agent
+  namespace: %[1]s
+spec:
+  interval: 30m
+  url: oci://gsoci.azurecr.io/charts/giantswarm/agent
+  ref:
+    semver: x.x.x
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: %[2]s
+  namespace: %[1]s
+spec:
+  interval: 10m
+  chartRef:
+    kind: OCIRepository
+    name: agent
+    namespace: %[1]s
+  values:
+    agent:
+      name: %[2]s
+      displayName: "agentlab toolset proof: portal"
+      description: "Throwaway agent of agentlab toolsets-test, applied through the portal's deploy path; deleted by the same run."
+      systemMessage: %[3]q
+    modelConfig:
+      name: %[4]s
+    toolset: [%[5]s]
+`, kagentNamespace, name, toolsetTestAgentSystemMsg, modelConfig, strings.Join(quoted, ", "))
+}
+
+// scaffold drives the hidden agent-deployment template the wizard's Deploy
+// button drives (useDeployAgent.ts): scaffolderApi.scaffold() with the
+// manifest, the installation and the user's per-installation OIDC token as
+// the USER_OIDC_TOKEN secret, then waits for the task to complete.
+func scaffold(ps *portalSession, manifest, releaseName string) (string, error) {
+	status, raw, err := ps.backstagePostJSON("/api/scaffolder/v2/tasks", map[string]any{
+		"templateRef": "template:default/agent-deployment",
+		"values": map[string]any{
+			"manifest":              manifest,
+			"clusterName":           platformRelease,
+			"releaseName":           releaseName,
+			"namespace":             kagentNamespace,
+			"oidcTokenInstallation": platformRelease,
+		},
+		"secrets": map[string]any{"USER_OIDC_TOKEN": ps.dexIDToken},
+	})
+	if err != nil {
+		return "", err
+	}
+	if status != http.StatusCreated && status != http.StatusOK {
+		return "", fmt.Errorf("scaffolder refused the task (%d): %.300s", status, raw)
+	}
+	var task struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &task); err != nil || task.ID == "" {
+		return "", fmt.Errorf("scaffolder answered without a task id: %.200s", raw)
+	}
+	var state string
+	done := waitFor(30, 3*time.Second, func() bool {
+		_, raw, err := ps.backstageGet("/api/scaffolder/v2/tasks/" + task.ID)
+		if err != nil {
+			return false
+		}
+		var t struct {
+			Status string `json:"status"`
+		}
+		_ = json.Unmarshal(raw, &t)
+		state = t.Status
+		return state == "completed" || state == "failed" || state == "cancelled"
+	})
+	if !done || state != "completed" {
+		_, events, _ := ps.backstageGet("/api/scaffolder/v2/tasks/" + task.ID + "/events")
+		return "", fmt.Errorf("scaffolder task %s ended %q:\n%s", task.ID, state, excerpt(string(events), 600))
+	}
+	return task.ID, nil
+}

--- a/internal/lab/toolsetstest_portal.go
+++ b/internal/lab/toolsetstest_portal.go
@@ -134,13 +134,17 @@ func proveSignInScopedToolset(cfg *config.Config, user, other *config.User, tool
 	if err := completeSignIn(challenge, user); err != nil {
 		return nil, err
 	}
-	// Leave the lab as found: the grant is the session's; muster forgets it
-	// with the sign-out (or when the token expires).
+	// Leave the lab as found: the grant is the session's and the sign-out
+	// forgets it, but the pooled connection to the fixture lingers until its
+	// next use and keeps the CR at Connected — where an older binary's
+	// platform-test waits for Auth Required. A one-shot restart request on
+	// the CR (spec.restartRequestedAt) drops the connection right away.
 	defer func() {
 		s, err := openMusterSession(cfg, ps.dexIDToken, "toolsets-test-g6-logout")
 		if err == nil {
 			_, _ = s.callToolEnvelope("core_auth_logout", map[string]any{serverKey: oauthFixtureServer})
 		}
+		restartOAuthFixture()
 	}()
 	note("Dex login completed; muster's proxy callback answered Authentication Successful")
 

--- a/internal/lab/toolsetstest_portal.go
+++ b/internal/lab/toolsetstest_portal.go
@@ -19,7 +19,7 @@ import (
 // the servers page and of the Tools step calls), with the session's own
 // forwarded Dex id_token, and returns the challenge URL.
 func signInChallengeViaPortal(ps *portalSession, server string) (string, error) {
-	status, raw, err := ps.musterPost("/auth/login"+installationQuery, map[string]any{"server": server})
+	status, raw, err := ps.musterPost("/auth/login"+installationQuery, map[string]any{serverKey: server})
 	if err != nil {
 		return "", err
 	}
@@ -139,7 +139,7 @@ func proveSignInScopedToolset(cfg *config.Config, user, other *config.User, tool
 	defer func() {
 		s, err := openMusterSession(cfg, ps.dexIDToken, "toolsets-test-g6-logout")
 		if err == nil {
-			_, _ = s.callToolEnvelope("core_auth_logout", map[string]any{"server": oauthFixtureServer})
+			_, _ = s.callToolEnvelope("core_auth_logout", map[string]any{serverKey: oauthFixtureServer})
 		}
 	}()
 	note("Dex login completed; muster's proxy callback answered Authentication Successful")
@@ -167,7 +167,7 @@ func proveSignInScopedToolset(cfg *config.Config, user, other *config.User, tool
 		return nil, err
 	}
 	agentSession.setHeader(toolsetHeader, toolsetFixtureSelector)
-	agentChallenge, err := agentSession.callToolEnvelope("core_auth_login", map[string]any{"server": oauthFixtureServer})
+	agentChallenge, err := agentSession.callToolEnvelope("core_auth_login", map[string]any{serverKey: oauthFixtureServer})
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func proveToolsetPortal(cfg *config.Config, user *config.User) ([]string, error)
 	for _, p := range presets.Presets {
 		presetNames = append(presetNames, p.Name)
 	}
-	for _, want := range []string{"read-only", "none", "full"} {
+	for _, want := range []string{presetReadOnlyName, presetNoneName, presetFullName} {
 		if !slices.Contains(presetNames, want) {
 			return nil, fmt.Errorf("/tools/filter?include_presets=true lacks the built-in preset %s: %v", want, presetNames)
 		}
@@ -356,10 +356,10 @@ func proveToolsetPortal(cfg *config.Config, user *config.User) ([]string, error)
 	}
 	header, err := toolsetHeaderOf(cr)
 	if err != nil {
-		return nil, fmt.Errorf("Agent %s: %w", toolsetsAgentPortal, err)
+		return nil, fmt.Errorf("agent %s: %w", toolsetsAgentPortal, err)
 	}
 	if header != presetReadOnly {
-		return nil, fmt.Errorf("Agent %s carries %s=%q, wanted %s", toolsetsAgentPortal, toolsetHeader, header, presetReadOnly)
+		return nil, fmt.Errorf("agent %s carries %s=%q, wanted %s", toolsetsAgentPortal, toolsetHeader, header, presetReadOnly)
 	}
 	note("HelmRelease values.toolset %v; Agent spec.declarative.tools[0].headersFrom %s=%s", toolset, toolsetHeader, header)
 	verdicts = append(verdicts, fmt.Sprintf("PASS: the portal's apply path (scaffolder template agent-deployment, kube:apply with the user's token) lands the composer's toolset on the HelmRelease and the header on the Agent (%s)", toolsetsAgentPortal))
@@ -448,7 +448,7 @@ func scaffold(ps *portalSession, manifest, releaseName string) (string, error) {
 		}
 		_ = json.Unmarshal(raw, &t)
 		state = t.Status
-		return state == "completed" || state == "failed" || state == "cancelled"
+		return state == "completed" || state == taskStateFailed || state == "cancelled"
 	})
 	if !done || state != "completed" {
 		_, events, _ := ps.backstageGet("/api/scaffolder/v2/tasks/" + task.ID + "/events")

--- a/internal/lab/toolsetstest_test.go
+++ b/internal/lab/toolsetstest_test.go
@@ -1,0 +1,104 @@
+package lab
+
+import (
+	"encoding/base64"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The fixture pins Dex as its authorization server with the platform client,
+// and ships the Secret that client is read from.
+func TestOAuthFixtureRenderPinsDex(t *testing.T) {
+	cfg := config.Default()
+	out, err := renderTemplate(cfg, "oauth-fixture.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		"authorizationServer:",
+		"issuer: " + cfg.Issuer(),
+		"name: " + oauthFixtureServer + "-client",
+		"scopes: openid profile email offline_access",
+		"kind: Secret",
+		"client-id: " + config.AgentPlatformClientID,
+		"client-secret: " + config.AgentPlatformClientSecret,
+		"forwardToken: false",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("rendered fixture lacks %q:\n%s", want, s)
+		}
+	}
+}
+
+// Dex lists muster's proxy callback on the platform client, next to the
+// server-role callback and Backstage's handler.
+func TestDexRenderRegistersProxyCallback(t *testing.T) {
+	cfg := config.Default()
+	out, err := renderTemplate(cfg, "dex.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(out)
+	for _, want := range []string{
+		cfg.MusterBaseURL() + oauthProxyCallbackPath,
+		cfg.MusterBaseURL() + "/oauth/callback",
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("rendered Dex config lacks the redirect URI %q", want)
+		}
+	}
+}
+
+func TestToolNamesInReply(t *testing.T) {
+	cases := []struct {
+		reply string
+		want  []string
+	}{
+		{"x_mcp-kubernetes_list\nx_mcp-kubernetes_get\nworkflow_lab-cluster-overview", []string{"workflow_lab-cluster-overview", "x_mcp-kubernetes_get", "x_mcp-kubernetes_list"}},
+		{"Here are the tools:\n- `x_mcp-kubernetes_list`\n- `core_workflow_list`", []string{"core_workflow_list", "x_mcp-kubernetes_list"}},
+		{"x_a_b, x_a_b, x_c_d", []string{"x_a_b", "x_c_d"}},
+		{"NO_TOOLS", nil},
+		{"I have no tools available.", nil},
+	}
+	for _, tc := range cases {
+		if got := toolNamesInReply(tc.reply); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("toolNamesInReply(%q) = %v, want %v", tc.reply, got, tc.want)
+		}
+	}
+}
+
+// The composed manifest is the composer's shape: OCIRepository first, then
+// the HelmRelease with the top-level toolset value.
+func TestComposeAgentManifest(t *testing.T) {
+	m := composeAgentManifest("probe", "default-model-config", []string{presetReadOnly, "workflow:incident-triage"})
+	docs := strings.Split(m, "\n---\n")
+	if len(docs) != 2 || !strings.Contains(docs[0], "kind: OCIRepository") || !strings.Contains(docs[1], "kind: HelmRelease") {
+		t.Fatalf("wanted OCIRepository then HelmRelease, got:\n%s", m)
+	}
+	for _, want := range []string{
+		"url: oci://gsoci.azurecr.io/charts/giantswarm/agent",
+		"semver: x.x.x",
+		"name: probe\n  namespace: kagent",
+		`toolset: ["preset:read-only", "workflow:incident-triage"]`,
+		"modelConfig:\n      name: default-model-config",
+	} {
+		if !strings.Contains(m, want) {
+			t.Errorf("manifest lacks %q:\n%s", want, m)
+		}
+	}
+}
+
+func TestSessionIDInChallenge(t *testing.T) {
+	state := base64.RawURLEncoding.EncodeToString([]byte(`{"session_id":"ext-0123abcd","user_id":"u","server_name":"lab-oauth-fixture"}`))
+	got := sessionIDInChallenge("https://muster.127.0.0.1.nip.io/oauth/proxy/start?state=" + state)
+	if got != "ext-0123abcd" {
+		t.Errorf("sessionIDInChallenge = %q", got)
+	}
+	if got := sessionIDInChallenge("https://muster.127.0.0.1.nip.io/oauth/proxy/start"); got != "" {
+		t.Errorf("no state must give no session id, got %q", got)
+	}
+}

--- a/internal/lab/toolsetstest_test.go
+++ b/internal/lab/toolsetstest_test.go
@@ -104,3 +104,28 @@ func TestSessionIDInChallenge(t *testing.T) {
 		t.Errorf("no state must give no session id, got %q", got)
 	}
 }
+
+// A streamed MCP answer may carry a notification frame before the response;
+// the response frame is the one that counts.
+func TestParseMCPResponsePicksTheResponseFrame(t *testing.T) {
+	raw := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/progress\",\"params\":{\"progress\":1}}\n\n" +
+		"event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":2,\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"ok\"}]}}\n\n")
+	res, err := parseMCPResponse(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if innerText(res) != "ok" {
+		t.Fatalf("picked the wrong frame: %v", res)
+	}
+	errRaw := []byte("data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/message\",\"params\":{}}\ndata: {\"jsonrpc\":\"2.0\",\"id\":3,\"error\":{\"code\":-1,\"message\":\"boom\"}}\n")
+	res, err = parseMCPResponse(errRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := res["error"]; !ok {
+		t.Fatalf("error frame not picked: %v", res)
+	}
+	if _, err := parseMCPResponse([]byte("nothing here")); err == nil {
+		t.Fatal("garbage must fail")
+	}
+}

--- a/internal/lab/toolsetstest_test.go
+++ b/internal/lab/toolsetstest_test.go
@@ -20,7 +20,9 @@ func TestOAuthFixtureRenderPinsDex(t *testing.T) {
 	s := string(out)
 	for _, want := range []string{
 		"authorizationServer:",
-		"issuer: " + cfg.Issuer(),
+		"issuer: " + cfg.MusterBaseURL(),
+		"authorizationEndpoint: " + cfg.Issuer() + "/auth",
+		"tokenEndpoint: " + cfg.Issuer() + "/token",
 		"name: " + oauthFixtureServer + "-client",
 		"scopes: openid profile email offline_access",
 		"kind: Secret",

--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ Then:        claude mcp add --transport http muster https://muster.127.0.0.1.nip
 		platformTestCmd(),
 		modelsTestCmd(),
 		agentsTestCmd(),
+		toolsetsTestCmd(),
 		labCmd("platform-down", "Remove the agent platform (leaves Dex and the cluster alone)", lab.PlatformDown),
 		labCmd("backstage", "Retired: Backstage deploys with the platform now (backstage.enabled + `agentlab up`)", lab.BackstageUp),
 		backstageTestCmd(),
@@ -440,6 +441,29 @@ func agentsTestCmd() *cobra.Command {
 			return lab.AgentsTest(cfg, email)
 		},
 	}
+}
+
+func toolsetsTestCmd() *cobra.Command {
+	var opts lab.ToolsetsTestOptions
+	cmd := &cobra.Command{
+		Use:   "toolsets-test [email]",
+		Short: "Headless toolset proof: agent-manager requires a toolset; the Agent carries the X-Muster-Toolset header; muster resolves and refuses per request; agents through kagent see their toolset; the OAuth-fixture sign-in scopes a server's tools to the token (G6); the portal's Tools step endpoints and apply path",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			email := cfg.AdminUser().Email
+			if len(args) == 1 {
+				email = args[0]
+			}
+			return lab.ToolsetsTest(cfg, email, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.ModelConfig, "model-config", "", "the kagent ModelConfig the throwaway agents run on (default: default-model-config, the Anthropic one the lab renders from $ANTHROPIC_API_KEY)")
+	cmd.Flags().BoolVar(&opts.SkipChat, "skip-chat", false, "skip the turns that need the model to answer (the runtime path, the chat-only agent, the real agent's view of the fixture)")
+	return cmd
 }
 
 func backstageTestCmd() *cobra.Command {


### PR DESCRIPTION
Closes #79. Closes #69 (the e2e half; the fixture half shipped in #80 / v0.18.0).

## What

A new headless proof, `agentlab toolsets-test`, drives the released toolset feature end to end against the lab (muster 5.12.0, agent chart 0.6.0, agent-manager 0.4.0, backstage 0.238.0, standalone chart 0.38.0 with the fleet presets), as the admin, and leaves nothing behind:

1. **agent-manager's contract** through muster: `create_agent` without a toolset is refused naming the shipped presets and `preset:none`; the removed `toolNames` argument is refused with the explaining error; four agents are created with `preset:read-only`, `preset:none`, `preset:full`, `server:lab-oauth-fixture`.
2. **What was rendered**: `spec.declarative.tools[0].headersFrom[{X-Muster-Toolset, <selectors>}]` on each Agent CR, `values.toolset` on each HelmRelease, `get_agent` reporting the same; the `preset:none` agent has no muster tool entry at all; a HelmRelease applied without the value renders a header-less entry and `list_agents` reports `implicitFullAccess: true`.
3. **muster's resolution** under the header the runtimes send: two workflows created as the caller (query-only / with a destructive step) with the derived `readOnlyHint` on the first only; `preset:read-only` = read-only tools only incl. the query-only workflows, excluding the mutating one and `core_*`; the read-only Kubernetes call succeeds, the destructive call (agent-manager's `delete_agent` — the lab's mcp-kubernetes runs non-destructive and registers no writers) and the mutating workflow are refused with `tool "…" is outside the toolset [preset:read-only]`; `preset:none` sees and gets nothing; `preset:full` equals the unscoped catalogue; header errors (unknown preset, reserved `toolset:`, inline `label:`) are error results; two toolsets on one token, request by request and from two parallel sessions, each see their own; the shipped `infrastructure` / `agent-platform` presets resolve by the tool-group label (skipped with a note when a muster has none).
4. **The runtime path** (`--skip-chat` to skip): through kagent's A2A endpoint behind the edge, as the user, the read-only agent lists read-only tools only and the `preset:none` agent answers a chat turn.
5. **Ground-truth G6**: before any sign-in `server:lab-oauth-fixture` resolves to nothing for everyone (`toolset_unmatched`); the portal's Sign in (`POST /api/muster/auth/login` with the portal's forwarded Dex id_token) yields the challenge, completed headlessly; an agent-shaped session on the **same** id_token then resolves the fixture's tools and calls one, and the real agent driven through kagent with that token reports them; a second user and the same user under a fresh id_token still resolve nothing.
6. **The portal**: the Tools step's backend calls (`/api/muster/tools/filter` with `include_presets`, a `toolset=` resolution, unmatched selectors, an unknown preset relayed) and the composer's apply path (the hidden `agent-deployment` scaffolder template with the composer's manifest and the user's OIDC token) landing `toolset` on the HelmRelease and the header on the Agent.

`agentlab backstage-test` gains the #69 e2e half: the MCP servers page's three groups, asserted from the data the page reads (the MCPServer CRs through Backstage's Kubernetes proxy, as the user) with the released plugin's grouping arithmetic ported to Go — fake-fleet families under Infrastructure, `lab-oauth-fixture` under Registered servers, chart-labelled servers under their group — and the fallback with every label removed (one Registered servers list, all sections present).

`agentlab agents-test` declares `preset:read-only` and asserts the refusal without one (agent-manager ≥ 0.4.0 refuses a create without a toolset; the proof was failing on the lab since the 0.4.0 roll).

## Why the OAuth fixture now pins Dex

The fixture's sign-in could never complete in the lab: discovery names muster's own OAuth 2.1 server, which identifies muster-as-client by Client ID Metadata Document, and mcp-oauth's SSRF guards refuse every lab hostname (the metadata URL resolves to the edge's cluster IP in-cluster; a DCR redirect URI is refused by the DNS-rebinding check). muster exposes none of the knobs (`AllowPrivateIPClientMetadata`, `DisableDNSValidation`, `AllowPrivateIPRedirectURIs`). The CR now pins the lab Dex via `spec.auth.authorizationServer` (issuer, `clientCredentialsSecretRef` → Secret `lab-oauth-fixture-client` with the platform client, `scopes`), and `dex.yaml.tmpl` registers muster's proxy callback on that client. `platform-test`'s challenge assertions hold (client id via `preregistered`, redirect to Dex's authorization endpoint). HACKS.md U18 documents it. A running lab needs `agentlab reload` once for the Dex change; `agentlab platform` (or `toolsets-test` itself) re-applies the pinned fixture.

## Lab evidence

Lab 2026-09-07 (muster 5.12.0, agent chart 0.6.0, agent-manager 0.4.0, model-manager 0.18.0, backstage 0.239.0, standalone chart 0.38.0 with the fleet presets), `agentlab toolsets-test` as admin@lab.local, 47 min wall clock, exit 0:

```
PASS: agent-manager refuses create_agent without a toolset (naming the presets and preset:none), refuses toolNames, and accepts a toolset
PASS: agentlab-toolset-ro carries headersFrom X-Muster-Toolset=preset:read-only on spec.declarative.tools[0] and toolset on its HelmRelease; agentlab-toolset-none has no muster tool entry; an agent without a toolset reports implicitFullAccess
PASS: preset:read-only resolves to 44 read-only tools incl. the query-only workflows workflow_agentlab-toolset-query and workflow_lab-cluster-overview, not workflow_agentlab-toolset-mutating or core tools; the read-only Kubernetes call succeeds and the destructive call (x_agent-manager_delete_agent) is refused naming the toolset
PASS: two toolsets on one token — in one session request by request and from two sessions in parallel — each see their own tools; preset:none sees nothing; preset:full equals the unscoped catalogue (84 tools) like an agent without a toolset
PASS: the shipped presets resolve by the tool-group label: preset:infrastructure -> 6 tools of infrastructure servers, preset:agent-platform -> 57 tools of agent-platform servers plus core tools
PASS: through kagent (A2A as admin@lab.local) agentlab-toolset-ro lists read-only tools only — the runtime sends the header and the user's token — and agentlab-toolset-none answers a chat turn with no tool entry
PASS: G6 — the sign-in completed through the portal (POST /api/muster/auth/login, muster session ext-241512b358fa8be1) makes server:lab-oauth-fixture resolve to the fixture's 13 tools for an agent-shaped request on the same forwarded id_token, callable through it
PASS: G6 boundary — dev@lab.local lacks the fixture's tools (toolset_unmatched names server:lab-oauth-fixture), and so does admin@lab.local under a fresh id_token: the grant is the token-derived session's, not the person's (grantScope: session)
PASS: G6 end to end — the agent agentlab-toolset-oauth (toolset server:lab-oauth-fixture), driven through kagent with the portal's token, reports the fixture's tools; driven by dev@lab.local it reports none
PASS: the Tools step's backend (/api/muster/tools/filter) offers the presets [read-only, none, full, agent-platform, infrastructure], resolves preset:read-only live (44 read-only tools) and reports unmatched selectors and unknown presets as muster does
PASS: the portal's apply path (scaffolder template agent-deployment, kube:apply with the user's token) lands the composer's toolset on the HelmRelease and the header on the Agent (agentlab-toolset-portal)
```

`agentlab backstage-test` (the #69 half):

```
  MCP servers page groups (11 CRs via /api/kubernetes/proxy):
    Agent Platform      2 rows: agent-manager, model-manager
    Infrastructure      4 rows: capi, kubernetes, prometheus, mcp-kubernetes
    Registered servers  2 rows: lab-oauth-fixture, mcp-prometheus
  fallback without any agent-platform.giantswarm.io/tool-group label: 8 rows, all under Registered servers; 9 of 11 CRs carry the label today
```

`agentlab platform-test` and `agentlab agents-test` green with the branch binary; unit tests, `go vet`, `pre-commit run --all-files` green.

Note for a running lab: the Dex client change needs one `agentlab reload` (done on the shared lab); an `agentlab platform` run with a binary older than this PR re-applies the un-pinned fixture — `toolsets-test` re-pins it itself, and `platform-test` accepts both challenge shapes.

