### PR TITLE
fix(platform): pin agent-platform 3.20.2 and drop the kagent metrics-selector and kagent-namespace workarounds the chart fixed

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -450,37 +450,42 @@ when muster exposes `allowPrivateIPClientMetadata` for its OAuth server — then
 the pin can go and the challenge chain becomes proxy start → muster
 `/oauth/authorize` → Dex again.
 
-### U19. `components.agent-platform-connectivity.postRenderers`: the kagent controller metrics Service selects the wrong instance label — BLOCKED UPSTREAM
-The connectivity chart (3.20.1) renders a Service for the kagent controller's
-metrics port and a ServiceMonitor on it, selecting the controller pods with
-`app.kubernetes.io/instance: <its own release name>`. Under the standalone
-umbrella every subchart shared one release name, so that matched; under the
-meta chart kagent is its own release named `kagent`, the Service selects no
-pod, and the lab Prometheus scrapes nothing of kagent (`platform-test`
-"Prometheus scrapes the platform itself" caught it on the first meta-chart
-run). **Fix here:** a Kustomize strategic-merge patch on the Service's
-selector (`postrenderers.go`, patch 6) rendered into
-`components.agent-platform-connectivity.postRenderers` while agents and
-observability are on — the chart's own mechanism for chart fixes.
-**Unblocks:** [giantswarm/agent-platform#305](https://github.com/giantswarm/agent-platform/issues/305)
-— select kagent's instance label. Then the patch is deleted.
+### U19. `components.agent-platform-connectivity.postRenderers`: the kagent controller metrics Service selects the wrong instance label — FIXED upstream
+The connectivity chart (up to 3.20.1) rendered a Service for the kagent
+controller's metrics port and a ServiceMonitor on it, selecting the controller
+pods with `app.kubernetes.io/instance: <its own release name>`. Under the
+standalone umbrella every subchart shared one release name, so that matched;
+under the meta chart kagent is its own release named `kagent`, the Service
+selected no pod, and the lab Prometheus scraped nothing of kagent
+(`platform-test` "Prometheus scrapes the platform itself" caught it on the
+first meta-chart run). The lab carried a Kustomize strategic-merge patch on
+the Service's selector in `components.agent-platform-connectivity.postRenderers`.
+**Fixed:** agent-platform 3.20.2
+([giantswarm/agent-platform#305](https://github.com/giantswarm/agent-platform/issues/305),
+PR #308) — the Service selects kagent's own release name. The patch is
+deleted; the lab renders no `postRenderers` for the connectivity component,
+and the lab's Prometheus scrapes the kagent controller through the chart's
+own Service.
 
-### U20. `platform.go`: the `kagent` namespace is created before the chart — BLOCKED UPSTREAM
+### U20. `platform.go`: the `kagent` namespace is created before the chart — FIXED upstream
 The kagent chart renders its workloads into `kagent.namespaceOverride`
 (`kagent`), but its HelmRelease targets the release namespace like every
 component, so helm-controller's `createNamespace` never creates `kagent`; the
-one chart object that does — the connectivity chart's Namespace — sits in a
-release that `dependsOn` kagent. A first install on a fresh cluster fails
+one chart object that did — the connectivity chart's Namespace — sits in a
+release that `dependsOn` kagent. A first install on a fresh cluster failed
 every kagent attempt with `namespaces "kagent" not found` until the retries
-are exhausted, and everything behind kagent waits (seen on the first
-meta-chart run: 6 attempts, then Stalled). Management clusters break the
-cycle by creating the namespace in their bases (management-cluster-bases#732);
-the lab does the same in `platformUp` when agents are on, and the
-connectivity release adopts it on install.
-**Unblocks:** [giantswarm/agent-platform#306](https://github.com/giantswarm/agent-platform/issues/306)
-— render the Namespace from the meta chart itself (or target the kagent
-HelmRelease at the namespace with `createNamespace`). Then `ensureNamespace`
-for kagent goes.
+were exhausted, and everything behind kagent waited (seen on the first
+meta-chart run: 6 attempts, then Stalled). The lab created the namespace in
+`platformUp` when agents are on, the way management clusters do in their
+bases, and the connectivity release adopted it.
+**Fixed:** agent-platform 3.20.2
+([giantswarm/agent-platform#306](https://github.com/giantswarm/agent-platform/issues/306),
+PR #308) — with the bundled engine and kagent on, a `pre-install,pre-upgrade`
+hook Job (`<release>-kagent-namespace`, weight -8) creates the namespace when
+it is missing (and waits out a `Terminating` one left by a previous
+uninstall) ahead of the kagent HelmRelease; the connectivity release adopts
+it on install and deletes it with the release. `ensureNamespace` for kagent
+is deleted; a fresh `agentlab up` gets the namespace from the hook.
 
 ## Accepted lab trade-offs (not hacks to fix)
 

--- a/README.md
+++ b/README.md
@@ -1049,10 +1049,11 @@ same one-URL trick, just spelled with a name.
   flips the type without also deleting that field fails with
   `rollingUpdate: Forbidden`. `maxSurge: 0` achieves the same thing without the
   conflict.
-- **The `kagent` namespace follows the kagent component.** The chart's
-  connectivity component renders it only while `components.kagent.enabled` is
-  true, and `helm uninstall` (the ordered teardown) removes it with the
-  connectivity release.
+- **The `kagent` namespace follows the kagent component.** While
+  `components.kagent.enabled` is true the chart's pre-install/pre-upgrade hook
+  creates it ahead of the kagent `HelmRelease`, the connectivity component
+  adopts it, and `helm uninstall` (the ordered teardown) removes it with the
+  connectivity release. The lab creates no namespace of its own for kagent.
 - **Kubernetes tools carry the server-name prefix.** The chart's bundled
   `mcp-kubernetes` MCPServer declares no muster *family*, so its tools use
   per-server prefixing: `call_tool(name=x_mcp-kubernetes_list, arguments={...})`. The fake fleet's members are the lab's only family servers and they stay

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,7 +92,7 @@ const DefaultDexPort = 32000
 // DefaultChartVersion is the agent-platform release the lab installs when
 // agentlab.yaml pins none — the release this agentlab was verified with.
 // Bump deliberately, with a lab run: the lab never floats.
-const DefaultChartVersion = "3.20.0"
+const DefaultChartVersion = "3.20.2"
 
 // ChartRepository is where the agent-platform chart releases live.
 const ChartRepository = "oci://gsoci.azurecr.io/charts/giantswarm/agent-platform"

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -141,21 +141,10 @@ func platformUp(cfg *config.Config, header string) error {
 	if err := ensureNamespace(platformNamespace); err != nil {
 		return err
 	}
-	// The kagent namespace is created here, before the chart. The kagent
-	// chart renders its workloads into it (kagent.namespaceOverride), but its
-	// HelmRelease targets the release namespace like every other component,
-	// so helm-controller's createNamespace never creates it — and the one
-	// chart object that does, the connectivity chart's Namespace, sits in a
-	// release that dependsOn kagent: a first install deadlocks on
-	// `namespaces "kagent" not found` until the retries are exhausted.
-	// Management clusters break the cycle the same way, by creating the
-	// namespace out of band in their bases; the connectivity release adopts
-	// it on install.
-	if cfg.Platform.Agents {
-		if err := ensureNamespace(kagentNamespace); err != nil {
-			return err
-		}
-	}
+	// The kagent namespace is the chart's: with the bundled engine and kagent
+	// on, its pre-install/pre-upgrade hook creates the namespace ahead of the
+	// kagent HelmRelease, and the connectivity release adopts it (deleting it
+	// with the release on the ordered teardown).
 	// muster appends this to its system trust pool so it can talk to the lab's
 	// self-signed Dex over TLS (values: muster.muster.extraCaFile); Backstage
 	// mounts the same Secret through global.identity.ca (NODE_EXTRA_CA_CERTS).

--- a/internal/lab/postrenderers.go
+++ b/internal/lab/postrenderers.go
@@ -54,14 +54,6 @@ import (
 //     build on this host plus imagePullPolicy IfNotPresent on its container,
 //     so the side-loaded image is used as is (backstage's chart pulls Always).
 //
-//  6. The selector of the connectivity chart's kagent controller metrics
-//     Service (the ServiceMonitor's target): the chart selects
-//     `app.kubernetes.io/instance: <its own release name>`, which matched
-//     under the standalone umbrella (one release for every subchart) and
-//     matches no pod under the meta chart, where kagent is its own release
-//     named `kagent`. Until the chart selects kagent's instance label the
-//     lab's Prometheus would scrape nothing of kagent (HACKS.md U19).
-//
 // The values-side shape is Flux's: `postRenderers: [{kustomize: {patches:
 // [{target, patch}], images: [{name, newName, newTag}]}}]`.
 
@@ -209,30 +201,6 @@ spec:
 	}
 }
 
-// connectivityComponent is the meta chart's component name of the
-// agent-platform-connectivity chart, also its release name.
-const connectivityComponent = "agent-platform-connectivity"
-
-// kagentMetricsService is the connectivity chart's kagent controller metrics
-// Service: `<release name>-kagent-controller-metrics`, in the kagent namespace.
-const kagentMetricsService = connectivityComponent + "-kagent-controller-metrics"
-
-// kagentMetricsSelectorPatch is patch 6: a strategic merge on the Service's
-// selector map, so only the instance key changes (HACKS.md U19).
-func kagentMetricsSelectorPatch() kustomizePatch {
-	return kustomizePatch{
-		Target: map[string]string{kindKey: kindService, nameKey: kagentMetricsService},
-		Patch: literalYAML(fmt.Sprintf(`apiVersion: v1
-kind: Service
-metadata:
-  name: %s
-spec:
-  selector:
-    app.kubernetes.io/instance: %s
-`, kagentMetricsService, componentKagent)),
-	}
-}
-
 // pullPolicyPatch is patch 5's second half: the container of a dev image
 // takes the side-loaded copy as is.
 func pullPolicyPatch(target devImageTarget) kustomizePatch {
@@ -275,12 +243,6 @@ func componentPostRenderers(cfg *config.Config) (map[string]string, error) {
 	}
 	if cfg.Platform.Agents {
 		patches[agentManagerMCPServer] = []kustomizePatch{dexLocalhostPatch(agentManagerMCPServer, cfg.DexPort)}
-	}
-	// The metrics Service renders only with kagent AND the monitors on; a
-	// kustomize target that matches nothing is a no-op, but the values stay
-	// minimal when the object is not there.
-	if cfg.Platform.Agents && cfg.Platform.Observability {
-		patches[connectivityComponent] = []kustomizePatch{kagentMetricsSelectorPatch()}
 	}
 	images := map[string][]kustomizeImage{}
 	for _, component := range slices.Sorted(maps.Keys(cfg.Platform.DevImages)) {

--- a/internal/lab/postrenderers_test.go
+++ b/internal/lab/postrenderers_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/giantswarm/agentlab/internal/config"
 )
 
+// connectivityComponent is the meta chart's component name of the
+// agent-platform-connectivity chart, also its release name — named here only
+// to assert the lab renders no patch for it.
+const connectivityComponent = "agent-platform-connectivity"
+
 // Fixture refs, hoisted so the linter's constant check stays quiet.
 const (
 	devMusterRef        = "muster:dev-1a2b"
@@ -66,11 +71,17 @@ func TestFullImageRef(t *testing.T) {
 func TestComponentPostRenderers(t *testing.T) {
 	cfg := config.Default()
 	cfg.Platform.Agents = true
+	cfg.Platform.Observability = true
 	cfg.Platform.ModelManager = config.ModelManager{Enabled: true, Backends: []string{ollama}}
 	cfg.Platform.DevImages = map[string]string{componentMuster: devMusterRef, componentBackstage: devBackstageRef}
 	rendered, err := componentPostRenderers(cfg)
 	if err != nil {
 		t.Fatal(err)
+	}
+	// The connectivity chart is not patched: its kagent controller metrics
+	// Service selects kagent's own release since agent-platform 3.20.2.
+	if raw, ok := rendered[connectivityComponent]; ok {
+		t.Errorf("connectivity: the lab patches nothing on the wiring chart, got postRenderers:\n%s", raw)
 	}
 	parse := func(component string) postRenderer {
 		raw, ok := rendered[component]
@@ -118,12 +129,6 @@ func TestComponentPostRenderers(t *testing.T) {
 		t.Errorf("kagent: want the kagent-ui NodePort pin on the chart's 8080/TCP port entry, got %q", got)
 	}
 
-	// The connectivity chart's kagent metrics Service selector, corrected to
-	// kagent's instance label (HACKS.md U19) — with agents and observability on.
-	if got := patchOn(connectivityComponent, kindService, kagentMetricsService); len(got) != 1 || !strings.Contains(got[0], "app.kubernetes.io/instance: kagent") {
-		t.Errorf("connectivity: want the kagent metrics selector patch, got %q", got)
-	}
-
 	// The dev images: the override to the fully qualified local ref and the
 	// pull policy on the chart's container.
 	muster := parse(componentMuster)
@@ -147,7 +152,7 @@ func TestComponentPostRenderers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, c := range []string{modelManagerMCPServer, agentManagerMCPServer, connectivityComponent} {
+	for _, c := range []string{modelManagerMCPServer, agentManagerMCPServer} {
 		if _, ok := rendered[c]; ok {
 			t.Errorf("%s: off, want no postRenderers", c)
 		}

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -176,14 +176,6 @@ components:
     postRenderers:
 {{ index .PostRenderers "backstage" | indent 6 }}
 {{- end }}
-{{- if and .Platform.Agents .Platform.Observability }}
-  # The wiring chart (always on). Its kagent controller metrics Service
-  # selects the wrong instance label under the meta chart (HACKS.md U19);
-  # the patch corrects the selector until the chart does.
-  agent-platform-connectivity:
-    postRenderers:
-{{ index .PostRenderers "agent-platform-connectivity" | indent 6 }}
-{{- end }}
 
 # The connectivity chart's key for the mcp-kubernetes MCPServer CR (dropped
 # from the values the mcp-kubernetes chart itself receives): the audience


### PR DESCRIPTION
## Problem

agentlab v0.23.0 pins `agent-platform` 3.20.0 (`config.DefaultChartVersion`) and carries two workarounds for chart bugs found on the first meta-chart run (HACKS.md U19, U20):

- **U19** — the connectivity chart's kagent controller metrics Service selected `app.kubernetes.io/instance: <its own release name>`, which matches no pod under the meta chart (kagent is its own release named `kagent`), so the lab's Prometheus scraped nothing of kagent. The lab patched the selector through `components.agent-platform-connectivity.postRenderers` (giantswarm/agent-platform#305).
- **U20** — a first install with kagent on and no `kagent` namespace deadlocked: the kagent HelmRelease targets the release namespace, so helm-controller never created `kagent`, and the one object that renders it (the connectivity chart's Namespace) sits in a release that `dependsOn` kagent. The lab pre-created the namespace in `platformUp` (giantswarm/agent-platform#306).

agent-platform 3.20.2 (giantswarm/agent-platform#308) fixes both: the connectivity Service selects kagent's own release name, and with the bundled engine and kagent on a `pre-install,pre-upgrade` hook Job (`<release>-kagent-namespace`) creates the namespace ahead of the kagent HelmRelease; the connectivity release adopts it.

## Change

- `config.DefaultChartVersion` → `3.20.2`.
- The kagent metrics-selector patch is gone: `kagentMetricsSelectorPatch`, the `connectivityComponent`/`kagentMetricsService` constants and the `agent-platform-connectivity.postRenderers` block of the values template. The lab renders no `postRenderers` for the connectivity component any more (the unit test asserts it).
- The kagent namespace pre-creation in `platformUp` is gone; the chart's hook creates the namespace.
- HACKS.md U19 and U20 are FIXED upstream (mechanism and fix referenced); the README's `kagent` namespace gotcha describes the hook.

Nothing else changes: every other lab patch (hostNetwork + maxSurge 0, the `dex-localhost` sidecar, the kagent-ui NodePort, dev images) stays.

## Proof

`go build ./... && go test ./...` and `pre-commit run -a` green. On the lab, with this branch's binary:

**1. Upgrade in place** (`platform.chartVersion: 3.20.2`, `agentlab platform`, 346 s): helm release rev 3 = `agent-platform-3.20.2` deployed; all 11 HelmReleases Ready, `agent-platform-connectivity` v3 at 3.20.2; the rendered `state/agent-platform-values.yaml` has no `components.agent-platform-connectivity` block and the live release values carry no `kagent-controller-metrics` patch. The chart's own Service selects the controller:

```
$ kubectl -n kagent get svc agent-platform-connectivity-kagent-controller-metrics -o jsonpath='{.spec.selector}'
{"app.kubernetes.io/component":"controller","app.kubernetes.io/instance":"kagent","app.kubernetes.io/name":"kagent"}
$ kubectl -n kagent get endpointslice -l kubernetes.io/service-name=agent-platform-connectivity-kagent-controller-metrics
agent-platform-connectivity-kagent-controller-metrics-m6ksk   IPv4   8080   10.244.0.19   (= the kagent-controller pod)
```

`agentlab platform-test` PASS (6/6, incl. "Prometheus scrapes the platform itself: muster, valkey, mcp-prometheus, kagent").

**2. Fresh `agentlab up` with nothing pre-creating the `kagent` namespace** (`agentlab down` 6 s, `up` 306 s, exit 0): a poller next to `up` caught the hook —

```
23:13:07 JOB agent-platform-kagent-namespace   Running   0/1   2s
23:13:07 POD agent-platform-kagent-namespace-j4lzk   0/1   Completed   0   2s
23:13:07 NS  kagent 2026-09-08T21:13:05Z Active
events: job/agent-platform-kagent-namespace SuccessfulCreate → pod Completed → "Job completed"
helm get hooks: agent-platform-kagent-namespace  helm.sh/hook: pre-install,pre-upgrade
```

The namespace exists since 21:13:05Z (two seconds after the release's install started, before any HelmRelease), owned by `agent-platform-connectivity` (`meta.helm.sh/release-name`, `managed-by=Helm`) — the hook created it, connectivity adopted it. The hook Job itself is gone afterwards (`hook-succeeded`). kagent HR Ready on its first install, 11/11 HelmReleases Ready, helm rev 1 = `agent-platform-3.20.2` "Install complete". Then `platform-test` PASS (6), `backstage-test` PASS, `test` 10/10, `agents-test` PASS (4).

Epic: https://github.com/giantswarm/roadmap/issues/4348
