### PR TITLE
fix(preload): side-load with `docker save --platform` + `kind load image-archive` — kind's own load fails under Docker's containerd image store (kind#3795)

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -487,6 +487,27 @@ uninstall) ahead of the kagent HelmRelease; the connectivity release adopts
 it on install and deletes it with the release. `ensureNamespace` for kagent
 is deleted; a fresh `agentlab up` gets the namespace from the hook.
 
+### U21. `preload.go`: the docker side-load is `docker save --platform` + `kind load image-archive` — BLOCKED UPSTREAM
+`kind load docker-image` runs a plain `docker save` and pipes the archive into
+the node's `ctr images import --all-platforms`. Under Docker's containerd image
+store — the default on Docker Desktop and on new Docker 29 installs — that
+archive carries a pulled image's whole multi-platform index while only the
+host platform's blobs were ever pulled, and the import fails on the first
+missing digest: `ERROR: failed to load image: command "docker exec ... ctr
+--namespace=k8s.io images import --all-platforms ..." failed with error: exit
+status 1` / `content digest sha256:...: not found`, once per side-load lane,
+every image degrading to the in-node pull the preload exists to avoid
+([kubernetes-sigs/kind#3795](https://github.com/kubernetes-sigs/kind/issues/3795),
+open since 2024-11; the maintainers point consumers to `docker save --platform
+| kind load image-archive` and will not lock the platform inside `kind load`).
+The lab does exactly that under docker (`dockerLoadImages`): `docker image
+inspect` says which platform the host holds each ref in, one `docker save
+--platform <p> -o <tmp.tar>` per platform, `kind load image-archive` of each.
+Needs Docker 28 (API 1.48) for `docker save --platform`; an older
+client/daemon keeps kind's own load, which is right under the classic graph
+driver. Podman keeps its one-image-per-call load (U16). Unblocks when kind's
+`load docker-image` survives the containerd image store.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -78,9 +78,19 @@ plumbing for model servers under
   process is using the cluster (`ps -eo pid,args | grep '[a]gentlab '`).
 - **The image cache manifest only records what a registry can serve.**
   `state/preload-images.txt` is snapshotted from the node after every boot;
-  an image built on the host and side-loaded (`kind load docker-image
-  backstage-dev:<tag>`) shows up there as `docker.io/library/backstage-dev:<tag>`
+  an image built on the host and side-loaded (a `platform.devImages` swap,
+  `backstage-dev:<tag>`) shows up there as `docker.io/library/backstage-dev:<tag>`
   — a Docker Hub ref that does not exist — and once the local copy is pruned
   every boot would ask Docker Hub for it (`denied: requested access to the
   resource is denied` in the dockerd log, once per ref). Images the host cache
   knows without a registry digest are therefore left out of the snapshot.
+- **`ERROR: failed to load image: command "docker exec ... ctr ... images import
+  --all-platforms ..." failed with error: exit status 1` during `up`** is kind's
+  own `kind load docker-image` meeting Docker's containerd image store (Docker
+  Desktop, new Docker 29 installs): its plain `docker save` writes a
+  multi-platform index whose other platforms were never pulled, and the node's
+  import fails on the first missing digest (kubernetes-sigs/kind#3795). The lab
+  side-loads with `docker save --platform` + `kind load image-archive` instead
+  wherever `docker save --platform` exists — Docker 28 or newer — so seeing this
+  means an older docker: upgrade it. The boot went on regardless; the affected
+  images were pulled by the node.

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -811,7 +811,8 @@ func ensureNodeImages(cfg *config.Config, refs []string) error {
 	}
 	if still := missingImages(have, refs); len(still) > 0 {
 		return fmt.Errorf("dev images not on the node %s after side-loading: %s\n"+
-			"check `docker image inspect <ref>` on the host and `kind load docker-image --name %s <ref>`,\n"+
+			"check `docker image inspect <ref>` on the host, load it by hand\n"+
+			"(`docker save --platform linux/<arch> -o img.tar <ref> && kind load image-archive --name %s img.tar`),\n"+
 			"then re-run `agentlab platform`", cfg.ControlPlaneNode(), strings.Join(still, ", "), cfg.ClusterName)
 	}
 	note("all %d dev images are on the node", len(refs))

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -98,20 +100,16 @@ func sideloadImages(cfg *config.Config, images []string) preloadResult {
 	return preloadResult{n: loaded, d: time.Since(start).Round(time.Second), err: err}
 }
 
-// kindLoadImages side-loads images and reports how many landed. It is one
-// `kind load docker-image` for the batch — except under podman, where kind's
-// own multi-image save would fold the batch into one image under every tag
-// (runtime.go): there it is one call per image, which saves a single image
-// and is always right. kind stages and cleans its own archive either way. A
-// failed image does not stop the rest, so the count and the error are both
-// reported and a partial load reads as one.
+// kindLoadImages side-loads images and reports how many landed. Under docker
+// the batch is saved per platform and loaded as archives (dockerLoadImages).
+// Under podman it is one `kind load docker-image` per image: kind's own
+// multi-image save would fold the batch into one image under every tag
+// (runtime.go), and a single-image save is always right. A failed image does
+// not stop the rest, so the count and the error are both reported and a
+// partial load reads as one.
 func kindLoadImages(cfg *config.Config, images []string) (int, error) {
 	if !dockerIsPodman() {
-		args := append([]string{"load", "docker-image", "--name", cfg.ClusterName}, images...)
-		if err := runQuiet("kind", args...); err != nil {
-			return 0, err
-		}
-		return len(images), nil
+		return dockerLoadImages(cfg, images)
 	}
 	loaded := 0
 	var errs []error
@@ -123,6 +121,137 @@ func kindLoadImages(cfg *config.Config, images []string) (int, error) {
 		loaded++
 	}
 	return loaded, errors.Join(errs...)
+}
+
+// dockerLoadImages is the docker side-load: `docker save --platform <what the
+// host holds>` into an archive, `kind load image-archive` of that — one
+// archive per platform — instead of `kind load docker-image`. kind's own load
+// runs a plain `docker save`, and under Docker's containerd image store (the
+// default on Docker Desktop and on new Docker 29 installs) that archive
+// carries the image's whole multi-platform index while only the host
+// platform's blobs were ever pulled; the node's `ctr images import
+// --all-platforms` then fails on the first missing digest
+// (kubernetes-sigs/kind#3795, HACKS.md U21). Saving only the platform the
+// host has — `docker image inspect` says which — writes an archive whose
+// index references nothing it does not carry, and is the recipe kind's
+// maintainers give consumers. `docker save --platform` arrived with Docker
+// 28 (API 1.48); an older engine keeps kind's own load, which is right under
+// the classic graph driver — the only store such an engine is likely to run.
+func dockerLoadImages(cfg *config.Config, images []string) (int, error) {
+	if !dockerSaveHasPlatform() {
+		args := append([]string{"load", "docker-image", "--name", cfg.ClusterName}, images...)
+		if err := runQuiet("kind", args...); err != nil {
+			return 0, err
+		}
+		return len(images), nil
+	}
+	groups, errs := hostImagePlatforms(images)
+	loaded := 0
+	for _, platform := range slices.Sorted(maps.Keys(groups)) {
+		imgs := groups[platform]
+		if err := saveAndLoadArchive(cfg, platform, imgs); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		loaded += len(imgs)
+	}
+	return loaded, errors.Join(errs...)
+}
+
+// imagePlatformFormat is the `docker image inspect` template that spells the
+// platform the host holds an image in the way `docker save --platform` wants
+// it: os/arch, with the variant where there is one (linux/arm/v7).
+const imagePlatformFormat = "{{.Os}}/{{.Architecture}}{{if .Variant}}/{{.Variant}}{{end}}"
+
+// hostImagePlatforms groups refs by the platform the host cache holds them in,
+// keeping each group in input order. A ref the host cannot inspect is not in
+// the cache: it is reported and left out, and the node pulls it itself.
+func hostImagePlatforms(images []string) (map[string][]string, []error) {
+	platforms := make([]string, len(images))
+	errs := make([]error, len(images))
+	var wg sync.WaitGroup
+	for i, img := range images {
+		wg.Go(func() {
+			out, err := outputQuiet("docker", "image", "inspect", "-f", imagePlatformFormat, img)
+			platforms[i], errs[i] = strings.TrimSpace(out), err
+		})
+	}
+	wg.Wait()
+	groups := map[string][]string{}
+	var failed []error
+	for i, img := range images {
+		if errs[i] != nil {
+			failed = append(failed, errs[i])
+			continue
+		}
+		groups[platforms[i]] = append(groups[platforms[i]], img)
+	}
+	return groups, failed
+}
+
+// saveAndLoadArchive writes the images' <platform> variants to a temporary
+// archive and loads it into the cluster's nodes. The archive is removed
+// either way; kind stages its own the same way, so the footprint is the one
+// `kind load docker-image` always had.
+func saveAndLoadArchive(cfg *config.Config, platform string, images []string) error {
+	f, err := os.CreateTemp("", "agentlab-images-*.tar")
+	if err != nil {
+		return err
+	}
+	tar := f.Name()
+	_ = f.Close()
+	defer func() { _ = os.Remove(tar) }()
+	// docker's one-line stderr (the ref and platform it could not export)
+	// belongs in the error the caller reports; kind's failure output is a
+	// diagnosis of its own and goes to the terminal as every kind call's does.
+	args := append([]string{"save", "--platform", platform, "-o", tar}, images...)
+	if _, err := outputQuiet("docker", args...); err != nil {
+		return err
+	}
+	return runQuiet("kind", "load", "image-archive", "--name", cfg.ClusterName, tar)
+}
+
+// dockerSaveHasPlatform reports whether `docker save --platform` works here:
+// the flag arrived with Docker 28 (API 1.48) and both the client and the
+// daemon have to speak that API. Cached for the process; a variable so tests
+// can pin the answer.
+var dockerSaveHasPlatform = sync.OnceValue(func() bool {
+	out, err := outputQuiet("docker", "version", "-f", "{{.Client.APIVersion}} {{.Server.APIVersion}}")
+	return err == nil && saveHasPlatform(out)
+})
+
+// saveHasPlatform reads `docker version -f '{{.Client.APIVersion}}
+// {{.Server.APIVersion}}'` ("1.53 1.53"): both at 1.48 or newer. The client
+// reports the version it negotiated with the daemon, so an old daemon shows on
+// both sides; an old client never prints a version it does not know.
+func saveHasPlatform(out string) bool {
+	versions := strings.Fields(out)
+	if len(versions) != 2 {
+		return false
+	}
+	for _, v := range versions {
+		if !apiAtLeast(v, 1, 48) {
+			return false
+		}
+	}
+	return true
+}
+
+// apiAtLeast compares a docker API version ("1.48") against major.minor.
+func apiAtLeast(v string, major, minor int) bool {
+	before, after, ok := strings.Cut(strings.TrimSpace(v), ".")
+	if !ok {
+		return false
+	}
+	gotMajor, err := strconv.Atoi(before)
+	if err != nil {
+		return false
+	}
+	gotMinor, err := strconv.Atoi(after)
+	if err != nil {
+		return false
+	}
+	return gotMajor > major || (gotMajor == major && gotMinor >= minor)
 }
 
 // pullLabImages starts pulling the snapshot manifest's images into the host

--- a/internal/lab/preload_test.go
+++ b/internal/lab/preload_test.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -183,17 +184,27 @@ func TestParseImageProvenancePodman(t *testing.T) {
 	}
 }
 
