### PR TITLE
fix(telemetry): wait up to half a second at command end for the usage signal, so sub-second commands stop losing it (telemetrydeck-go v0.3.0 Flush)

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -22,9 +22,11 @@ One signal contains:
 
 Nothing from `agentlab.yaml`, `state/`, `certs/`, the cluster, the users, the
 models or the model servers is ever sent. Help output (`-h`, `--help`) and
-shell completion do not count. The signal goes out in the background while the command runs
-and is dropped when the network is unavailable — it never blocks or fails a
-command.
+shell completion do not count. The signal goes out in the background while
+the command runs; a command that finishes before the signal has left the
+machine (`agentlab version`, say) waits for it at most half a second, then
+exits regardless. The signal is dropped when the network is unavailable — it
+never fails a command.
 
 Data is stored at [TelemetryDeck](https://telemetrydeck.com/) on servers in
 the EU; see their [privacy FAQ](https://telemetrydeck.com/docs/guides/privacy-faq/).

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/creativeprojects/go-selfupdate v1.6.0
 	github.com/giantswarm/selfupdate-cosign v0.1.0
-	github.com/giantswarm/telemetrydeck-go v0.2.0
+	github.com/giantswarm/telemetrydeck-go v0.3.0
 	github.com/smallstep/truststore v0.13.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/crypto v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sa
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/giantswarm/selfupdate-cosign v0.1.0 h1:KRfPVIzbaDjO658QcPsFmof0QUAEj6AnIZ2e9mCbThA=
 github.com/giantswarm/selfupdate-cosign v0.1.0/go.mod h1:CVnryjSRY/xDqJDn+QeivgT8+WkOvVbY/Z+xLaIfZ1w=
-github.com/giantswarm/telemetrydeck-go v0.2.0 h1:Ojw0XncmOEQyM68TK+4T9IYnU6xmJMFM/vr3oS8eb+I=
-github.com/giantswarm/telemetrydeck-go v0.2.0/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
+github.com/giantswarm/telemetrydeck-go v0.3.0 h1:hgmySEd5P6D78ZoUcNBKB/xaEBhtF9yGa8xhuQUrc1g=
+github.com/giantswarm/telemetrydeck-go v0.3.0/go.mod h1:BitlH7nTrQmWvVEtnAa8pNM+FjI0+9S7JA9tl1PVvzo=
 github.com/go-chi/chi/v5 v5.3.0 h1:halUjDxhshgXHMrao5bB8eNBXo/rnzwr8m5m36glehM=
 github.com/go-chi/chi/v5 v5.3.0/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -6,13 +6,17 @@
 // arguments or flags — leaves the machine. See docs/telemetry.md.
 //
 // Setting AGENTLAB_TELEMETRY_OPTOUT (any value) or the console convention
-// DO_NOT_TRACK=1 disables it. Reporting never blocks or fails a command.
+// DO_NOT_TRACK=1 disables it. Reporting never fails a command: the signal
+// travels while the command works, and a command that finishes first waits
+// for it at most half a second (Flush) before the process exits.
 package telemetry
 
 import (
+	"context"
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/giantswarm/telemetrydeck-go"
 	"github.com/spf13/cobra"
@@ -41,11 +45,20 @@ const (
 
 	// signalType is the same as kubectl-gs's, so one usage report reads both.
 	signalType = "GiantSwarm.command"
+
+	// flushTimeout caps how long a finished command waits for its signal to
+	// leave the machine. One round trip to the ingest endpoint takes a few
+	// hundred milliseconds at most, and a slow exit is felt from about half a
+	// second on; a command that ran longer than this finds nothing to wait for.
+	flushTimeout = 500 * time.Millisecond
 )
 
 // endpoint overrides the TelemetryDeck ingest URL; tests point it at a local
 // server. Empty means the library's default.
 var endpoint string
+
+// sender is the client Command sent through, kept for Flush; nil until then.
+var sender *telemetrydeck.Client
 
 // Enabled reports whether this process sends usage signals.
 func Enabled() bool {
@@ -59,9 +72,10 @@ func Enabled() bool {
 }
 
 // Command records one execution of a user-facing command ("agentlab up").
-// Fire-and-forget: the HTTP request runs on its own goroutine while the
-// command does its work, and a failure to deliver is swallowed — telemetry
-// must never get in the user's way. Same shape as kubectl-gs: signal type
+// The HTTP request runs on its own goroutine while the command does its work
+// (Flush, at the end, gives a fast command a bounded moment to see it out),
+// and a failure to deliver is swallowed — telemetry must never get in the
+// user's way. Same shape as kubectl-gs: signal type
 // GiantSwarm.command with the command path and the app version in the
 // payload, plus the OS, architecture and SDK version the library adds. The
 // version and commit also go out as TelemetryDeck.AppInfo.version and
@@ -77,20 +91,47 @@ func Command(cmd *cobra.Command) {
 	if !Enabled() || !UserFacing(cmd) {
 		return
 	}
-	testMode := os.Getenv(TestModeEnv) != ""
-	client, err := newClient(testMode)
+	client, err := newClient(testMode())
 	if err != nil {
-		if testMode {
-			log.Printf("telemetry: creating the TelemetryDeck client: %s", err)
-		}
+		logf("creating the TelemetryDeck client: %s", err)
 		return
 	}
+	sender = client
 	err = client.SendSignal(cmd.Context(), signalType, map[string]interface{}{
 		"appVersion": project.Version(),
 		"command":    cmd.CommandPath(),
 	})
-	if err != nil && testMode {
-		log.Printf("telemetry: sending the usage signal: %s", err)
+	if err != nil {
+		logf("sending the usage signal: %s", err)
+	}
+}
+
+// Flush lets the signal Command sent finish its trip before the process
+// exits, waiting at most flushTimeout (and no longer than ctx allows): a
+// sub-second command such as `agentlab version` would otherwise exit before
+// its request has left the machine. Never an error for the caller — a signal
+// that did not make it is dropped, and said so only in test mode.
+func Flush(ctx context.Context) {
+	if sender == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, flushTimeout)
+	defer cancel()
+	if err := sender.Flush(ctx); err != nil {
+		logf("the usage signal was not delivered within %s: %s", flushTimeout, err)
+	}
+}
+
+// testMode says whether AGENTLAB_TELEMETRY_TESTMODE is set.
+func testMode() bool {
+	return os.Getenv(TestModeEnv) != ""
+}
+
+// logf reports a telemetry problem on stderr in test mode; production runs
+// stay silent, telemetry being nobody's concern but the lab's developers.
+func logf(format string, args ...any) {
+	if testMode() {
+		log.Printf("telemetry: "+format, args...)
 	}
 }
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,10 +1,12 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -179,5 +181,75 @@ func TestCommandSendsNothingWhenOptedOutOrUnconfigured(t *testing.T) {
 	case p := <-hit:
 		t.Fatalf("a signal was sent (%s) despite the opt-out / plumbing / empty app ID", p)
 	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// enable turns reporting on for one test, pointed at srv.
+func enable(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	withAppID(t, testAppID)
+	t.Setenv(OptOutEnv, "")
+	t.Setenv(doNotTrackEnv, "")
+	t.Setenv(TestModeEnv, "1")
+	endpoint = srv.URL
+	t.Cleanup(func() {
+		endpoint = ""
+		sender = nil
+	})
+}
+
+// TestFlushSeesTheSignalOut: a command that finishes before the endpoint has
+// answered waits for the answer, so nothing is lost.
+func TestFlushSeesTheSignalOut(t *testing.T) {
+	got := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond) // a slow network
+		got <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	enable(t, srv)
+
+	Flush(context.Background()) // nothing sent yet: returns at once
+
+	Command(lab(t, "up"))
+	start := time.Now()
+	Flush(context.Background())
+	waited := time.Since(start)
+
+	select {
+	case <-got:
+	default:
+		t.Fatalf("Flush returned after %s without the signal having reached the endpoint", waited)
+	}
+	if waited >= flushTimeout {
+		t.Errorf("Flush waited %s, the whole budget, for a signal that was answered after 100ms", waited)
+	}
+}
+
+// TestFlushIsBounded: an endpoint that never answers costs the command's exit
+// no more than the budget, and no error.
+func TestFlushIsBounded(t *testing.T) {
+	gate := make(chan struct{})
+	var once sync.Once
+	release := func() { once.Do(func() { close(gate) }) }
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-gate:
+		case <-r.Context().Done():
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer func() {
+		release()
+		srv.Close()
+	}()
+	enable(t, srv)
+
+	Command(lab(t, "up"))
+	start := time.Now()
+	Flush(context.Background())
+	if waited := time.Since(start); waited < flushTimeout || waited > flushTimeout+time.Second {
+		t.Errorf("Flush waited %s on a stalled endpoint, want about %s", waited, flushTimeout)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -29,6 +30,9 @@ import (
 
 func main() {
 	err := rootCmd().Execute()
+	// After Execute rather than in a PersistentPostRun, which cobra skips
+	// when the command failed: the usage signal counts failed runs too.
+	telemetry.Flush(context.Background())
 	if errors.Is(err, update.ErrOutdated) {
 		// `self-update --check` has reported both versions; the status is
 		// the answer (devctl's `version check` exits the same way).
@@ -61,7 +65,8 @@ Then:        claude mcp add --transport http muster https://muster.127.0.0.1.nip
 		// Runs for every subcommand, none of which has a PersistentPreRun of
 		// its own: one anonymous usage signal per command a person runs, like
 		// kubectl-gs (docs/telemetry.md; AGENTLAB_TELEMETRY_OPTOUT=1 to
-		// disable), and the hint that a newer release exists, ahead of the
+		// disable; main gives it a bounded moment to be delivered once the
+		// command is done), and the hint that a newer release exists, ahead of the
 		// command's own output (docs/cli.md "Keeping agentlab current";
 		// AGENTLAB_NO_UPDATE_CHECK=1 to disable). Plumbing, completion and
 		// help stay quiet for both; self-update reports the versions itself.


### PR DESCRIPTION
## Problem

The usage signal is sent from the root `PersistentPreRun` and travels while the command works. A command that finishes before the request has left the machine (a warm `agentlab logs`, a fast failure, `render`) exits mid-way through DNS + TCP + TLS and the signal is lost, silently even in test mode. telemetrydeck-go had no way to wait (telemetrydeck-go#122).

## Change

- telemetrydeck-go v0.2.0 → v0.3.0 (`Flush(ctx)`, requests carry the caller's context, the client times out after 5 s).
- `telemetry.Flush(ctx)` waits at most 500 ms for the signal `Command` sent; never an error for the caller, a signal that did not make it is dropped and said so only in test mode. `flushTimeout` reasoning is on the constant.
- `main` calls it after `Execute` returns rather than in a `PersistentPostRun`, which cobra skips when the command failed: failed runs count too.
- `docs/telemetry.md` states the half-second wait.

## Tests

`TestFlushSeesTheSignalOut` (an endpoint that answers after 100 ms: Flush returns once the signal arrived, well under the budget) and `TestFlushIsBounded` (an endpoint that never answers: Flush returns after ~500 ms, no error). `make test` (race) and `pre-commit run --all-files` green.

## Proof

Both binaries built with the ingest endpoint pointed (ldflags) at a local TLS listener that delays the ServerHello, i.e. the WAN phase in which no request can be sent yet; `AGENTLAB_TELEMETRY_TESTMODE=1 AGENTLAB_NO_UPDATE_CHECK=1`. "before" is `main` (v0.2.0), "after" is this branch.

| handshake delay | command | before | after |
|---|---|---|---|
| 150 ms | `logs nonexistent-component` (~280 ms) | delivered, 284 ms | delivered, 243 ms |
| 400 ms | `logs nonexistent-component` | **lost** (client gone before the TLS handshake finished), 281 ms — 4 of 4 runs | **delivered**, 443–448 ms — 4 of 4 runs |
| 400 ms | `render` (~600 ms) | delivered, 571 ms | delivered, 609 ms |

A command that already outlived the round trip pays nothing; a faster one waits for the answer and never longer than the budget.