### PR TITLE
fix(telemetry): send the version as TelemetryDeck.AppInfo.version so the dashboard's App Versions insight shows agentlab versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,9 @@ The lab's own e2e checks are the `*-test` subcommands, not `go test`.
   keystrokes.
 - `internal/telemetry` — one anonymous usage signal per user-facing command
   to TelemetryDeck (giantswarm/telemetrydeck-go, kubectl-gs's signal shape:
-  `GiantSwarm.command` with the command path and the version). `main.go`
+  `GiantSwarm.command` with the command path and the version; the version
+  and commit also as `TelemetryDeck.AppInfo.version`/`.buildNumber`, which
+  the dashboard's standard insights read). `main.go`
   wires it as the root `PersistentPreRun`; hidden commands (`__complete`),
   `completion` and `help` never count. Opt-outs:
   `AGENTLAB_TELEMETRY_OPTOUT`, `DO_NOT_TRACK=1`. When iterating on the lab,

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -10,7 +10,8 @@ One signal contains:
 
 - the command (`agentlab up`, `agentlab platform-test`, …) — never its
   arguments or flags
-- the agentlab version (what `agentlab --version` prints)
+- the agentlab version (what `agentlab --version` prints) and the commit it
+  was built from
 - operating system and processor architecture
 - the library and version that sent it (`telemetrydeck-go/…`)
 - a user identifier hash: SHA-256 over OS, architecture, host name, OS user

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/creativeprojects/go-selfupdate v1.6.0
 	github.com/giantswarm/selfupdate-cosign v0.1.0
-	github.com/giantswarm/telemetrydeck-go v0.1.26
+	github.com/giantswarm/telemetrydeck-go v0.2.0
 	github.com/smallstep/truststore v0.13.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/giantswarm/selfupdate-cosign v0.1.0 h1:KRfPVIzbaDjO658QcPsFmof0QUAEj6AnIZ2e9mCbThA=
 github.com/giantswarm/selfupdate-cosign v0.1.0/go.mod h1:CVnryjSRY/xDqJDn+QeivgT8+WkOvVbY/Z+xLaIfZ1w=
-github.com/giantswarm/telemetrydeck-go v0.1.26 h1:CX8Df6SMhbfbCetc/biRrXf4YHgZUmC2LyJyULH92EA=
-github.com/giantswarm/telemetrydeck-go v0.1.26/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
+github.com/giantswarm/telemetrydeck-go v0.2.0 h1:Ojw0XncmOEQyM68TK+4T9IYnU6xmJMFM/vr3oS8eb+I=
+github.com/giantswarm/telemetrydeck-go v0.2.0/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-fed/httpsig v1.1.0 h1:9M+hb0jkEICD8/cAiNqEB66R87tTINszBRTjwjQzWcI=

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -62,8 +62,12 @@ func Enabled() bool {
 // Fire-and-forget: the HTTP request runs on its own goroutine while the
 // command does its work, and a failure to deliver is swallowed — telemetry
 // must never get in the user's way. Same shape as kubectl-gs: signal type
-// GiantSwarm.command with the command path and the app version, plus the
-// OS, architecture and SDK version the library adds.
+// GiantSwarm.command with the command path and the app version in the
+// payload, plus the OS, architecture and SDK version the library adds. The
+// version and commit also go out as TelemetryDeck.AppInfo.version and
+// .buildNumber (the library's WithAppVersion/WithBuildNumber): those are the
+// parameters the TelemetryDeck dashboard's standard "App Versions" insight
+// reads — the payload's appVersion is what the shared usage report queries.
 //
 // Not every invocation is a person using the lab: hidden commands are
 // plumbing (__complete runs on every TAB press), `completion` runs on every
@@ -115,5 +119,9 @@ func newClient(testMode bool) (*telemetrydeck.Client, error) {
 			telemetrydeck.WithLogger(log.New(os.Stderr, "telemetry: ", 0)),
 		)
 	}