-// The reason this whole podman branch exists: `kind load docker-image a b c`
-// runs one `docker save` of all three, and podman's archive is single-image,
-// so the batch would land one image under every tag. Under podman the lab
-// therefore loads one image per call; under docker the batch stays one call.
+// withSavePlatform pins whether `docker save --platform` counts as available
+// (Docker 28+) for the test's duration.
+func withSavePlatform(t *testing.T, has bool) {
+	t.Helper()
+	prev := dockerSaveHasPlatform
+	dockerSaveHasPlatform = func() bool { return has }
+	t.Cleanup(func() { dockerSaveHasPlatform = prev })
+}
+
+// The two side-loads that still go through kind's own `kind load docker-image`.
+// Podman: kind's multi-image `docker save` is single-image there, so the batch
+// would land one image under every tag — one call per image. Docker older
+// than 28: no `docker save --platform`, so kind's own batched save it is (right
+// under the classic graph driver such an engine runs).
 func TestKindLoadImagesOneCallPerImageUnderPodman(t *testing.T) {
 	images := []string{refPostgres, refGolangADK, refMusterDev}
 	for name, tc := range map[string]struct {
 		podman    bool
 		wantCalls []string
 	}{
-		"docker batches": {false, []string{
+		"docker without save --platform batches": {false, []string{
 			"kind load docker-image --name agentlab " + refPostgres + " " + refGolangADK + " " + refMusterDev,
 		}},
 		"podman loads one at a time": {true, []string{
@@ -205,7 +216,9 @@ func TestKindLoadImagesOneCallPerImageUnderPodman(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
 			calls := installFakeTool(t, dir, "kind", "exit 0")
+			dockerCalls := installFakeTool(t, dir, "docker", "exit 0")
 			withPodman(t, tc.podman)
+			withSavePlatform(t, false)
 			cfg := config.Default()
 			loaded, err := kindLoadImages(cfg, images)
 			if err != nil {
@@ -218,7 +231,175 @@ func TestKindLoadImagesOneCallPerImageUnderPodman(t *testing.T) {
 			if !slices.Equal(got, tc.wantCalls) {
 				t.Errorf("calls\n got  %v\n want %v", got, tc.wantCalls)
 			}
+			if d := readCalls(t, dockerCalls); d != "" {
+				t.Errorf("kind's own load must not shell out to docker itself, got:\n%s", d)
+			}
 		})
+	}
+}
+
+// tarPathRe matches the temporary archive's path in a stand-in's call log.
+var tarPathRe = regexp.MustCompile(`\S+\.tar`)
+
+// kindLoadArchiveCall is the one kind call the docker side-load makes, as the
+// stand-in logs it with the archive path normalised.
+const kindLoadArchiveCall = "kind load image-archive --name agentlab <tar>"
+
+// callLines splits a stand-in's log into lines with the archive path
+// normalised to <tar>, so the argv can be compared exactly.
+func callLines(t *testing.T, path string) []string {
+	t.Helper()
+	raw := strings.TrimSpace(readCalls(t, path))
+	if raw == "" {
+		return nil
+	}
+	return strings.Split(tarPathRe.ReplaceAllString(raw, "<tar>"), "\n")
+}
+
+// installSideloadFakes puts a docker and a kind on PATH for the docker
+// side-load: docker answers `image inspect` with a platform per ref (muster
+// amd64, everything else arm64) and creates the archive `save` is asked for;
+// kind's `load image-archive` insists the archive exists when it runs. The
+// archives land in dir (TMPDIR), where the test can see them gone again.
+func installSideloadFakes(t *testing.T, dir, saveBody string) (dockerCalls, kindCalls string) {
+	t.Helper()
+	t.Setenv("TMPDIR", dir)
+	dockerCalls = installFakeTool(t, dir, "docker", `case "$1 $2" in
+"image inspect") case "$5" in
+  *muster*) echo linux/amd64 ;;
+  *socat*) echo "Error response from daemon: No such image: $5" >&2; exit 1 ;;
+  *) echo linux/arm64/v8 ;;
+  esac ;;
+"save --platform") `+saveBody+` ;;
+*) echo "unexpected docker $*" >&2; exit 2 ;;
+esac`)
+	kindCalls = installFakeTool(t, dir, "kind", `[ "$1 $2" = "load image-archive" ] || { echo "unexpected kind $*" >&2; exit 2; }
+[ -f "$5" ] || { echo "archive $5 is not there" >&2; exit 1; }`)
+	withPodman(t, false)
+	withSavePlatform(t, true)
+	return dockerCalls, kindCalls
+}
+
+// leftoverArchives lists the temporary archives still in dir.
+func leftoverArchives(t *testing.T, dir string) []string {
+	t.Helper()
+	left, err := filepath.Glob(filepath.Join(dir, "agentlab-images-*.tar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return left
+}
+
+// Under docker the side-load is `docker save --platform` + `kind load
+// image-archive`, one archive per platform the host holds the images in,
+// never kind's own `kind load docker-image`: its plain `docker save` breaks
+// under the containerd image store (kind#3795). Every ref is inspected for
+// its platform, the archives are written where docker was told to and are
+// gone afterwards.
+func TestDockerLoadImagesSavesOneArchivePerPlatform(t *testing.T) {
+	dir := t.TempDir()
+	dockerCalls, kindCalls := installSideloadFakes(t, dir, `: > "$5"`)
+	images := []string{refPostgres, refGolangADK, refMusterDev}
+	loaded, err := kindLoadImages(config.Default(), images)
+	if err != nil {
+		t.Fatalf("kindLoadImages: %v", err)
+	}
+	if loaded != len(images) {
+		t.Errorf("loaded %d images, want %d", loaded, len(images))
+	}
+	var inspects, saves []string
+	for _, c := range callLines(t, dockerCalls) {
+		if strings.HasPrefix(c, "docker image inspect ") {
+			inspects = append(inspects, c)
+		} else {
+			saves = append(saves, c)
+		}
+	}
+	slices.Sort(inspects)
+	wantInspects := []string{
+		"docker image inspect -f " + imagePlatformFormat + " " + refPostgres,
+		"docker image inspect -f " + imagePlatformFormat + " " + refGolangADK,
+		"docker image inspect -f " + imagePlatformFormat + " " + refMusterDev,
+	}
+	slices.Sort(wantInspects)
+	if !slices.Equal(inspects, wantInspects) {
+		t.Errorf("inspects\n got  %v\n want %v", inspects, wantInspects)
+	}
+	wantSaves := []string{
+		"docker save --platform linux/amd64 -o <tar> " + refMusterDev,
+		"docker save --platform linux/arm64/v8 -o <tar> " + refPostgres + " " + refGolangADK,
+	}
+	if !slices.Equal(saves, wantSaves) {
+		t.Errorf("saves\n got  %v\n want %v", saves, wantSaves)
+	}
+	wantKind := []string{kindLoadArchiveCall, kindLoadArchiveCall}
+	if got := callLines(t, kindCalls); !slices.Equal(got, wantKind) {
+		t.Errorf("kind calls\n got  %v\n want %v", got, wantKind)
+	}
+	if left := leftoverArchives(t, dir); len(left) > 0 {
+		t.Errorf("temporary archives left behind: %v", left)
+	}
+}
+
+// A platform group whose save fails, and a ref the host cannot inspect, must
+// not stop the other groups: the count says how many landed, the error names
+// what did not, and no archive is left behind either way.
+func TestDockerLoadImagesPartialFailure(t *testing.T) {
+	dir := t.TempDir()
+	dockerCalls, kindCalls := installSideloadFakes(t, dir, `case "$3" in
+  linux/amd64) echo "Error response from daemon: no suitable export target found" >&2; exit 1 ;;
+  *) : > "$5" ;;
+  esac`)
+	loaded, err := kindLoadImages(config.Default(), []string{refPostgres, refSocat, refGolangADK, refMusterDev})
+	if err == nil {
+		t.Fatal("a failed save and an uninspectable ref must surface as an error")
+	}
+	for _, want := range []string{"No such image", "no suitable export target"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must carry %q, got:\n%v", want, err)
+		}
+	}
+	if loaded != 2 {
+		t.Errorf("loaded = %d, want 2 (the arm64 group must land despite the rest)", loaded)
+	}
+	var saves []string
+	for _, c := range callLines(t, dockerCalls) {
+		if strings.HasPrefix(c, "docker save ") {
+			saves = append(saves, c)
+		}
+	}
+	wantSaves := []string{
+		"docker save --platform linux/amd64 -o <tar> " + refMusterDev,
+		"docker save --platform linux/arm64/v8 -o <tar> " + refPostgres + " " + refGolangADK,
+	}
+	if !slices.Equal(saves, wantSaves) {
+		t.Errorf("saves\n got  %v\n want %v", saves, wantSaves)
+	}
+	if got, want := callLines(t, kindCalls), []string{kindLoadArchiveCall}; !slices.Equal(got, want) {
+		t.Errorf("kind calls\n got  %v\n want %v (only the group whose save succeeded)", got, want)
+	}
+	if left := leftoverArchives(t, dir); len(left) > 0 {
+		t.Errorf("temporary archives left behind: %v", left)
+	}
+}
+
+// saveHasPlatform reads both API versions `docker version` prints: `docker
+// save --platform` needs 1.48 (Docker 28) on the client and the daemon.
+func TestSaveHasPlatform(t *testing.T) {
+	for out, want := range map[string]bool{
+		"1.53 1.53\n": true,
+		"1.48 1.48":   true,
+		"2.0 2.1":     true,
+		"1.47 1.47":   false,
+		"1.53 1.47":   false,
+		"1.47 1.53":   false,
+		"1.48":        false,
+		"":            false,
+		"x.y 1.53":    false,
+	} {
+		if got := saveHasPlatform(out); got != want {
+			t.Errorf("saveHasPlatform(%q) = %v, want %v", out, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #102 — Marian's report: `agentlab up` prints `ERROR: failed to load image: command "docker exec --privileged -i agentlab-control-plane ctr --namespace=k8s.io images import --all-platforms --digests --snapshotter=overlayfs -" failed with error: exit status 1` several times.

## Root cause

`kind load docker-image` runs a plain `docker save` and pipes the archive into the node's `ctr images import --all-platforms`. Under Docker's **containerd image store** (the default on Docker Desktop and on new Docker 29 installs) that archive carries a pulled image's whole multi-platform index while only the host platform's blobs were ever pulled, so the import fails on the first missing digest (`ctr: content digest sha256:…: not found`). Once per side-load lane, every image degrading to the in-node pull the preload exists to avoid; a `platform.devImages` swap fails outright. Upstream: kubernetes-sigs/kind#3795 (open since 2024-11) — the maintainers point consumers to `docker save --platform … | kind load image-archive` and will not lock the platform inside `kind load`.

## Fix

Under docker the side-load is now `docker save --platform <the platform the host holds the ref in, per docker image inspect> -o <tmp.tar> <refs…>` + `kind load image-archive`, one archive per platform, the archive removed either way (`dockerLoadImages` in `preload.go`). `docker save --platform` needs Docker 28 (API 1.48); an older client/daemon pair keeps kind's own batched load, which is right under the classic graph driver such an engine runs. Podman keeps its one-image-per-call load (HACKS.md U16). HACKS.md U21 documents the upstream blocker; troubleshooting names the symptom (on Docker ≥ 28 it can no longer occur).

## Verification

- **Reproduced and proven in Docker-in-Docker** (Docker 29.8.0, `driver-type io.containerd.snapshotter.v1`, kind v0.32.0, kindest/node v1.36.1): `kind load docker-image alpine:3.22` fails exactly as reported; `docker save --platform linux/amd64 -o imgs.tar alpine:3.22 busybox:1.37 && kind load image-archive imgs.tar` lands both (`crictl images` lists them); a local `docker build` loads the same way; a same-repo re-tag re-imports idempotently; a platform the host does not hold fails the save with a clear daemon error.
- **Unit tests** pin the argv: per-platform `docker save --platform` + `kind load image-archive` with the archive present when kind runs and gone afterwards; a failed platform group and an uninspectable ref not stopping the others (count + joined error); the Docker < 28 fallback to `kind load docker-image`; the API-version parse.
- **Classic graph driver** (this host, Docker 29.7.2 / API 1.55, overlay2): `docker save --platform linux/amd64` of a cached image writes a loadable OCI archive; full-lab boot with the new binary in an isolated lab — see the comment below.