### PR TITLE
fix(platform-down): also uninstall the old lab's Flux, so `platform-down` then `platform` works on a cluster an earlier agentlab built

### DIFF
--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,10 @@ same one-URL trick, just spelled with a name.
   migration on purpose — the kind cluster is throwaway. `agentlab platform`
   names what it found and asks for `agentlab down && agentlab up`. It also
   removes the leftovers of those versions in the working directory
-  (`.vendor/`, `state/helm-plugins/`).
+  (`.vendor/`, `state/helm-plugins/`). To keep the cluster and its Dex
+  instead, `agentlab platform-down` then `agentlab platform`: platform-down
+  uninstalls the umbrella and those Flux controllers too, and the component
+  releases replace the umbrella's CRDs (`crds: CreateReplace`).
 - **`agentlab platform-down` is the chart's ordered teardown.** It deletes
   the lab's mcp-prometheus `HelmRelease` while the engine still runs, then
   `helm uninstall --wait` runs the chart's pre-delete hooks — delete the
@@ -1034,7 +1037,9 @@ same one-URL trick, just spelled with a name.
   which takes every remaining `HelmRelease` (the agents' too) with it — and
   only then deletes the namespaces. Nothing is left with a finalizer nobody
   processes. The four Flux Operator CRDs and the prometheus-operator CRDs
-  stay (Helm never removes a chart's `crds/`); a reinstall is clean.
+  stay (Helm never removes a chart's `crds/`); a reinstall is clean. On a
+  cluster an earlier agentlab built it also uninstalls the Flux controllers
+  that lab installed itself (release `flux` in `flux-system`).
 - **`allowPublicClientRegistration` must be on for Claude Code's login.**
   Claude Code registers over DCR as a public client on a random loopback port,
   so none of the other registration gates can be opened for it: it cannot send

--- a/README.md
+++ b/README.md
@@ -1025,7 +1025,8 @@ same one-URL trick, just spelled with a name.
   migration on purpose — the kind cluster is throwaway. `agentlab platform`
   names what it found and asks for `agentlab down && agentlab up`. It also
   removes the leftovers of those versions in the working directory
-  (`.vendor/`, `state/helm-plugins/`). To keep the cluster and its Dex
+  (`.vendor/`, `state/helm-plugins/`, `state/flux-values.yaml`,
+  `state/mcp-prometheus-values.yaml`). To keep the cluster and its Dex
   instead, `agentlab platform-down` then `agentlab platform`: platform-down
   uninstalls the umbrella and those Flux controllers too, and the component
   releases replace the umbrella's CRDs (`crds: CreateReplace`).

--- a/internal/lab/down.go
+++ b/internal/lab/down.go
@@ -65,5 +65,23 @@ func PlatformDown(cfg *config.Config) error {
 	}
 	_ = runQuiet("helm", "-n", observabilityNamespace, "uninstall", kpsRelease)
 	_ = runQuiet("kubectl", "delete", "namespace", observabilityNamespace, "--ignore-not-found")
-	return run("kubectl", "delete", "namespace", platformNamespace, "--ignore-not-found")
+	if err := run("kubectl", "delete", "namespace", platformNamespace, "--ignore-not-found"); err != nil {
+		return err
+	}
+	// What an earlier agentlab installed next to the umbrella: its own Flux
+	// controllers for the agent create flow. The chart brings the engine now
+	// and refuses a second Flux (refuseOlderLabShape), so they go with the
+	// platform — after it, so the umbrella's agent HelmReleases were
+	// finalized by a running helm-controller — and `agentlab platform` is a
+	// clean reinstall on this cluster.
+	if legacyFluxInstalled() {
+		step("Uninstalling the Flux controllers an earlier agentlab installed (release %s in %s)", legacyFluxRelease, legacyFluxNamespace)
+		if err := run("helm", "-n", legacyFluxNamespace, "uninstall", legacyFluxRelease, "--wait", "--timeout", "5m"); err != nil {
+			return err
+		}
+		if err := run("kubectl", "delete", "namespace", legacyFluxNamespace, "--ignore-not-found"); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -42,6 +42,10 @@ const conditionTrue = "True"
 const (
 	legacyVendorDir      = ".vendor"
 	legacyHelmPluginsDir = StateDir + "/helm-plugins"
+	// Renders of templates that are gone: the old lab's own Flux values and
+	// the mcp-prometheus values of its `helm install` (a HelmRelease now).
+	legacyFluxValues          = StateDir + "/flux-values.yaml"
+	legacyMCPPrometheusValues = StateDir + "/mcp-prometheus-values.yaml"
 	// The Flux controllers the old lab installed itself (flux2 chart) for the
 	// agent create flow; the chart brings its own engine now and refuses a
 	// second Flux. Named here so the refusal and `platform-down` agree.
@@ -539,19 +543,19 @@ func legacyFluxInstalled() bool {
 }
 
 // removeLegacyArtifacts deletes what earlier agentlab versions left in the
-// working directory (see legacyVendorDir, legacyHelmPluginsDir). Quiet when
-// there is nothing; a failure to remove is a note, not an error — nothing
-// reads either directory anymore.
+// working directory (see legacyVendorDir and the constants next to it).
+// Quiet when there is nothing; a failure to remove is a note, not an error —
+// nothing reads any of them anymore.
 func removeLegacyArtifacts() {
-	for _, dir := range []string{legacyVendorDir, legacyHelmPluginsDir} {
-		if _, err := os.Stat(dir); err != nil {
+	for _, path := range []string{legacyVendorDir, legacyHelmPluginsDir, legacyFluxValues, legacyMCPPrometheusValues} {
+		if _, err := os.Stat(path); err != nil {
 			continue
 		}
-		if err := os.RemoveAll(dir); err != nil {
-			note("could not remove %s (left by an earlier agentlab; safe to delete by hand): %v", dir, err)
+		if err := os.RemoveAll(path); err != nil {
+			note("could not remove %s (left by an earlier agentlab; safe to delete by hand): %v", path, err)
 			continue
 		}
-		note("removed %s (left by an earlier agentlab; nothing reads it anymore)", dir)
+		note("removed %s (left by an earlier agentlab; nothing reads it anymore)", path)
 	}
 }
 

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -42,6 +42,11 @@ const conditionTrue = "True"
 const (
 	legacyVendorDir      = ".vendor"
 	legacyHelmPluginsDir = StateDir + "/helm-plugins"
+	// The Flux controllers the old lab installed itself (flux2 chart) for the
+	// agent create flow; the chart brings its own engine now and refuses a
+	// second Flux. Named here so the refusal and `platform-down` agree.
+	legacyFluxNamespace = "flux-system"
+	legacyFluxRelease   = "flux"
 )
 
 // helmInstallTimeout bounds `helm upgrade --install --wait` of the meta chart.
@@ -122,10 +127,12 @@ func platformUp(cfg *config.Config, header string) error {
 	if err := ensureHelmSupportsPlatform(); err != nil {
 		return err
 	}
+	// The working-directory leftovers go first: nothing reads them, and the
+	// refusal below is exactly the moment a user of an earlier agentlab meets.
+	removeLegacyArtifacts()
 	if err := refuseOlderLabShape(); err != nil {
 		return err
 	}
-	removeLegacyArtifacts()
 	chart := platformChartFor(cfg)
 	step("Installing %s in the lab shape (bundled Flux engine on, self-management off)", chart)
 
@@ -506,20 +513,29 @@ func platformUp(cfg *config.Config, header string) error {
 // guard refuses a second Flux too, with a message about clusters that run
 // Flux — this one names the actual cause). The lab has no in-place migration
 // on purpose: the kind cluster is throwaway, and `agentlab down && agentlab
-// up` is a clean five-minute slate.
+// up` is a clean five-minute slate. The other way out, `agentlab
+// platform-down` then `agentlab platform`, keeps the cluster and Dex:
+// platform-down removes both of the above (PlatformDown), and the component
+// releases replace the umbrella's CRDs (`crds: CreateReplace`).
 func refuseOlderLabShape() error {
+	const fix = "run `agentlab down && agentlab up` (or `agentlab platform-down`, then `agentlab platform`)"
 	if out, err := outputQuiet("helm", "-n", platformNamespace, "list", "--filter", "^"+platformRelease+"$", "-o", "json"); err == nil &&
 		strings.Contains(out, `"chart":"agent-platform-standalone`) {
 		return fmt.Errorf("this cluster runs the agent-platform-standalone umbrella an earlier agentlab installed;\n" +
-			"the lab installs the agent-platform meta chart now and has no in-place migration:\n" +
-			"run `agentlab down && agentlab up` (or `agentlab platform-down`, then `agentlab platform`)")
+			"the lab installs the agent-platform meta chart now and has no in-place migration:\n" + fix)
 	}
-	if _, err := outputQuiet("helm", "-n", "flux-system", "status", "flux"); err == nil {
-		return fmt.Errorf("this cluster runs the Flux controllers an earlier agentlab installed (release flux in flux-system);\n" +
-			"the agent-platform chart brings its own engine and refuses a second Flux:\n" +
-			"run `agentlab down && agentlab up`")
+	if legacyFluxInstalled() {
+		return fmt.Errorf("this cluster runs the Flux controllers an earlier agentlab installed (release %s in %s);\n"+
+			"the agent-platform chart brings its own engine and refuses a second Flux:\n"+fix, legacyFluxRelease, legacyFluxNamespace)
 	}
 	return nil
+}
+
+// legacyFluxInstalled reports whether the Flux controllers an earlier
+// agentlab installed itself are on the cluster (release flux in flux-system).
+func legacyFluxInstalled() bool {
+	_, err := outputQuiet("helm", "-n", legacyFluxNamespace, "status", legacyFluxRelease)
+	return err == nil
 }
 
 // removeLegacyArtifacts deletes what earlier agentlab versions left in the


### PR DESCRIPTION
## What

Tested the upgrade path from the last standalone-umbrella agentlab (v0.22.1: umbrella under release `agent-platform` + its own Flux controllers as release `flux` in `flux-system`) to v0.23.1 (the meta chart in the lab shape) on a fresh kind cluster. Findings:

- `agentlab self-update` v0.22.1 → v0.23.1: verified the cosign bundle and installed the release binary (4 s, sha256 matches the release asset).
- v0.23.1 `agentlab platform` and `agentlab up` on the old cluster refuse with the standalone message and offer two ways out: `agentlab down && agentlab up` **or `agentlab platform-down`, then `agentlab platform`**.
- `agentlab down && agentlab up` works as documented (meta chart 3.20.2, leftovers `.vendor/` and `state/helm-plugins/` removed by the first successful `platform`).
- The alternative was a dead end: v0.23.1 `platform-down` uninstalls the umbrella but leaves the old `flux` release in `flux-system`, so the next `agentlab platform` refuses again ("this cluster runs the Flux controllers an earlier agentlab installed") — and that second message offered only `down && up`.
- The working-directory leftovers were only removed after a *successful* refusal check, so a user who hits the refusal keeps `.vendor/` (3.8 MB) until the first successful `platform`.

## Fix

- `PlatformDown` also uninstalls the old lab's Flux release (`flux` in `flux-system`, `--wait`) and deletes the namespace when present — after the platform, so the umbrella's agent HelmReleases were finalized by a running helm-controller. Same predicate as the refusal (`legacyFluxInstalled`), constants shared.
- `platformUp` removes the working-directory leftovers *before* the refusal.
- Both refusal messages offer the same two paths.
- README: the clean-slate gotcha names the `platform-down` → `platform` alternative and why it is safe (component releases replace the umbrella's CRDs with `crds: CreateReplace`); the platform-down bullet mentions the legacy Flux removal.

## Verification

Lab-verified on a kind cluster built by the v0.22.1 release binary (standalone umbrella at its default pin + flux2 2.19.0): this branch's binary runs `platform-down` (umbrella, observability, the old Flux, namespaces) and then `platform` installs agent-platform 3.20.2 on the same cluster with Dex kept; proofs (`platform-test`, `backstage-test`, `test`, `agents-test`) green. Details in the PR comments once the run completes.