### PR TITLE
feat(up): refuse to boot on a docker too small for the lab, with the fix

### DIFF
--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -25,6 +25,13 @@ func note(format string, a ...any) {
 	fmt.Printf("    "+format+"\n", a...)
 }
 
+// warn prints a loud, indented warning on stderr — for a check that found
+// something the boot goes on despite (the runtime's memory below what the
+// lab really uses), as opposed to a note, which is informational.
+func warn(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "    WARNING: "+format+"\n", a...)
+}
+
 // The two tools whose cluster is pinned by command; every other subprocess
 // (kind, docker, git, helm's plugins) inherits the environment untouched.
 const (

--- a/internal/lab/resources.go
+++ b/internal/lab/resources.go
@@ -1,0 +1,430 @@
+package lab
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The lab runs the whole platform on ONE kind node, and the kube-scheduler
+// refuses a pod whose CPU request does not fit that node. Nothing degrades:
+// a docker VM with two CPUs leaves agentgateway (100m) Pending forever, and
+// the platform install waits on a workload that will never start until helm
+// gives up; with the platform up but the node full, models-test gets as far
+// as the agent turn and fails there, because the agent's own pod cannot be
+// scheduled. Nothing along the way says "out of CPU". preflightRuntimeResources
+// asks the container runtime what it has BEFORE any cluster work and refuses
+// (CPU, a hard limit) or warns (memory, a soft one) with the fix — in the
+// spirit of ensureHelmSupportsPlatform and preflightHostServer: a host-side
+// shortfall fails here, with its remedy, not after a five-minute boot and a
+// ten-minute helm wait.
+//
+// The figures below are the requests `kubectl describe node` reports for each
+// group of pods, measured on a live full default lab (agents, observability,
+// Backstage, model-manager) on 2026-09-08: 2540m / 2532Mi allocated in total.
+// README "### Docker resources" is the human copy of these constants — its
+// table lists the same groups — so a change here is a change there.
+
+// resourceRequests is what a group of pods asks the scheduler for: CPU in
+// millicores, memory in MiB — the units describe node uses.
+type resourceRequests struct {
+	CPU int
+	Mem int
+}
+
+// add returns the sum of two request pairs.
+func (r resourceRequests) add(o resourceRequests) resourceRequests {
+	return resourceRequests{r.CPU + o.CPU, r.Mem + o.Mem}
+}
+
+// resourceGroup is one group of pods the lab may schedule, with what it
+// requests and the configuration that installs it.
+type resourceGroup struct {
+	Name     string
+	Requests resourceRequests
+	Enabled  func(*config.Config) bool
+}
+
+// The request figures, one constant per group (see the package comment for
+// where they were measured).
+const (
+	// kind's static pods: kube-apiserver 250m, controller-manager 200m,
+	// scheduler 100m, etcd 100m/100Mi, kindnet 100m/50Mi, two CoreDNS at
+	// 100m/70Mi. Always there — it is the node.
+	reqKindControlPlaneCPU = 950
+	reqKindControlPlaneMem = 290
+	// The lab's own Dex. Always deployed by Up.
+	reqDexCPU = 50
+	reqDexMem = 64
+	// The umbrella chart without its optional parts: muster 100m/128Mi and
+	// its valkey 150m/192Mi, agentgateway 100m/128Mi and its controller
+	// 50m/128Mi, mcp-kubernetes 105m/144Mi, agent-manager 55m/80Mi.
+	reqPlatformCoreCPU = 510
+	reqPlatformCoreMem = 736
+	// The agents runtime: kagent controller 100m/128Mi, UI 100m/256Mi, its
+	// bundled PostgreSQL 250m/256Mi.
+	reqAgentsRuntimeCPU = 450
+	reqAgentsRuntimeMem = 640
+	// model-manager in front of the host model servers.
+	reqModelManagerCPU = 55
+	reqModelManagerMem = 80
+	// Backstage requests almost nothing and uses several times its 250Mi;
+	// the memory floor below accounts for that with a factor, not here.
+	reqBackstageCPU = 20
+	reqBackstageMem = 250
+	// Flux source-controller + helm-controller at 100m/64Mi each: installed
+	// by the Backstage step when agents are on (platformUp/fluxUp) — the
+	// agent create flow's delivery engine.
+	reqFluxCPU = 200
+	reqFluxMem = 128
+	// observability: kube-state-metrics 200m/200Mi, mcp-prometheus
+	// 105m/144Mi. The Prometheus server, the operator and node-exporter
+	// declare no requests at all, which is one reason real memory use runs
+	// so far above this column.
+	reqObservabilityCPU = 305
+	reqObservabilityMem = 344
+
+	// runtimeHeadroomCPU is what the CPU floor keeps free beyond the
+	// requests for the pods the platform creates AFTER the boot: every kagent
+	// agent is one more pod, and models-test and agents-test each create one.
+	// Six of them at the 100m the platform's own small pods request; without
+	// this room a lab that boots fine cannot run a single agent.
+	runtimeHeadroomCPU = 600
+
+	// memRealUseFactor is how far real memory use runs above the requests
+	// column on a live lab: about twice (README "Docker resources" — a
+	// platform+agents node sat at 2.4 GiB of real use against 1.8 GiB of
+	// requests, and the full lab's Backstage and Prometheus use several
+	// times what they declare). The memory floor is the requests times this.
+	memRealUseFactor = 2
+)
+
+// labResourceGroups lists every group in boot order, gated the way Up and
+// platformUp install them. Groups that hang off the platform are inert when
+// the platform itself is disabled, like their config fields.
+var labResourceGroups = []resourceGroup{
+	{"kind control plane", resourceRequests{reqKindControlPlaneCPU, reqKindControlPlaneMem},
+		func(*config.Config) bool { return true }},
+	{"Dex", resourceRequests{reqDexCPU, reqDexMem},
+		func(*config.Config) bool { return true }},
+	{"agent platform", resourceRequests{reqPlatformCoreCPU, reqPlatformCoreMem},
+		func(c *config.Config) bool { return c.Platform.Enabled }},
+	{"agents runtime", resourceRequests{reqAgentsRuntimeCPU, reqAgentsRuntimeMem},
+		func(c *config.Config) bool { return c.Platform.Enabled && c.Platform.Agents }},
+	{"model-manager", resourceRequests{reqModelManagerCPU, reqModelManagerMem},
+		func(c *config.Config) bool { return c.ModelManagerEnabled() }},
+	{"Backstage", resourceRequests{reqBackstageCPU, reqBackstageMem},
+		func(c *config.Config) bool { return c.Platform.Enabled && c.Backstage.Enabled }},
+	{"Flux", resourceRequests{reqFluxCPU, reqFluxMem},
+		func(c *config.Config) bool { return c.Platform.Enabled && c.Backstage.Enabled && c.Platform.Agents }},
+	{"observability", resourceRequests{reqObservabilityCPU, reqObservabilityMem},
+		func(c *config.Config) bool { return c.Platform.Enabled && c.Platform.Observability }},
+}
+
+// resourceNeeds is what one configuration asks of the container runtime.
+type resourceNeeds struct {
+	// Requests is the sum over the enabled groups: what the boot schedules.
+	Requests resourceRequests
+	// Groups names the enabled groups with their requests, for the
+	// breakdown a refusal prints.
+	Groups []resourceGroup
+	// MinCPUs is the hard floor: the requests plus the run-time headroom,
+	// rounded up to whole CPUs — the unit docker is given them in, and the
+	// node's allocatable CPU is exactly the runtime's count.
+	MinCPUs int
+	// MinMemMiB is the soft floor: the requests times memRealUseFactor.
+	// Below Requests.Mem the pods do not even schedule; between the two
+	// they schedule and then get evicted or OOM-killed under real use.
+	MinMemMiB int
+}
+
+// labResourceNeeds computes what cfg asks of the runtime from the enabled
+// groups — never one hard-coded number, so a lab without Backstage and
+// observability is held to its own, smaller floor.
+func labResourceNeeds(cfg *config.Config) resourceNeeds {
+	var n resourceNeeds
+	for _, g := range labResourceGroups {
+		if !g.Enabled(cfg) {
+			continue
+		}
+		n.Groups = append(n.Groups, g)
+		n.Requests = n.Requests.add(g.Requests)
+	}
+	n.MinCPUs = ceilCPUs(n.Requests.CPU + runtimeHeadroomCPU)
+	n.MinMemMiB = n.Requests.Mem * memRealUseFactor
+	return n
+}
+
+// ceilCPUs rounds millicores up to whole CPUs.
+func ceilCPUs(millicores int) int {
+	return (millicores + 999) / 1000
+}
+
+// smallerLabFlags is the configuration a refused boot is pointed at: the
+// platform and its agents without Backstage and observability — the README's
+// "platform + agents only" row. Empty when cfg is already that (or smaller),
+// so the message never suggests a change that changes nothing.
+func smallerLabFlags(cfg *config.Config) string {
+	if !cfg.Platform.Enabled || (!cfg.Backstage.Enabled && !cfg.Platform.Observability) {
+		return ""
+	}
+	return "agentlab configure --backstage=false --observability=false"
+}
+
+// smallerLab is cfg with Backstage and observability off — what
+// smallerLabFlags configures — for quoting its floor next to the flags.
+func smallerLab(cfg *config.Config) *config.Config {
+	c := *cfg
+	c.Backstage.Enabled = false
+	c.Platform.Observability = false
+	return &c
+}
+
+// runtimeResources asks the container runtime behind `docker` for its CPU
+// count and total memory in bytes — the VM's under Docker Desktop, Colima or
+// a podman machine, the host's own under a native engine. Docker's `info`
+// document has them at the top level (NCPU, MemTotal); podman's
+// docker-compatible CLI answers `docker info` with podman's own document,
+// where they live under Host (CPUs, MemTotal), and each engine's template
+// engine errors on the other's field names. The engine's shape is tried
+// first (dockerIsPodman), the other one second — a docker CLI in front of a
+// podman API socket, and any future divergence, still get an answer.
+func runtimeResources() (int, int64, error) {
+	templates := []string{dockerInfoResourcesTemplate, podmanInfoResourcesTemplate}
+	if dockerIsPodman() {
+		templates[0], templates[1] = templates[1], templates[0]
+	}
+	var firstErr error
+	for _, tmpl := range templates {
+		out, probeErr := outputQuiet("docker", "info", "--format", tmpl)
+		if probeErr == nil {
+			cpus, memBytes, parseErr := parseRuntimeResources(out)
+			if parseErr == nil {
+				return cpus, memBytes, nil
+			}
+			probeErr = parseErr
+		}
+		if firstErr == nil {
+			firstErr = probeErr
+		}
+	}
+	return 0, 0, firstErr
+}
+
+// The two `docker info --format` templates for CPU count and memory bytes.
+const (
+	dockerInfoResourcesTemplate = "{{.NCPU}} {{.MemTotal}}"
+	podmanInfoResourcesTemplate = "{{.Host.CPUs}} {{.Host.MemTotal}}"
+)
+
+// parseRuntimeResources reads the two fields the templates above print:
+// "24 92417925120". Anything else — a template that hit the wrong engine
+// ("<no value> <no value>"), an empty answer, a zero — is an error, and the
+// caller degrades to a warning: an unreadable runtime is not a small one.
+func parseRuntimeResources(out string) (cpus int, memBytes int64, err error) {
+	fields := strings.Fields(out)
+	if len(fields) != 2 {
+		return 0, 0, fmt.Errorf("unexpected `docker info` answer %q, want \"<cpus> <memory bytes>\"", strings.TrimSpace(out))
+	}
+	cpus, err = strconv.Atoi(fields[0])
+	if err != nil || cpus <= 0 {
+		return 0, 0, fmt.Errorf("unexpected CPU count %q in `docker info` answer", fields[0])
+	}
+	memBytes, err = strconv.ParseInt(fields[1], 10, 64)
+	if err != nil || memBytes <= 0 {
+		return 0, 0, fmt.Errorf("unexpected memory total %q in `docker info` answer", fields[1])
+	}
+	return cpus, memBytes, nil
+}
+
+// runtimeMeasure is what the probe found, plus where it found it: which
+// engine, on which OS, with how many CPUs the host itself has — the facts
+// the fix text is built from.
+type runtimeMeasure struct {
+	CPUs     int
+	MemMiB   int
+	Podman   bool
+	GOOS     string
+	HostCPUs int
+}
+
+// engine names the runtime the way the user knows it.
+func (m runtimeMeasure) engine() string {
+	if m.Podman {
+		return "podman"
+	}
+	return "docker"
+}
+
+// onHost reports whether the runtime IS this machine — a native engine on
+// Linux (docker's daemon, or rootless podman running the containers in the
+// user's own namespaces) — rather than a VM the user can resize. A VM on a
+// Linux host with exactly the host's CPU count is misread as native, which
+// only costs the resize hints; the smaller-lab alternative is always printed.
+func (m runtimeMeasure) onHost() bool {
+	return m.GOOS == "linux" && m.CPUs == m.HostCPUs
+}
+
+// judgeRuntimeResources compares what the runtime has with what the lab
+// needs: an error below the CPU floor or below the memory requests (neither
+// schedules), a warning between the memory requests and the memory floor
+// (schedules, then starves), and otherwise a note only when the run-time
+// pods have less than one CPU to themselves. Pure, so every branch is
+// unit-tested without a container runtime.
+func judgeRuntimeResources(m runtimeMeasure, cfg *config.Config, needs resourceNeeds) (warning string, err error) {
+	if m.CPUs < needs.MinCPUs {
+		return "", fmt.Errorf("%s has %d CPUs; this lab configuration needs %d.\n"+
+			"  Its pods request %s CPUs of the single kind node, plus room for the pods the\n"+
+			"  platform creates at run time, and the kube-scheduler refuses a pod whose CPU\n"+
+			"  request does not fit: the boot would wait on an agentgateway that stays\n"+
+			"  Pending forever (README \"Docker resources\"). The requests:\n%s\n%s",
+			m.engine(), m.CPUs, needs.MinCPUs, fmtCPUs(needs.Requests.CPU),
+			wrap(requestsBreakdown(needs), 84, "    "), resourceFixes(m, cfg, needs))
+	}
+	if m.MemMiB < needs.Requests.Mem {
+		return "", fmt.Errorf("%s has %s of memory; this lab configuration needs %s.\n"+
+			"  Its pods request %s of the single kind node, which does not fit, so they do not\n"+
+			"  even all schedule — and real use runs about %dx the requests (README \"Docker resources\").\n%s",
+			m.engine(), fmtGiB(m.MemMiB), fmtGiB(needs.MinMemMiB), fmtGiB(needs.Requests.Mem),
+			memRealUseFactor, resourceFixes(m, cfg, needs))
+	}
+	if m.MemMiB < needs.MinMemMiB {
+		warning = fmt.Sprintf("%s has %s of memory; this lab configuration wants %s.\n"+
+			"    Its pods request only %s, so they schedule — but real use runs about %dx the requests\n"+
+			"    (Backstage and Prometheus use several times what they declare): expect evictions\n"+
+			"    and OOM kills under load (README \"Docker resources\").\n%s",
+			m.engine(), fmtGiB(m.MemMiB), fmtGiB(needs.MinMemMiB), fmtGiB(needs.Requests.Mem), memRealUseFactor,
+			indent(resourceFixes(m, cfg, needs), "  "))
+	}
+	return warning, nil
+}
+
+// requestsBreakdown lists the enabled groups with their CPU requests, so a
+// refusal shows where the number comes from: "kind control plane 0.95, Dex
+// 0.05, agent platform 0.51, ...". The names are the README table's rows.
+func requestsBreakdown(needs resourceNeeds) string {
+	parts := make([]string, 0, len(needs.Groups))
+	for _, g := range needs.Groups {
+		parts = append(parts, g.Name+" "+fmtCPUs(g.Requests.CPU))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// resourceFixes is the "what to change" tail of a refusal or warning: the
+// resize step for the runtime the user has, and the smaller lab that fits.
+func resourceFixes(m runtimeMeasure, cfg *config.Config, needs resourceNeeds) string {
+	var b strings.Builder
+	cpus, memGiB := needs.MinCPUs, ceilGiB(needs.MinMemMiB)
+	switch {
+	case m.onHost() && m.Podman:
+		fmt.Fprintf(&b, "  Rootless Podman on Linux runs the containers on this machine itself, so there is\n"+
+			"  no VM to resize: this host has %d CPUs and %s of memory.\n", m.HostCPUs, fmtGiB(m.MemMiB))
+	case m.onHost():
+		fmt.Fprintf(&b, "  docker here is the host's own engine, so there is no VM to resize: this machine\n"+
+			"  has %d CPUs and %s of memory.\n", m.HostCPUs, fmtGiB(m.MemMiB))
+	default:
+		fmt.Fprintf(&b, "  Give %s %d CPUs and %d GiB of memory:\n", m.engine(), cpus, memGiB)
+		if m.Podman {
+			fmt.Fprintf(&b, "  - podman machine: podman machine set --cpus %d --memory %d, then podman machine stop && podman machine start\n", cpus, memGiB*1024)
+		} else {
+			fmt.Fprintf(&b, "  - Docker Desktop: Settings -> Resources -> CPUs / Memory\n")
+			fmt.Fprintf(&b, "  - Colima:         colima stop && colima start --cpu %d --memory %d\n", cpus, memGiB)
+		}
+	}
+	if flags := smallerLabFlags(cfg); flags != "" {
+		small := labResourceNeeds(smallerLab(cfg))
+		fmt.Fprintf(&b, "  Or run the smaller lab, the platform and its agents without Backstage and observability\n"+
+			"  (needs %d CPUs and %s):  %s", small.MinCPUs, fmtGiB(small.MinMemMiB), flags)
+	} else {
+		b.WriteString("  This is already the smaller lab (no Backstage, no observability); it needs a bigger machine.")
+	}
+	return b.String()
+}
+
+// preflightRuntimeResources is the boot's second check, after the Helm
+// version and before any cluster work: what the container runtime has
+// against what this configuration schedules. The measured values and the
+// requests print on every boot, so the numbers are in every boot log. A
+// probe that fails (no docker on PATH is caught later by kind, with its own
+// message; an engine answering something unexpected) degrades to a note and
+// lets the boot go on — an unreadable runtime is not a small one.
+func preflightRuntimeResources(cfg *config.Config) error {
+	needs := labResourceNeeds(cfg)
+	step("Checking the container runtime's CPUs and memory against this lab's requests")
+	cpus, memBytes, err := runtimeResources()
+	if err != nil {
+		note("could not read them (%v); going on. This lab requests %s CPUs / %s and needs %d CPUs / %s (README \"Docker resources\")",
+			err, fmtCPUs(needs.Requests.CPU), fmtGiB(needs.Requests.Mem), needs.MinCPUs, fmtGiB(needs.MinMemMiB))
+		return nil
+	}
+	m := runtimeMeasure{
+		CPUs:     cpus,
+		MemMiB:   int(memBytes / (1024 * 1024)),
+		Podman:   dockerIsPodman(),
+		GOOS:     runtime.GOOS,
+		HostCPUs: runtime.NumCPU(),
+	}
+	note("%s: %d CPUs, %s memory; the lab requests %s CPUs / %s and needs %d CPUs / %s",
+		m.engine(), m.CPUs, fmtGiB(m.MemMiB), fmtCPUs(needs.Requests.CPU), fmtGiB(needs.Requests.Mem), needs.MinCPUs, fmtGiB(needs.MinMemMiB))
+	warning, err := judgeRuntimeResources(m, cfg, needs)
+	if err != nil {
+		return err
+	}
+	if warning != "" {
+		warn("%s", warning)
+	}
+	// Above the floor but with less than a CPU for the run-time pods: say so,
+	// so a models-test that later fails at the agent turn has its cause on
+	// record in the boot log.
+	if spare := m.CPUs*1000 - needs.Requests.CPU; spare < 1000 {
+		note("tight: %s CPUs left for the pods the platform creates at run time (every kagent agent is one; models-test and agents-test create one each)", fmtCPUs(spare))
+	}
+	return nil
+}
+
+// fmtCPUs prints millicores as CPUs with two decimals, rounding half up in
+// integers (305m is "0.31", which float formatting would make "0.30"):
+// 2540 -> "2.54".
+func fmtCPUs(millicores int) string {
+	hundredths := (millicores + 5) / 10
+	return fmt.Sprintf("%d.%02d", hundredths/100, hundredths%100)
+}
+
+// fmtGiB prints MiB as GiB with one decimal, rounding half up in integers:
+// 2532 -> "2.5 GiB".
+func fmtGiB(mib int) string {
+	tenths := (mib*10 + 512) / 1024
+	return fmt.Sprintf("%d.%d GiB", tenths/10, tenths%10)
+}
+
+// wrap breaks text at spaces into lines of at most width characters, each
+// prefixed with indent — for the group breakdown, which is one long clause.
+func wrap(text string, width int, indent string) string {
+	var b strings.Builder
+	line := indent
+	for _, word := range strings.Fields(text) {
+		if len(line) > len(indent) && len(line)+1+len(word) > width {
+			b.WriteString(line + "\n")
+			line = indent
+		}
+		if len(line) > len(indent) {
+			line += " "
+		}
+		line += word
+	}
+	b.WriteString(line)
+	return b.String()
+}
+
+// ceilGiB rounds MiB up to whole GiB — the unit the resize commands take.
+func ceilGiB(mib int) int {
+	return (mib + 1023) / 1024
+}
+
+// indent prefixes every line of s.
+func indent(s, prefix string) string {
+	return prefix + strings.ReplaceAll(s, "\n", "\n"+prefix)
+}

--- a/internal/lab/resources_test.go
+++ b/internal/lab/resources_test.go
@@ -1,0 +1,315 @@
+package lab
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// Nothing in this file touches a container runtime: the probe is split into
+// the shell-out (runtimeResources, untested here) and the parsing and
+// arithmetic below, which is where the decisions are.
+
+// Both engines' `info` templates print "<cpus> <memory bytes>"; everything
+// else — the other engine's template hitting missing fields, an empty
+// answer, garbage, zeros — must be an error, which the preflight turns into
+// a note rather than a refusal.
+func TestParseRuntimeResources(t *testing.T) {
+	for name, tc := range map[string]struct {
+		out     string
+		cpus    int
+		mem     int64
+		wantErr bool
+	}{
+		"docker":                       {out: "24 92417925120\n", cpus: 24, mem: 92417925120},
+		"podman machine":               {out: "4 8589934592", cpus: 4, mem: 8589934592},
+		"two cpus two gib":             {out: "2 2147483648\n", cpus: 2, mem: 2147483648},
+		"template hit the wrong shape": {out: "<no value> <no value>\n", wantErr: true},
+		"empty":                        {out: "", wantErr: true},
+		"whitespace only":              {out: "  \n", wantErr: true},
+		"one field":                    {out: "24\n", wantErr: true},
+		"three fields":                 {out: "24 92417925120 extra", wantErr: true},
+		"garbage":                      {out: "Cannot connect to the Docker daemon", wantErr: true},
+		"zero cpus":                    {out: "0 92417925120", wantErr: true},
+		"zero memory":                  {out: "24 0", wantErr: true},
+		"negative":                     {out: "-1 -1", wantErr: true},
+		"float cpus":                   {out: "2.5 2147483648", wantErr: true},
+	} {
+		cpus, mem, err := parseRuntimeResources(tc.out)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: parseRuntimeResources(%q) = %d, %d, want an error", name, tc.out, cpus, mem)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: parseRuntimeResources(%q): %v", name, tc.out, err)
+			continue
+		}
+		if cpus != tc.cpus || mem != tc.mem {
+			t.Errorf("%s: parseRuntimeResources(%q) = %d, %d, want %d, %d", name, tc.out, cpus, mem, tc.cpus, tc.mem)
+		}
+	}
+}
+
+// labConfig builds a configuration from the four toggles the floor depends
+// on (plus model-manager, which rides on agents).
+func labConfig(platform, agents, observability, backstage, modelManager bool) *config.Config {
+	cfg := config.Default()
+	cfg.Platform.Enabled = platform
+	cfg.Platform.Agents = agents
+	cfg.Platform.Observability = observability
+	cfg.Backstage.Enabled = backstage
+	cfg.Platform.ModelManager.Enabled = modelManager
+	return cfg
+}
+
+// The floor follows the enabled components. The full default lab reproduces
+// the live measurement the constants come from (2540m / 2532Mi allocated on
+// 2026-09-08) and lands on the README's rows: 4 CPUs for the full lab, 3 for
+// the platform and its agents alone (which requests the ~2.05 CPUs the
+// README quotes). Flux counts only when Backstage AND agents are on
+// (platformUp installs it in that case only); everything but kind and Dex
+// is inert when the platform is off.
+func TestLabResourceNeeds(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg     *config.Config
+		cpu     int
+		mem     int
+		minCPUs int
+		minMem  int
+		groups  string
+	}{
+		"full default lab with model-manager (the measured lab)": {
+			cfg: labConfig(true, true, true, true, true),
+			cpu: 2540, mem: 2532, minCPUs: 4, minMem: 5064,
+			groups: "kind control plane,Dex,agent platform,agents runtime,model-manager,Backstage,Flux,observability",
+		},
+		"full default lab without model-manager": {
+			cfg: labConfig(true, true, true, true, false),
+			cpu: 2485, mem: 2452, minCPUs: 4, minMem: 4904,
+			groups: "kind control plane,Dex,agent platform,agents runtime,Backstage,Flux,observability",
+		},
+		"platform + agents only (README's smaller lab)": {
+			cfg: labConfig(true, true, false, false, true),
+			cpu: 2015, mem: 1810, minCPUs: 3, minMem: 3620,
+			groups: "kind control plane,Dex,agent platform,agents runtime,model-manager",
+		},
+		"platform + agents + Backstage, no observability: Flux comes along": {
+			cfg: labConfig(true, true, false, true, false),
+			cpu: 2180, mem: 2108, minCPUs: 3, minMem: 4216,
+			groups: "kind control plane,Dex,agent platform,agents runtime,Backstage,Flux",
+		},
+		"platform + agents + observability, no Backstage: no Flux": {
+			cfg: labConfig(true, true, true, false, false),
+			cpu: 2265, mem: 2074, minCPUs: 3, minMem: 4148,
+			groups: "kind control plane,Dex,agent platform,agents runtime,observability",
+		},
+		"platform + Backstage without agents: no kagent, no Flux, no model-manager": {
+			cfg: labConfig(true, false, false, true, true),
+			cpu: 1530, mem: 1340, minCPUs: 3, minMem: 2680,
+			groups: "kind control plane,Dex,agent platform,Backstage",
+		},
+		"platform alone": {
+			cfg: labConfig(true, false, false, false, false),
+			cpu: 1510, mem: 1090, minCPUs: 3, minMem: 2180,
+			groups: "kind control plane,Dex,agent platform",
+		},
+		"platform off: kind and Dex only, the other toggles inert": {
+			cfg: labConfig(false, true, true, true, true),
+			cpu: 1000, mem: 354, minCPUs: 2, minMem: 708,
+			groups: "kind control plane,Dex",
+		},
+	} {
+		n := labResourceNeeds(tc.cfg)
+		if n.Requests.CPU != tc.cpu || n.Requests.Mem != tc.mem {
+			t.Errorf("%s: requests = %dm / %dMi, want %dm / %dMi", name, n.Requests.CPU, n.Requests.Mem, tc.cpu, tc.mem)
+		}
+		if n.MinCPUs != tc.minCPUs {
+			t.Errorf("%s: MinCPUs = %d, want %d", name, n.MinCPUs, tc.minCPUs)
+		}
+		if n.MinMemMiB != tc.minMem {
+			t.Errorf("%s: MinMemMiB = %d, want %d", name, n.MinMemMiB, tc.minMem)
+		}
+		got := make([]string, 0, len(n.Groups))
+		for _, g := range n.Groups {
+			got = append(got, g.Name)
+		}
+		if strings.Join(got, ",") != tc.groups {
+			t.Errorf("%s: groups = %s, want %s", name, strings.Join(got, ","), tc.groups)
+		}
+	}
+}
+
+// The floor is the requests plus the run-time headroom rounded UP to whole
+// CPUs: 2540m + 600m = 3140m needs 4, not 3.
+func TestCeilCPUs(t *testing.T) {
+	for in, want := range map[int]int{0: 0, 1: 1, 999: 1, 1000: 1, 1001: 2, 2540: 3, 3140: 4, 3000: 3} {
+		if got := ceilCPUs(in); got != want {
+			t.Errorf("ceilCPUs(%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+const goosLinux = "linux"
+
+// measure is a docker VM on a Mac unless a test says otherwise: the case the
+// resize hints are written for.
+func measure(cpus, memMiB int) runtimeMeasure {
+	return runtimeMeasure{CPUs: cpus, MemMiB: memMiB, GOOS: "darwin", HostCPUs: 10}
+}
+
+// Below the CPU floor the boot is refused, and the refusal carries the
+// measured value, this configuration's floor, the breakdown, the resize
+// steps and the smaller lab that fits.
+func TestJudgeRuntimeResourcesRefusesTooFewCPUs(t *testing.T) {
+	cfg := labConfig(true, true, true, true, true)
+	needs := labResourceNeeds(cfg)
+	warning, err := judgeRuntimeResources(measure(2, 2048), cfg, needs)
+	if err == nil {
+		t.Fatal("2 CPUs for the full lab must be refused")
+	}
+	if warning != "" {
+		t.Errorf("a refusal carries no separate warning, got %q", warning)
+	}
+	for _, want := range []string{
+		"docker has 2 CPUs; this lab configuration needs 4",
+		"request 2.54 CPUs",
+		// The breakdown is word-wrapped, so each group is asserted on its own.
+		"kind control plane 0.95", "Dex 0.05", "agent platform 0.51", "agents runtime 0.45",
+		"model-manager 0.06", "Backstage 0.02", "Flux 0.20", "observability 0.31",
+		"Docker Desktop: Settings -> Resources",
+		"colima start --cpu 4 --memory 5",
+		"agentlab configure --backstage=false --observability=false",
+		"needs 3 CPUs and 3.5 GiB",
+		`README "Docker resources"`,
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal lacks %q:\n%s", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "podman") {
+		t.Errorf("a docker refusal must not talk about podman:\n%s", err)
+	}
+}
+
+// The floor is per configuration: 3 CPUs refuse the full lab and pass the
+// platform + agents lab, whose refusal at 2 CPUs offers no smaller lab (it is
+// the smaller lab).
+func TestJudgeRuntimeResourcesFloorFollowsConfiguration(t *testing.T) {
+	full := labConfig(true, true, true, true, true)
+	if _, err := judgeRuntimeResources(measure(3, 8192), full, labResourceNeeds(full)); err == nil {
+		t.Error("3 CPUs must be refused for the full lab (floor 4)")
+	}
+	small := labConfig(true, true, false, false, true)
+	if warning, err := judgeRuntimeResources(measure(3, 8192), small, labResourceNeeds(small)); err != nil || warning != "" {
+		t.Errorf("3 CPUs / 8 GiB must pass the platform + agents lab, got warning %q, err %v", warning, err)
+	}
+	_, err := judgeRuntimeResources(measure(2, 8192), small, labResourceNeeds(small))
+	if err == nil {
+		t.Fatal("2 CPUs must be refused even for the platform + agents lab")
+	}
+	if strings.Contains(err.Error(), "agentlab configure --backstage=false") {
+		t.Errorf("the smaller lab must not be offered to itself:\n%s", err)
+	}
+	if !strings.Contains(err.Error(), "already the smaller lab") {
+		t.Errorf("the refusal should say this is already the smaller lab:\n%s", err)
+	}
+}
+
+// Memory is soft: between the requests and the floor the boot goes on with a
+// loud warning; below the requests nothing schedules, so it is refused.
+func TestJudgeRuntimeResourcesMemory(t *testing.T) {
+	cfg := labConfig(true, true, true, true, true)
+	needs := labResourceNeeds(cfg) // 2532Mi requested, floor 5064Mi
+
+	warning, err := judgeRuntimeResources(measure(6, 4096), cfg, needs)
+	if err != nil {
+		t.Fatalf("4 GiB is below the floor but above the requests — a warning, not a refusal: %v", err)
+	}
+	for _, want := range []string{"docker has 4.0 GiB of memory", "wants 4.9 GiB", "request only 2.5 GiB", "OOM", "colima start --cpu 4 --memory 5"} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("warning lacks %q:\n%s", want, warning)
+		}
+	}
+
+	if _, err := judgeRuntimeResources(measure(6, 2048), cfg, needs); err == nil {
+		t.Fatal("2 GiB is below the 2.5 GiB of requests: the pods cannot schedule, refuse")
+	} else if !strings.Contains(err.Error(), "docker has 2.0 GiB of memory") || !strings.Contains(err.Error(), "do not\n  even all schedule") {
+		t.Errorf("memory refusal wording:\n%s", err)
+	}
+
+	if warning, err := judgeRuntimeResources(measure(6, 8192), cfg, needs); err != nil || warning != "" {
+		t.Errorf("6 CPUs / 8 GiB is the README's recommendation and must pass silently, got warning %q, err %v", warning, err)
+	}
+	if warning, err := judgeRuntimeResources(measure(4, 5064), cfg, needs); err != nil || warning != "" {
+		t.Errorf("exactly the floor passes without a warning, got warning %q, err %v", warning, err)
+	}
+}
+
+// The fix text names the runtime the user has. Podman on a Mac is a podman
+// machine; rootless Podman on Linux, and docker's own daemon on Linux, are the
+// host itself — nothing to resize, only the smaller lab to fall back to.
+func TestResourceFixesPerRuntime(t *testing.T) {
+	cfg := labConfig(true, true, true, true, true)
+	needs := labResourceNeeds(cfg)
+	podmanMac := runtimeMeasure{CPUs: 2, MemMiB: 2048, Podman: true, GOOS: "darwin", HostCPUs: 10}
+	_, err := judgeRuntimeResources(podmanMac, cfg, needs)
+	if err == nil {
+		t.Fatal("2 CPUs must be refused")
+	}
+	if !strings.Contains(err.Error(), "podman has 2 CPUs") || !strings.Contains(err.Error(), "podman machine set --cpus 4 --memory 5120") {
+		t.Errorf("podman machine refusal wording:\n%s", err)
+	}
+	if strings.Contains(err.Error(), "Colima") || strings.Contains(err.Error(), "Docker Desktop") {
+		t.Errorf("a podman refusal must not send the user to Docker Desktop or Colima:\n%s", err)
+	}
+
+	podmanLinuxHost := runtimeMeasure{CPUs: 2, MemMiB: 2048, Podman: true, GOOS: goosLinux, HostCPUs: 2}
+	_, err = judgeRuntimeResources(podmanLinuxHost, cfg, needs)
+	if err == nil {
+		t.Fatal("2 CPUs must be refused")
+	}
+	if !strings.Contains(err.Error(), "Rootless Podman on Linux runs the containers on this machine itself") ||
+		strings.Contains(err.Error(), "podman machine set") {
+		t.Errorf("rootless podman on Linux is the host itself, nothing to resize:\n%s", err)
+	}
+
+	dockerLinuxHost := runtimeMeasure{CPUs: 2, MemMiB: 2048, GOOS: goosLinux, HostCPUs: 2}
+	_, err = judgeRuntimeResources(dockerLinuxHost, cfg, needs)
+	if err == nil {
+		t.Fatal("2 CPUs must be refused")
+	}
+	if !strings.Contains(err.Error(), "docker here is the host's own engine") || strings.Contains(err.Error(), "Colima") {
+		t.Errorf("a native docker on Linux is the host itself, nothing to resize:\n%s", err)
+	}
+
+	// A Linux host running a VM (Docker Desktop for Linux) has more CPUs than
+	// the VM: the resize hints apply.
+	dockerLinuxVM := runtimeMeasure{CPUs: 2, MemMiB: 2048, GOOS: goosLinux, HostCPUs: 16}
+	_, err = judgeRuntimeResources(dockerLinuxVM, cfg, needs)
+	if err == nil || !strings.Contains(err.Error(), "Docker Desktop: Settings") {
+		t.Errorf("a VM on a Linux host gets the resize hints:\n%v", err)
+	}
+}
+
+func TestResourceFormatting(t *testing.T) {
+	if got := fmtCPUs(2540); got != "2.54" {
+		t.Errorf("fmtCPUs(2540) = %q", got)
+	}
+	if got := fmtCPUs(460); got != "0.46" {
+		t.Errorf("fmtCPUs(460) = %q", got)
+	}
+	if got := fmtGiB(2532); got != "2.5 GiB" {
+		t.Errorf("fmtGiB(2532) = %q", got)
+	}
+	if got := fmtGiB(88136); got != "86.1 GiB" {
+		t.Errorf("fmtGiB(88136) = %q", got)
+	}
+	for in, want := range map[int]int{5064: 5, 4096: 4, 4097: 5, 3620: 4} {
+		if got := ceilGiB(in); got != want {
+			t.Errorf("ceilGiB(%d) = %d, want %d", in, got, want)
+		}
+	}
+}

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -22,6 +22,14 @@ func Up(cfg *config.Config) error {
 			return err
 		}
 	}
+	// Same moment for the machine itself: a docker VM too small for what
+	// this configuration schedules leaves pods Pending forever (the
+	// scheduler refuses CPU requests that do not fit — resources.go), and the
+	// symptom would be an install timing out on agentgateway, minutes from
+	// now. Refused here, with the fix and the numbers.
+	if err := preflightRuntimeResources(cfg); err != nil {
+		return err
+	}
 
 	if err := GenCerts(cfg.Platform.Domain, false); err != nil {
 		return err


### PR DESCRIPTION
## What

`agentlab up` now checks the container runtime's CPUs and memory **before any cluster work**, in the spirit of `ensureHelmSupportsPlatform` (fail on Helm 3 before a five-minute boot) and `preflightHostServer` (prove reachability before helm's ten-minute wait).

The lab runs the whole platform on one kind node, and the kube-scheduler refuses a pod whose CPU *request* does not fit: a docker VM with 2 CPUs leaves `agentgateway` (100m) `Pending` forever and the platform install waits on a workload that never starts; with the platform up but the node full, `models-test` fails at the agent turn because the agent's pod cannot be scheduled. Nothing along the way says "out of CPU". #85 documents this; this PR enforces it.

### How it works (`internal/lab/resources.go`)

- **Probe:** `docker info --format '{{.NCPU}} {{.MemTotal}}'`. Podman's docker-compatible CLI answers `docker info` with podman's own document (`{{.Host.CPUs}} {{.Host.MemTotal}}`), and each engine's template errors on the other's fields — so the engine's shape is tried first (`dockerIsPodman`), the other second. A probe that fails for any reason degrades to a note and the boot goes on: an unreadable runtime is not a small one.
- **Floor per configuration**, not one number: the request figures of each group of pods are named constants in one place — kind control plane (always), Dex (always), agent platform core, agents runtime (kagent), model-manager, Backstage, Flux (only when Backstage AND agents are on, as `platformUp` installs it), observability — gated by `cfg.Platform.Enabled/Agents/Observability`, `cfg.Backstage.Enabled`, `cfg.ModelManagerEnabled()`. Measured on a live full default lab on 2026-09-08 (`kubectl describe node`: 2540m / 2532Mi allocated); the full default lab reproduces exactly that sum in the tests.
  - **CPU floor (hard):** requests + 600m headroom for the pods the platform creates at run time (every kagent agent is one; `models-test` and `agents-test` create one each), rounded up to whole CPUs. Full default lab → 4 CPUs; platform + agents only → 3 CPUs (requests 2.015 CPUs, the ~2.05 the README quotes). Both match the README table's rows.
  - **Memory floor (soft):** 2× the requests (real use runs about twice the requests column). Below the *requests* total nothing schedules → error; between the requests and the floor → loud warning on stderr; above → nothing.
- **Every boot** prints the measured values and this configuration's requests and floor, plus a `tight:` note when less than one CPU is left for the run-time pods.
- **Refusal text** names the measured value, the floor for THIS configuration, the per-group breakdown, the resize step for the runtime at hand — Docker Desktop (Settings → Resources), Colima (`colima start --cpu N --memory M`), podman machine (`podman machine set --cpus N --memory M`); a native engine or rootless Podman on Linux is the host itself, and the message says so instead of offering a resize — and the smaller lab that fits: `agentlab configure --backstage=false --observability=false` with its own floor (omitted when the configuration already is that lab).

### README

The table in #85 ("### Docker resources") is the **human copy of these constants** — same groups, same figures (with the review suggestions on #85 applied: kind's control plane requests 290 MiB, total ≈ 2.5 GiB). #85 is a teammate's PR and still open, so this PR adds **no competing README edit**. Once #85 has merged, one sentence should land under "### Docker resources": *`agentlab up` enforces the CPU floor and prints these numbers on every boot; below the memory floor it warns.* I'll follow up with that sentence after #85 merges.

### Tests

`internal/lab/resources_test.go` — parsing (docker and podman shapes, `<no value>`, empty, garbage, zeros, negatives, floats), the floor for every component combination (full lab with/without model-manager, platform + agents, ± Backstage, ± observability, platform without agents, platform alone, platform off), the refusal/warning/pass branches, the fix text per runtime (docker on a Mac, podman machine, rootless Podman on Linux, native docker on Linux, a VM on a Linux host), and the formatting. No test touches a container runtime; `go test ./...`, `golangci-lint` and `pre-commit run --all-files` are green.

## Proof (live, this 24-core host)

Run from a scratch directory with a default `agentlab configure --defaults` config (full lab, model-manager on: the measured configuration) and `clusterName` changed, so the real `agentlab` cluster was never touched. A `kind` shim on PATH refuses every call, so the boot stops right after the preflight and nothing is created.

**A — the real docker (24 CPUs / 86 GiB): the step line, then the boot continues**

```
==> [00:00] Checking the container runtime's CPUs and memory against this lab's requests
    docker: 24 CPUs, 86.1 GiB memory; the lab requests 2.54 CPUs / 2.5 GiB and needs 4 CPUs / 4.9 GiB
Generated certs/ca.crt (3650-day CA; name constraints: DNS 127.0.0.1.nip.io, dex, dex.dex.svc, dex.dex.svc.cluster.local, localhost, IP 127.0.0.0/8)
Generated certs/tls.crt (minting; 825-day leaf, SAN: IP:127.0.0.1, DNS:localhost,dex,dex.dex.svc,dex.dex.svc.cluster.local)
==> [00:01] Creating kind cluster "preflight-proof"
kind shim: refusing 'create cluster --config state/kind-config.yaml --wait 120s' — the proof stops here, nothing is created
Error: exit status 1
```

**B — a `docker` shim on PATH whose `info` answers `2 2147483648` (2 CPUs / 2 GiB; everything else goes to the real docker). The real docker was not reconfigured.**

```
==> [00:00] Checking the container runtime's CPUs and memory against this lab's requests
    docker: 2 CPUs, 2.0 GiB memory; the lab requests 2.54 CPUs / 2.5 GiB and needs 4 CPUs / 4.9 GiB
Error: docker has 2 CPUs; this lab configuration needs 4.
  Its pods request 2.54 CPUs of the single kind node, plus room for the pods the
  platform creates at run time, and the kube-scheduler refuses a pod whose CPU
  request does not fit: the boot would wait on an agentgateway that stays
  Pending forever (README "Docker resources"). The requests:
    kind control plane 0.95, Dex 0.05, agent platform 0.51, agents runtime 0.45,
    model-manager 0.06, Backstage 0.02, Flux 0.20, observability 0.31
  Give docker 4 CPUs and 5 GiB of memory:
  - Docker Desktop: Settings -> Resources -> CPUs / Memory
  - Colima:         colima stop && colima start --cpu 4 --memory 5
  Or run the smaller lab, the platform and its agents without Backstage and observability
  (needs 3 CPUs and 3.5 GiB):  agentlab configure --backstage=false --observability=false
```

Exit code 1, no certs generated, no kind call made.

**C — a shim answering `4 4294967296` (4 CPUs / 4 GiB): above the CPU floor, below the memory floor → warning, boot goes on**

```
==> [00:00] Checking the container runtime's CPUs and memory against this lab's requests
    docker: 4 CPUs, 4.0 GiB memory; the lab requests 2.54 CPUs / 2.5 GiB and needs 4 CPUs / 4.9 GiB
    WARNING: docker has 4.0 GiB of memory; this lab configuration wants 4.9 GiB.
    Its pods request only 2.5 GiB, so they schedule — but real use runs about 2x the requests
    (Backstage and Prometheus use several times what they declare): expect evictions
    and OOM kills under load (README "Docker resources").
    Give docker 4 CPUs and 5 GiB of memory:
    - Docker Desktop: Settings -> Resources -> CPUs / Memory
    - Colima:         colima stop && colima start --cpu 4 --memory 5
    Or run the smaller lab, the platform and its agents without Backstage and observability
    (needs 3 CPUs and 3.5 GiB):  agentlab configure --backstage=false --observability=false
certs/ already populated (agentlab certs --force to regenerate)
==> [00:00] Creating kind cluster "preflight-proof"
```

**D — the two `info` shapes against the real engines on this host** (why the probe tries both):

```
$ podman info --format '{{.Host.CPUs}} {{.Host.MemTotal}}'      # podman 6.1.1
24 92417925120
$ podman info --format '{{.NCPU}} {{.MemTotal}}'
Error: template: info:1:2: executing "info" at <.NCPU>: can't evaluate field NCPU in type system.infoReport
$ docker info --format '{{.Host.CPUs}} {{.Host.MemTotal}}'      # docker 29.7.2
template: :1:7: executing "" at <.Host.CPUs>: can't evaluate field Host in type system.dockerInfo
```

## Scope notes

- Only `agentlab up` gets the preflight (the task: fail before any cluster work). The standalone `agentlab platform` entry point could repeat it the way it repeats the Helm check; left for a follow-up if wanted.
- The 600m run-time headroom is the lab's own allowance (six pods at the 100m the platform's small pods request); the exact request of a kagent agent pod is not pinned by this repo.
- Requires #85 to merge first for the README sentence (see above).