+	opts = append(opts,
+		telemetrydeck.WithAppVersion(project.Version()),
+		telemetrydeck.WithBuildNumber(project.ShortSHA()),
+	)
 	return telemetrydeck.NewClient(appID, opts...)
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -135,6 +135,14 @@ func TestCommandPostsOneSignal(t *testing.T) {
 		if payload["appVersion"] != project.Version() {
 			t.Errorf("payload.appVersion %v, want %s", payload["appVersion"], project.Version())
 		}
+		// The dashboard's standard "App Versions" insight reads the reserved
+		// parameter, not the payload key the usage report queries.
+		if payload["TelemetryDeck.AppInfo.version"] != project.Version() {
+			t.Errorf("payload[TelemetryDeck.AppInfo.version] %v, want %s", payload["TelemetryDeck.AppInfo.version"], project.Version())
+		}
+		if sha := project.ShortSHA(); sha != "" && payload["TelemetryDeck.AppInfo.buildNumber"] != sha {
+			t.Errorf("payload[TelemetryDeck.AppInfo.buildNumber] %v, want %s", payload["TelemetryDeck.AppInfo.buildNumber"], sha)
+		}
 		for _, k := range []string{"TelemetryDeck.Device.operatingSystem", "TelemetryDeck.Device.architecture", "TelemetryDeck.SDK.nameAndVersion"} {
 			if payload[k] == "" || payload[k] == nil {
 				t.Errorf("payload lacks %s", k)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -51,6 +51,16 @@ func GitSHA() string {
 	return buildSetting("vcs.revision")
 }
 
+// ShortSHA is GitSHA cut to the seven characters git shows, or "" when
+// unknown — the build identifier the usage signal carries.
+func ShortSHA() string {
+	sha := GitSHA()
+	if len(sha) > 7 {
+		sha = sha[:7]
+	}
+	return sha
+}
+
 // BuildTimestamp returns the build (or, unstamped, the commit) time in
 // RFC 3339, or "" when unknown.
 func BuildTimestamp() string {
@@ -65,10 +75,7 @@ func BuildTimestamp() string {
 func VersionLine() string {
 	line := Version()
 	var details []string
-	if sha := GitSHA(); sha != "" {
-		if len(sha) > 7 {
-			sha = sha[:7]
-		}
+	if sha := ShortSHA(); sha != "" {
 		details = append(details, "commit "+sha)
 	}
 	if ts := BuildTimestamp(); ts != "" {


### PR DESCRIPTION
## Problem

The TelemetryDeck dashboard's Overview "App Versions" insight is empty for agentlab (and for kubectl-gs) although events and users are there. The insight breaks down by the reserved parameter `TelemetryDeck.AppInfo.version`, which the official TelemetryDeck SDKs set on every signal; agentlab carried its version only in the payload key `appVersion` (the kubectl-gs shape), which that insight does not read. A `groupBy` over both keys in the Explore Playground shows 16 distinct `appVersion` values and an empty `TelemetryDeck.AppInfo.version` column for every production signal.

## Solution

- telemetrydeck-go v0.2.0 ([#121](https://github.com/giantswarm/telemetrydeck-go/pull/121)) adds `WithAppVersion`/`WithBuildNumber`, which send `TelemetryDeck.AppInfo.version`, `.buildNumber` and `.versionAndBuildNumber` with every signal, and reports the real library version in `TelemetryDeck.SDK.nameAndVersion` instead of the constant `0.0.1`.
- `internal/telemetry` passes `project.Version()` and the short commit (new `project.ShortSHA()`, also used by `--version`). The payload's `appVersion` stays: the usage report queries it.
- docs/telemetry.md and CLAUDE.md name the two parameters; the unit test asserts them on the captured ingest request.

## Verification

- `go test ./internal/telemetry/... ./pkg/project/...` green against v0.2.0.
- Dashboard: with Test Mode on, the App Versions chart shows exactly one bar, `v0.23.3` — the one test signal that carried `TelemetryDeck.AppInfo.version`; the other 89 test signals (legacy key only) are invisible to it. Production versions appear as people run the released binary.
- Historical signals keep only `appVersion`; the standard chart shows versions from this release on.