### PR TITLE
fix(toolsets-test): the hand-applied legacy and portal HelmReleases name kagent-flux — the chart's engine is multitenant

### DIFF
--- a/internal/lab/toolsetstest.go
+++ b/internal/lab/toolsetstest.go
@@ -28,12 +28,19 @@ import (
 // Names of what the proof creates; every one of them is deleted by the same
 // run (and a leftover of an aborted run is removed first).
 const (
-	toolsetsTestPrefix        = "agentlab-toolset"
-	toolsetsAgentReadOnly     = toolsetsTestPrefix + "-ro"
-	toolsetsAgentNone         = toolsetsTestPrefix + "-none"
-	toolsetsAgentFull         = toolsetsTestPrefix + "-full"
-	toolsetsAgentOAuth        = toolsetsTestPrefix + "-oauth"
-	toolsetsAgentLegacy       = toolsetsTestPrefix + "-legacy"
+	toolsetsTestPrefix    = "agentlab-toolset"
+	toolsetsAgentReadOnly = toolsetsTestPrefix + "-ro"
+	toolsetsAgentNone     = toolsetsTestPrefix + "-none"
+	toolsetsAgentFull     = toolsetsTestPrefix + "-full"
+	toolsetsAgentOAuth    = toolsetsTestPrefix + "-oauth"
+	toolsetsAgentLegacy   = toolsetsTestPrefix + "-legacy"
+	// The tenant identity every agent HelmRelease runs as (the connectivity
+	// chart renders the ServiceAccount + RoleBinding from
+	// kagent.fluxServiceAccountName; agent-manager and the portal's template
+	// name it). The chart's engine is multitenant: a HelmRelease that names
+	// no ServiceAccount runs as the namespace's `default`, which holds no
+	// RBAC, and never renders.
+	kagentFluxServiceAccount  = "kagent-flux"
 	toolsetsAgentPortal       = toolsetsTestPrefix + "-portal"
 	toolsetsWorkflowQuery     = toolsetsTestPrefix + "-query"
 	toolsetsWorkflowMutating  = toolsetsTestPrefix + "-mutating"
@@ -421,6 +428,7 @@ metadata:
     app.kubernetes.io/managed-by: agentlab
 spec:
   interval: 10m
+  serviceAccountName: %s
   chartRef:
     kind: OCIRepository
     name: agent
@@ -433,7 +441,7 @@ spec:
       systemMessage: %q
     modelConfig:
       name: %s
-`, toolsetsAgentLegacy, kagentNamespace, kagentNamespace, toolsetsAgentLegacy, toolsetTestAgentSystemMsg, modelConfig)
+`, toolsetsAgentLegacy, kagentNamespace, kagentFluxServiceAccount, kagentNamespace, toolsetsAgentLegacy, toolsetTestAgentSystemMsg, modelConfig)
 	if err := pipeInto([]byte(hr), "kubectl", "apply", "-f", "-"); err != nil {
 		return err
 	}

--- a/internal/lab/toolsetstest_portal.go
+++ b/internal/lab/toolsetstest_portal.go
@@ -373,7 +373,9 @@ func proveToolsetPortal(cfg *config.Config, user *config.User) ([]string, error)
 // composeAgentManifest is the composer's combinedManifest for a new agent
 // (plugins/agent-platform composeManifests.ts): the shared OCIRepository of
 // the chart, then the HelmRelease with the values — `agent`, `modelConfig`
-// and the top-level `toolset` exactly as the Tools step composed it.
+// and the top-level `toolset` exactly as the Tools step composed it — and
+// `spec.serviceAccountName`, which the portal takes from the app-config key
+// `agentPlatform.fluxServiceAccountName` the chart renders (composeManifests.ts).
 func composeAgentManifest(name, modelConfig string, toolset []string) string {
 	quoted := make([]string, 0, len(toolset))
 	for _, sel := range toolset {
@@ -397,6 +399,7 @@ metadata:
   namespace: %[1]s
 spec:
   interval: 10m
+  serviceAccountName: %[6]s
   chartRef:
     kind: OCIRepository
     name: agent
@@ -410,7 +413,7 @@ spec:
     modelConfig:
       name: %[4]s
     toolset: [%[5]s]
-`, kagentNamespace, name, toolsetTestAgentSystemMsg, modelConfig, strings.Join(quoted, ", "))
+`, kagentNamespace, name, toolsetTestAgentSystemMsg, modelConfig, strings.Join(quoted, ", "), kagentFluxServiceAccount)
 }
 
 // scaffold drives the hidden agent-deployment template the wizard's Deploy


### PR DESCRIPTION
## What

Since v0.23.0 the lab installs the agent-platform meta chart, whose bundled Flux engine is **multitenant** (`FluxInstance.spec.cluster.multitenant: true`, `tenantDefaultServiceAccount: default`, helm-controller `--default-service-account=default --no-cross-namespace-refs`). A `HelmRelease` that names no `serviceAccountName` therefore runs as the namespace's `default` ServiceAccount, which holds no RBAC, and never renders:

```
Could not determine release state: failed to retrieve last release from storage: … secrets is forbidden:
User "system:serviceaccount:kagent:default" cannot list resource "secrets"
```

`agentlab toolsets-test` applies two `HelmRelease`s by hand — the "legacy" agent without a toolset value, and the manifest its portal step composes the way the Tools step's composer does — and neither named a ServiceAccount. Both passed on the old lab (the lab's own flux2 controllers ran cluster-admin, no tenancy) and have failed on every meta-chart lab since; v0.23.0's proof list did not include `toolsets-test`.

## Fix

Both `HelmRelease`s carry `spec.serviceAccountName: kagent-flux` — the tenant identity the connectivity chart renders from `kagent.fluxServiceAccountName`, which agent-manager writes (`flux.helmReleaseServiceAccount`) and the portal's composer takes from the app-config key `agentPlatform.fluxServiceAccountName` (`composeManifests.ts`; the chart renders `kagent-flux` into the lab's `agent-platform-backstage-app-config`). The test now mirrors what every agent `HelmRelease` on the platform looks like.

## Verification

On a lab running agent-platform 3.20.2 (built by `platform-down` → `platform` on a cluster an earlier agentlab had built, see #95): `toolsets-test --skip-chat` with this branch's binary → 9/9 PASS (legacy agent renders with no header and implicit full access; the portal's apply path lands the toolset and the header on `agentlab-toolset-portal`). Before the fix the run stopped at the legacy step, and with only the legacy step fixed at the portal step, each with the forbidden-Secrets error above.