### PR TITLE
chore: ignore graphify-out/ (regenerable knowledge graph)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ kubeconfig.oidc
 /bin-dist/
 .ldflags
 .platforms
+
+# graphify knowledge graph (regenerable, rebuilt by the post-commit hook)
+graphify-out/


### PR DESCRIPTION
`graphify-out/` is the machine-local knowledge graph that graphify rebuilds from a post-commit hook. It is regenerable and must never be committed. This adds the same ignore block that `giantswarm/muster` already carries.

No other files change.