### PR TITLE
fix(configure): refuse a Helm 3, a kind below 0.31 or a missing tool before the form asks anything

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -154,8 +154,11 @@ Applied to the configuration:
 ```
 
 - **Tools**: `docker`, `kind`, `kubectl`, `helm` are looked up and their
-  versions shown; a missing one (or a Helm 3) is called out here rather than
-  minutes into `agentlab up`.
+  versions shown. A missing one, a kind below 0.31 or a Helm 3 **refuses
+  `configure` right here** — before the first question, with why the lab
+  needs it and where to get it — rather than after the whole form or minutes
+  into `agentlab up`. `helm` is only required while the platform is on
+  (`--platform=false`, the bare kind+Dex sandbox, does without it).
 - **Ports**: every host-side port is probed on 127.0.0.1 — the address all
   kind port mappings bind. While **no kind node of this configuration
   exists** (a fresh lab, or after `agentlab down`), an occupied port is moved

--- a/internal/lab/discover.go
+++ b/internal/lab/discover.go
@@ -75,10 +75,10 @@ const flmOwner = "FastFlowLM"
 func Discover(cfg *config.Config) *Discovery {
 	d := &Discovery{AnthropicKey: os.Getenv(AnthropicKeyEnv) != ""}
 	d.Tools = []ToolVersion{
-		{"docker", dockerVersion()},
-		{"kind", kindVersion()},
-		{"kubectl", kubectlVersion()},
-		{"helm", helmVersion()},
+		{dockerBin, dockerVersion()},
+		{kindBin, kindVersion()},
+		{kubectlBin, kubectlVersion()},
+		{helmBin, helmVersion()},
 	}
 	d.ClusterExists, d.ClusterPorts = kindNodePublishedPorts(cfg.ControlPlaneNode())
 	if gw, err := kindGatewayIP(cfg.ControlPlaneNode()); err == nil {
@@ -124,19 +124,92 @@ func (d *Discovery) ModelServersHint() string {
 	return strings.Join(parts, ", ")
 }
 
-// MissingTools names the CLIs `agentlab up` needs that did not answer.
-func (d *Discovery) MissingTools() []string {
-	var missing []string
-	for _, t := range d.Tools {
-		if t.Version == "" {
-			missing = append(missing, t.Name)
+// kindFloor is the kind the lab needs. The rendered kind config names no node
+// image, so kind's default — the Kubernetes of its release — is what boots,
+// and the lab's OIDC flow relies on an apiserver that keeps retrying discovery
+// until Dex answers (Kubernetes >= 1.35, kind's default since v0.31; up.go,
+// docs/troubleshooting.md). The kubeadm patches are carried in both config
+// generations kind has emitted since (kind-config.yaml.tmpl).
+const kindFloor = "0.31.0"
+
+// toolRequirement is one CLI `agentlab up` shells out to: the version floor
+// the lab needs ("" for any version), whether only the platform needs it, why,
+// and where to get it.
+type toolRequirement struct {
+	name         string
+	floor        string
+	platformOnly bool
+	why          string
+	install      string
+}
+
+// toolRequirements is what Preflight checks the discovered tools against, in
+// report order.
+var toolRequirements = []toolRequirement{
+	{name: dockerBin, why: "kind runs the cluster as a container of this engine (Podman >= 4's docker-compatible CLI works too)",
+		install: "https://docs.docker.com/get-started/get-docker/"},
+	{name: kindBin, floor: kindFloor, why: "its default node image brings the Kubernetes whose apiserver keeps retrying OIDC discovery until Dex answers",
+		install: "https://kind.sigs.k8s.io/docs/user/quick-start/#installation"},
+	{name: kubectlBin, why: "every manifest is applied and every proof is read through it",
+		install: "https://kubernetes.io/docs/tasks/tools/"},
+	{name: helmBin, floor: helmFloor, platformOnly: true, why: helmWhy,
+		install: "https://helm.sh/docs/intro/install/ — the `helm` first on PATH has to be the Helm 4 one"},
+}
+
+// Preflight is the verdict on the tools, taken before `agentlab configure`
+// asks its first question (or, with --defaults, writes anything): an error
+// naming every tool `agentlab up` would fail on — not on PATH, or below the
+// version the lab needs — each with why and where to get it. So nobody walks
+// through the whole form to be refused at boot time. platform says whether
+// the configuration installs the platform; without it (the bare kind+Dex
+// sandbox) helm is not needed.
+func (d *Discovery) Preflight(platform bool) error {
+	var problems []string
+	helmProblem := false
+	for _, req := range toolRequirements {
+		if req.platformOnly && !platform {
+			continue
+		}
+		v := d.toolVersion(req.name)
+		var problem string
+		switch {
+		case v == "":
+			problem = fmt.Sprintf("%s is not on PATH (or does not answer) — %s", req.name, req.why)
+		case req.floor != "":
+			below, err := belowFloor(v, req.floor)
+			switch {
+			case err != nil:
+				problem = fmt.Sprintf("%s reports a version this lab cannot read (%q); it needs %s >= %s — %s", req.name, v, req.name, req.floor, req.why)
+			case below:
+				problem = fmt.Sprintf("%s %s is too old; the lab needs %s >= %s — %s", req.name, v, req.name, req.floor, req.why)
+			}
+		}
+		if problem == "" {
+			continue
+		}
+		problems = append(problems, problem+"\n    install: "+req.install)
+		if req.name == helmBin {
+			helmProblem = true
 		}
 	}
-	return missing
+	if len(problems) == 0 {
+		return nil
+	}
+	var b strings.Builder
+	b.WriteString("this machine cannot run the lab yet:\n")
+	for _, p := range problems {
+		b.WriteString("  - " + p + "\n")
+	}
+	b.WriteString("Install the above and run the command again.")
+	if helmProblem {
+		b.WriteString("\nWithout the platform (`agentlab configure --platform=false`: a bare kind+Dex OIDC sandbox) helm is not needed.")
+	}
+	return errors.New(b.String())
 }
 
 // Report is the human-readable account of the discovery, printed by
-// `agentlab configure` before it changes anything.
+// `agentlab configure` before it changes anything. The tools line only
+// states what answered; the verdict on them is Preflight's.
 func (d *Discovery) Report(cfg *config.Config) string {
 	var b strings.Builder
 	line := func(label, format string, a ...any) {
@@ -152,13 +225,6 @@ func (d *Discovery) Report(cfg *config.Config) string {
 		tools = append(tools, t.Name+" "+t.Version)
 	}
 	line("tools", "%s", strings.Join(tools, ", "))
-	if missing := d.MissingTools(); len(missing) > 0 {
-		line("", "`agentlab up` needs docker, kind, kubectl and helm >= 4 — install: %s", strings.Join(missing, ", "))
-	} else if v := d.toolVersion("helm"); v != "" {
-		if major, err := helmMajor(v); err == nil && major < 4 {
-			line("", "helm %s cannot install the platform: Helm >= 4 is required (agent-platform-standalone#21)", v)
-		}
-	}
 	switch {
 	case d.ClusterExists:
 		line("cluster", "kind %q exists — its port mappings are fixed at node creation (`agentlab down && agentlab up` to change them)", cfg.ClusterName)
@@ -372,9 +438,9 @@ func kubectlVersion() string {
 }
 
 func helmVersion() string {
-	out, err := outputQuiet("helm", "version", "--template", "{{.Version}}")
+	v, err := probeHelmVersion()
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(out)
+	return v
 }

--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -32,9 +32,12 @@ func warn(format string, a ...any) {
 	fmt.Fprintf(os.Stderr, "    WARNING: "+format+"\n", a...)
 }
 
-// The two tools whose cluster is pinned by command; every other subprocess
-// (kind, docker, git, helm's plugins) inherits the environment untouched.
+// The CLIs the lab shells out to. kubectl and helm are the two whose cluster
+// is pinned by command; every other subprocess (kind, docker, git, helm's
+// plugins) inherits the environment untouched.
 const (
+	dockerBin  = "docker"
+	kindBin    = "kind"
 	kubectlBin = "kubectl"
 	helmBin    = "helm"
 )

--- a/internal/lab/helm.go
+++ b/internal/lab/helm.go
@@ -1,47 +1,70 @@
 package lab
 
 import (
+	"errors"
 	"fmt"
-	"strconv"
 	"strings"
+
+	"github.com/Masterminds/semver/v3"
 )
 
-// ensureHelmSupportsPlatform fails fast when the installed Helm cannot
-// install the platform chart. Helm 4's `--wait` is kstatus over the chart's
-// objects, custom resources included: `helm upgrade --install --wait` of the
-// agent-platform chart returns when the FluxInstance and every component
-// HelmRelease are Ready, which is what the platform install relies on and
-// what the chart documents as measured. Helm 3's --wait skips custom
-// resources — the command would return before a single component exists —
-// and the chart's own README lists a Helm 3 install as not measured. Called
+// helmFloor is the Helm the platform install needs. Helm 4's `--wait` is
+// kstatus over the chart's objects, custom resources included: `helm upgrade
+// --install --wait` of the agent-platform chart returns when the FluxInstance
+// and every component HelmRelease are Ready, which is what the platform
+// install relies on and what the chart documents as measured. Helm 3's --wait
+// skips custom resources — the command would return before a single component
+// exists — and the chart's own README lists a Helm 3 install as not measured.
+const helmFloor = "4.0.0"
+
+// helmWhy is the one-clause reason behind helmFloor, worded for the person who
+// has to install it.
+const helmWhy = "the platform install relies on Helm 4's --wait, which waits on the chart's Flux custom resources (the platform is Ready when the command returns); Helm 3's does not"
+
+// ensureHelmSupportsPlatform fails fast when the installed Helm cannot install
+// the platform chart. `agentlab configure` refuses the same Helm before it asks
+// anything (Discovery.Preflight); this is the guard of the lifecycle commands,
+// whose agentlab.yaml may predate a change of the machine's tools — called
 // before any cluster work so a Helm 3 user is not told after a five-minute
 // boot.
 func ensureHelmSupportsPlatform() error {
-	raw, err := outputQuiet("helm", "version", "--template", "{{.Version}}")
+	version, err := probeHelmVersion()
 	if err != nil {
 		return fmt.Errorf("probing the helm version (`helm version`): %w", err)
 	}
-	version := strings.TrimSpace(raw)
-	major, err := helmMajor(version)
+	below, err := belowFloor(version, helmFloor)
 	if err != nil {
 		return err
 	}
-	if major < 4 {
-		return fmt.Errorf("helm %s cannot install the agent platform — Helm >= 4 is required:\n"+
-			"the install relies on Helm 4's --wait, which waits on the chart's Flux custom\n"+
-			"resources (the platform is Ready when the command returns); Helm 3's does not,\n"+
-			"and the agent-platform chart documents a Helm 3 install as not measured", version)
+	if below {
+		return fmt.Errorf("helm %s cannot install the agent platform — Helm >= %s is required:\n%s", version, helmFloor, helmWhy)
 	}
 	return nil
 }
 
-// helmMajor extracts the major version from `helm version --template
-// {{.Version}}` output ("v4.2.2").
-func helmMajor(version string) (int, error) {
-	majorStr, _, _ := strings.Cut(strings.TrimPrefix(version, "v"), ".")
-	major, err := strconv.Atoi(majorStr)
+// probeHelmVersion is `helm version --template {{.Version}}` ("v4.2.2").
+func probeHelmVersion() (string, error) {
+	raw, err := outputQuiet("helm", "version", "--template", "{{.Version}}")
 	if err != nil {
-		return 0, fmt.Errorf("unparseable helm version %q", version)
+		return "", err
 	}
-	return major, nil
+	return strings.TrimSpace(raw), nil
+}
+
+// belowFloor reports whether a tool's reported version is below the floor the
+// lab needs. The version is the first word of what the tool printed, with or
+// without a leading v; a pre-release of the floor counts as reaching it
+// (v4.0.0-rc.1 is a Helm 4). An unparseable version is an error, never a
+// pass.
+func belowFloor(version, floor string) (bool, error) {
+	fields := strings.Fields(version)
+	if len(fields) == 0 {
+		return false, errors.New("empty version")
+	}
+	v, err := semver.NewVersion(fields[0])
+	if err != nil {
+		return false, fmt.Errorf("unparseable version %q", version)
+	}
+	release, _ := v.SetPrerelease("")
+	return release.LessThan(semver.MustParse(floor)), nil
 }

--- a/internal/lab/helm_test.go
+++ b/internal/lab/helm_test.go
@@ -2,33 +2,37 @@ package lab
 
 import "testing"
 
-func TestHelmMajor(t *testing.T) {
+func TestBelowFloor(t *testing.T) {
 	cases := []struct {
-		version string
-		want    int
-		wantErr bool
+		version, floor string
+		want           bool
+		wantErr        bool
 	}{
-		{"v4.2.2", 4, false},
-		{"v3.19.0", 3, false},
-		{"v4.0.0-rc.1", 4, false},
-		{"4.2.2", 4, false}, // defensive: no leading v
-		{"", 0, true},
-		{"garbage", 0, true},
+		{"v4.2.2", helmFloor, false, false},
+		{"v3.19.0", helmFloor, true, false},
+		{"v4.0.0-rc.1", helmFloor, false, false}, // a pre-release of the floor reaches it
+		{"4.2.2", helmFloor, false, false},       // defensive: no leading v
+		{"v0.32.0", kindFloor, false, false},
+		{"v0.31.0", kindFloor, false, false},
+		{"v0.30.0", kindFloor, true, false},
+		{"v0.32.0 go1.26.4 linux/amd64", kindFloor, false, false}, // the first word is the version
+		{"", helmFloor, false, true},
+		{"garbage", helmFloor, false, true},
 	}
 	for _, c := range cases {
-		got, err := helmMajor(c.version)
+		got, err := belowFloor(c.version, c.floor)
 		if c.wantErr {
 			if err == nil {
-				t.Errorf("helmMajor(%q): expected error, got %d", c.version, got)
+				t.Errorf("belowFloor(%q, %q): expected error, got %v", c.version, c.floor, got)
 			}
 			continue
 		}
 		if err != nil {
-			t.Errorf("helmMajor(%q): %v", c.version, err)
+			t.Errorf("belowFloor(%q, %q): %v", c.version, c.floor, err)
 			continue
 		}
 		if got != c.want {
-			t.Errorf("helmMajor(%q) = %d, want %d", c.version, got, c.want)
+			t.Errorf("belowFloor(%q, %q) = %v, want %v", c.version, c.floor, got, c.want)
 		}
 	}
 }

--- a/internal/lab/preflight_test.go
+++ b/internal/lab/preflight_test.go
@@ -1,0 +1,68 @@
+package lab
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDiscoveryPreflight: the verdict `agentlab configure` takes on the tools
+// before its first question — every missing or too-old tool named with its
+// install hint, helm only while the platform is on, nothing when all answer.
+func TestDiscoveryPreflight(t *testing.T) {
+	const sandboxFlag = "--platform=false"
+	tools := func(docker, kind, kubectl, helm string) []ToolVersion {
+		return []ToolVersion{{dockerBin, docker}, {kindBin, kind}, {kubectlBin, kubectl}, {helmBin, helm}}
+	}
+	cases := []struct {
+		name     string
+		tools    []ToolVersion
+		platform bool
+		want     []string // substrings of the error; nil for no error
+		wantNot  []string
+	}{
+		{name: "all good", tools: tools("29.7.2", "v0.32.0", "v1.36.4", "v4.2.2"), platform: true},
+		{name: "podman", tools: tools("5.8.4 (podman)", "v0.32.0", "v1.36.4", "v4.2.2"), platform: true},
+		{name: "helm 3 with the platform", tools: tools("29.7.2", "v0.32.0", "v1.36.4", "v3.19.0"), platform: true,
+			want:    []string{"helm v3.19.0 is too old; the lab needs helm >= 4.0.0", "https://helm.sh/docs/intro/install/", sandboxFlag},
+			wantNot: []string{"kind v", "kind is", "docker is", "kubectl is"}},
+		{name: "helm 3 without the platform", tools: tools("29.7.2", "v0.32.0", "v1.36.4", "v3.19.0"), platform: false},
+		{name: "helm missing without the platform", tools: tools("29.7.2", "v0.32.0", "v1.36.4", ""), platform: false},
+		{name: "helm pre-release of 4", tools: tools("29.7.2", "v0.32.0", "v1.36.4", "v4.0.0-rc.1"), platform: true},
+		{name: "old kind", tools: tools("29.7.2", "v0.30.0", "v1.36.4", "v4.2.2"), platform: true,
+			want:    []string{"kind v0.30.0 is too old; the lab needs kind >= 0.31.0", "kind.sigs.k8s.io"},
+			wantNot: []string{"helm v", "helm is", sandboxFlag}},
+		{name: "everything missing", tools: tools("", "", "", ""), platform: true,
+			want: []string{"docker is not on PATH", "kind is not on PATH", "kubectl is not on PATH", "helm is not on PATH",
+				"docs.docker.com", "kubernetes.io/docs/tasks/tools", "run the command again", sandboxFlag}},
+		{name: "unreadable kind version", tools: tools("29.7.2", "kind", "v1.36.4", "v4.2.2"), platform: true,
+			want: []string{`kind reports a version this lab cannot read ("kind")`}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := &Discovery{Tools: c.tools}
+			err := d.Preflight(c.platform)
+			if c.want == nil {
+				if err != nil {
+					t.Fatalf("expected no refusal, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected a refusal naming %q", c.want)
+			}
+			for _, w := range c.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("refusal lacks %q:\n%v", w, err)
+				}
+			}
+			for _, w := range c.wantNot {
+				if strings.Contains(err.Error(), w) {
+					t.Errorf("refusal must not mention %q:\n%v", w, err)
+				}
+			}
+			if !strings.HasPrefix(err.Error(), "this machine cannot run the lab yet:\n  - ") {
+				t.Errorf("refusal should open with the verdict and a list:\n%v", err)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -145,6 +145,11 @@ func loadOrCreateConfig() (*config.Config, error) {
 	fmt.Printf("No %s yet — let's create one.\n\n", config.File)
 	cfg = config.Default()
 	disc := discoverInto(cfg, nil, nil)
+	// The tools before the questions: a Helm 3 or a missing kind is refused
+	// here, not after the form and a cluster boot.
+	if err := disc.Preflight(cfg.Platform.Enabled); err != nil {
+		return nil, err
+	}
 	if err := forms.Run(cfg, accessibleMode(), forms.Hints{ModelServers: disc.ModelServersHint()}); err != nil {
 		return nil, err
 	}
@@ -274,6 +279,14 @@ func configureCmd() *cobra.Command {
 			// on them (managed models need the agents runtime).
 			if cmd.Flags().Changed("platform") {
 				cfg.Platform.Enabled = platform
+				// Backstage implies the platform (Normalize), so turning
+				// the platform off turns Backstage off with it unless
+				// --backstage says otherwise — `--platform=false` alone is
+				// the bare kind+Dex sandbox the docs promise, not a
+				// validation error about Backstage.
+				if !platform && !cmd.Flags().Changed("backstage") {
+					cfg.Backstage.Enabled = false
+				}
 			}
 			if cmd.Flags().Changed("agents") {
 				cfg.Platform.Agents = agents
@@ -303,6 +316,14 @@ func configureCmd() *cobra.Command {
 			// follows the host too: a server that appeared is added, one that
 			// is gone drops out, ports move while no cluster holds them.
 			disc := discoverInto(cfg, pinEnabled, pinBackends)
+			// The tools before the questions (or, with --defaults, before
+			// the file): what `agentlab up` would refuse is refused here,
+			// with the install hints, instead of after the whole form. The
+			// component flags are applied above, so --platform=false is
+			// spared the helm check.
+			if err := disc.Preflight(cfg.Platform.Enabled); err != nil {
+				return err
+			}
 			if defaults {
 				if err := cfg.Validate(); err != nil {
 					return err


### PR DESCRIPTION
## Problem

A Helm 3 user walked through every question of the `configure` form (a first `agentlab up` runs the same form) and was told only afterwards, by `up`'s Helm guard, that the platform needs Helm 4. The discovery already looked the tools up, but its verdict was one indented line in the report, right before the form took the screen. Feedback from Marian.

## Change

- `Discovery.Preflight(platform)` is the verdict on the tools, taken by `configure` (interactive and `--defaults`) and by the first-run path of every lifecycle command **before the first question / before anything is written**. Every tool `agentlab up` would fail on is named with why the lab needs it and where to get it:
  - `docker`, `kind`, `kubectl` not on PATH (or not answering)
  - `kind` below 0.31 (the rendered kind config names no node image, so kind's default Kubernetes is what boots, and the OIDC flow relies on the apiserver retrying discovery until Dex answers — Kubernetes ≥ 1.35, kind's default since v0.31; README already required it)
  - `helm` below 4, only while the platform is on — the refusal names `--platform=false`, the bare kind+Dex sandbox, as the way around it
- `up` / `platform` keep their own Helm guard (an `agentlab.yaml` can predate a change of the machine's tools); both now share one semver floor check (`belowFloor`; a pre-release of the floor reaches it) instead of a hand-rolled major parse.
- `--platform=false` alone also turns Backstage off (unless `--backstage` is passed) instead of failing validation with "backstage requires the agent platform" — the sandbox the docs promise.
- Docs: the getting-started "Tools" bullet says the refusal happens here.

## Verified

Built binary, fake `helm` printing `v3.19.0` first on PATH:

- `agentlab configure --defaults` → discovery report, then the refusal; no `agentlab.yaml` written.
- bare `agentlab up` with no `agentlab.yaml` on a pseudo-TTY → "No agentlab.yaml yet", discovery report, the refusal — **the form never opens**.
- `agentlab configure --defaults --platform=false` → saved (platform false, backstage false).
- PATH without `kind`, real Helm 4 → refusal names kind only, with the install link.

Unit tests for the verdict (`TestDiscoveryPreflight`) and the floor check (`TestBelowFloor`); `go test ./...` and `golangci-lint run -E gosec -E goconst` clean.

The refusal as printed:

```
Error: this machine cannot run the lab yet:
  - helm v3.19.0 is too old; the lab needs helm >= 4.0.0 — the platform install relies on Helm 4's --wait, which waits on the chart's Flux custom resources (the platform is Ready when the command returns); Helm 3's does not
    install: https://helm.sh/docs/intro/install/ — the `helm` first on PATH has to be the Helm 4 one
Install the above and run the command again.
Without the platform (`agentlab configure --platform=false`: a bare kind+Dex OIDC sandbox) helm is not needed.
```
