### PR TITLE
docs(lab): the OAuth fixture's issuer comment after muster#1174/#1175

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -410,11 +410,13 @@ the lab:** the CR pins the lab Dex through `spec.auth.authorizationServer`
 (Dex's `authorizationEndpoint`/`tokenEndpoint`, `clientCredentialsSecretRef` →
 the platform client's id/secret in the Secret `lab-oauth-fixture-client`,
 `scopes` — a pinned server gets no default scope and Dex refuses a request
-without `openid` — and as `issuer` muster's own public URL: the grant is filed
-under the issuer the endpoint's RFC 9728 metadata names, which is also the key
-the connection looks it up under; a pin naming Dex's URL as the issuer
-completes the sign-in but every call then fails with "no valid token
-available" — worth a muster issue, the CRD text does not say so), and `dex.yaml.tmpl` lists
+without `openid` — and as `issuer` muster's own public URL, so the grant's
+token-store key stays apart from muster's own login issuer (Dex) and a
+`core_auth_logout` clears it; a pin naming Dex's URL as the issuer works since
+muster 5.12.1 (muster#1174, muster#1175: the grant key follows the pin and a
+changed pin takes effect without a restart) but leaves the grant behind on
+logout, which would make the next run's sign-in proof reconnect without a
+challenge), and `dex.yaml.tmpl` lists
 muster's proxy callback on that client. Dex matches redirect URIs exactly and
 the token it issues carries the platform client's audience, which the endpoint
 trusts, so `agentlab toolsets-test` completes the sign-in headlessly. Unblocks

--- a/internal/lab/templates/oauth-fixture.yaml.tmpl
+++ b/internal/lab/templates/oauth-fixture.yaml.tmpl
@@ -59,12 +59,15 @@ spec:
     # platform client's audience, which the endpoint trusts -- so the sign-in
     # completes and the fixture connects, as `agentlab toolsets-test` proves.
     #
-    # The issuer is the identity the grant is filed under, not where the
-    # browser goes: it must be the authorization server the endpoint's own
-    # RFC 9728 metadata names (muster's public URL), because that is the key
-    # muster looks the session's token up under when it calls the server.
-    # Pinning Dex's URL as the issuer completes the sign-in but files the
-    # grant where no call finds it ("no valid token available").
+    # The issuer is the authorization server the sign-in runs against and the
+    # key the grant is filed under; since muster 5.12.1 (muster#1174) it may
+    # differ from the one the endpoint's RFC 9728 metadata names, and it may
+    # be muster's own IdP. This fixture keeps muster's public URL as the
+    # issuer with Dex's endpoints (the GitHub shape) on purpose: a grant
+    # under Dex's issuer would share muster's own login issuer, and
+    # core_auth_logout leaves grants of a shared issuer in place -- the next
+    # run's sign-in would then reconnect without a challenge and the
+    # per-server sign-in proof would have nothing to complete.
     authorizationServer:
       issuer: {{ .MusterBaseURL }}
       authorizationEndpoint: {{ .Issuer }}/auth


### PR DESCRIPTION
muster 5.12.1 (giantswarm/muster#1177) made a pinned `spec.auth.authorizationServer.issuer` the one key of a server's grants, so the fixture template's and HACKS U18's claim that a Dex-issuer pin "completes the sign-in but every call fails" is no longer true. The fixture stays on muster's public URL as issuer with Dex's endpoints on purpose: a grant under Dex's issuer would share muster's own login issuer, where `core_auth_logout` leaves the grant in place and the next run's sign-in proof would reconnect without a challenge. Comments only, no behaviour change.