### PR TITLE
refactor(kube): a client-go layer for the lab's cluster calls — namespaces, secrets, apply, rollout and whoami no longer shell out to kubectl

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -23,11 +23,24 @@ out of the production usage numbers (see [Usage data](telemetry.md)).
 
 The rendered manifests are always in `state/` (`agentlab render` writes them
 without applying), so `kubectl diff -f state/dex.yaml` and plain reading stay
-possible. The lab's own `kubectl` and its embedded Helm never read your
-shell's kubeconfig: every cluster-facing command exports the kind cluster's
-kubeconfig to `state/kubeconfig` and binds to it (`KUBECONFIG` for kubectl,
-the REST client getter for Helm), so `KUBECONFIG=state/kubeconfig kubectl ...`
-and `KUBECONFIG=state/kubeconfig helm ...` are the same view from a shell.
+possible. The lab's own `kubectl`, its embedded Helm and its embedded
+Kubernetes client never read your shell's kubeconfig: every cluster-facing
+command exports the kind cluster's kubeconfig to `state/kubeconfig` and binds
+to it (`KUBECONFIG` for kubectl, the REST client getter for Helm and the
+client), so `KUBECONFIG=state/kubeconfig kubectl ...` and
+`KUBECONFIG=state/kubeconfig helm ...` are the same view from a shell.
+
+The Kubernetes client is embedded: `internal/lab/kube.go` is the vocabulary
+the package speaks to the apiserver through client-go — server-side apply of
+the rendered manifests under the field manager `agentlab` (forced, so an
+object an earlier lab applied through kubectl is taken over rather than
+refused as a conflict), reads by resource, deletes with the CLI's wait,
+patches, `rollout status`/`rollout restart`, `wait --for=condition`, the
+`auth can-i`/`auth whoami` reviews as a token or an impersonated principal,
+pod logs and a probe pod. Kinds resolve through a discovery-backed mapper
+cached in memory and reset after a batch carries CRDs. `kubectl` itself is
+still shelled out to for the calls not converted yet (exec.go), with
+`KUBECONFIG` pinned the same way.
 
 Helm is embedded: `internal/lab/helm.go` runs Helm 4's SDK
 (`helm.sh/helm/v4/pkg/action`) in-process for the upgrade-or-install with
@@ -98,7 +111,8 @@ internal/lab/                    everything operational:
   observability.go                 the lab Prometheus (kube-prometheus-stack through the embedded Helm) and the mcp-prometheus HelmRelease through the platform's engine
   backstage.go backstagetest.go    Backstage deploy + headless sign-in proof
   portal.go mcpsession.go          one user's signed-in portal session; the proofs' MCP session against muster
-  exec.go kubeconfig.go            running kubectl with KUBECONFIG pinned to state/kubeconfig; the OIDC kubeconfig `login` writes
+  kube.go                          the embedded Kubernetes client: server-side apply, reads, deletes, rollouts, the can-i/whoami reviews, pod logs — bound to state/kubeconfig
+  exec.go kubeconfig.go            running docker, and kubectl with KUBECONFIG pinned to state/kubeconfig for the calls not yet on the client; the OIDC kubeconfig `login` writes
   render.go logs.go                template rendering into state/; `agentlab logs`
   templates/                       every manifest, rendered from agentlab.yaml (static/: the verbatim agent-deployment Template)
 docs/                            this documentation; README.md is the front door
@@ -106,7 +120,7 @@ HACKS.md                         the hack journal
 agentlab.yaml                    your configuration (gitignored; `agentlab configure`)
 certs/                           the lab CA and leaf certs (gitignored; key 0600)
 state/                           rendered manifests, for inspection (gitignored)
-  kubeconfig                       the kind cluster's admin kubeconfig, written at creation and re-exported per run — what the lab's own kubectl and embedded Helm use
+  kubeconfig                       the kind cluster's admin kubeconfig, written at creation and re-exported per run — what the lab's own kubectl, embedded Helm and Kubernetes client use
   agent-platform-values.yaml       the chart's values in the lab shape, incl. the postRenderers
 .mcp.json                        registers muster as an MCP server for Claude Code
 ```

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	golang.org/x/term v0.46.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.2.4
+	k8s.io/api v0.36.1
+	k8s.io/apimachinery v0.36.1
 	k8s.io/cli-runtime v0.36.1
 	k8s.io/client-go v0.36.1
 	k8s.io/klog/v2 v2.140.0
@@ -191,9 +193,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	howett.net/plist v1.0.0 // indirect
-	k8s.io/api v0.36.1 // indirect
 	k8s.io/apiextensions-apiserver v0.36.1 // indirect
-	k8s.io/apimachinery v0.36.1 // indirect
 	k8s.io/apiserver v0.36.1 // indirect
 	k8s.io/component-base v0.36.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect

--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -36,7 +36,9 @@ func warn(format string, a ...any) {
 // by command; every other subprocess (docker) inherits the environment
 // untouched. kind and Helm are not subprocesses: both are embedded — kind
 // (kind.go) drives docker — or podman — through its CLI itself, Helm
-// (helm.go) is bound to the same lab kubeconfig through labRESTClientGetter.
+// (helm.go) is bound to the same lab kubeconfig through labRESTClientGetter,
+// and so is the Kubernetes client (kube.go) that replaces kubectl call by
+// call.
 const (
 	dockerBin  = "docker"
 	kubectlBin = "kubectl"
@@ -158,48 +160,4 @@ func notReached(subject, want, last string, readErr error, hint string) error {
 		return fmt.Errorf("%s: kubectl failed: %w;\n%s", subject, readErr, hint)
 	}
 	return fmt.Errorf("%s never reached %s (last status: %q);\n%s", subject, want, last, hint)
-}
-
-// ensureNamespace idempotently creates a namespace (the dry-run|apply trick,
-// so re-runs are clean no-ops).
-func ensureNamespace(ns string) error {
-	manifest, err := output("kubectl", "create", "namespace", ns, "--dry-run=client", "-o", "yaml")
-	if err != nil {
-		return err
-	}
-	return pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-")
-}
-
-// ensureSecretFromFiles idempotently applies a generic secret built from
-// files, same dry-run|apply trick as ensureNamespace.
-func ensureSecretFromFiles(ns, name string, files map[string]string) error {
-	args := []string{"-n", ns, "create", "secret", "generic", name}
-	for key, path := range files {
-		args = append(args, "--from-file="+key+"="+path)
-	}
-	args = append(args, "--dry-run=client", "-o", "yaml")
-	manifest, err := output("kubectl", args...)
-	if err != nil {
-		return err
-	}
-	return pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-")
-}
-
-// ensureTLSSecret idempotently applies a kubernetes.io/tls secret from a cert
-// and key file — the type the Gateway API's certificateRefs require, which
-// ensureSecretFromFiles's generic secrets are not.
-func ensureTLSSecret(ns, name, certPath, keyPath string) error {
-	manifest, err := output("kubectl", "-n", ns, "create", "secret", "tls", name,
-		"--cert="+certPath, "--key="+keyPath, "--dry-run=client", "-o", "yaml")
-	if err != nil {
-		return err
-	}
-	return pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-")
-}
-
-// secretHasKey reports whether a secret exists and carries the given data key.
-func secretHasKey(ns, name, key string) bool {
-	out, err := outputQuiet("kubectl", "-n", ns, "get", "secret", name,
-		"-o", "jsonpath={.data."+strings.ReplaceAll(key, ".", `\.`)+"}")
-	return err == nil && strings.TrimSpace(out) != ""
 }

--- a/internal/lab/kube.go
+++ b/internal/lab/kube.go
@@ -1,0 +1,1203 @@
+package lab
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// The embedded Kubernetes client. Every call the lab makes to its cluster's
+// apiserver — applying rendered manifests, reading a resource's status,
+// deleting, patching, waiting for a rollout or a condition, the RBAC and
+// identity probes, pod logs, a probe pod — runs in this process through
+// client-go, bound to the lab-owned kubeconfig through labRESTClientGetter
+// (restclient.go): the shell's KUBECONFIG and current-context play no part,
+// and a lab that is not up fails on the missing state/kubeconfig, by name.
+// The helpers below are the vocabulary the rest of the package speaks; the
+// context comes first everywhere and every wait is bounded.
+//
+// Writes are server-side apply under the field manager applyFieldManager,
+// forced: an object an earlier lab applied through kubectl carries the
+// kubectl-client-side-apply manager (one kubectl applied server-side carries
+// "kubectl"), and without Force the first re-apply over it would be refused
+// as a conflict on every field both set. Taking the fields over is exactly
+// what a re-apply means here — the rendered manifest is the whole intent.
+// What kubectl reported as created/configured/unchanged is
+// applyResult.changed: whether the object was created or its
+// resourceVersion moved; a re-apply that changes nothing leaves it alone,
+// the apiserver skips the write.
+//
+// Kinds resolve through a discovery-backed RESTMapper cached in memory
+// (never under ~/.kube/cache) and reset after a batch carries CRDs, so the
+// kinds a CRD introduces resolve for what follows it — in the same batch
+// after the CRD is served, and in the rest of the run.
+
+// applyFieldManager is the field manager of every server-side apply the lab
+// performs; `kubectl get -o yaml --show-managed-fields` names it.
+const applyFieldManager = "agentlab"
+
+// defaultNamespace is where a namespace-scoped object that names none lands:
+// kubectl applies such an object in the kubeconfig's namespace, and the kind
+// kubeconfig sets none — "default". Also the namespace kubectl evaluates
+// `auth can-i` in when no -n is given.
+const defaultNamespace = "default"
+
+// crdEstablishTimeout bounds how long applyManifests waits, after applying a
+// CustomResourceDefinition, for the apiserver to serve its kinds before
+// applying the objects that follow it.
+const crdEstablishTimeout = 60 * time.Second
+
+// pollInterval is the cadence of the bounded waits below (a rollout, a
+// condition, an object going away) — kubectl's own for `rollout status`.
+const pollInterval = 2 * time.Second
+
+// probeContainer names the one container of a probe pod (runProbePod).
+const probeContainer = "probe"
+
+// restartedAtAnnotation is the pod-template annotation `kubectl rollout
+// restart` stamps to roll a Deployment.
+const restartedAtAnnotation = "kubectl.kubernetes.io/restartedAt"
+
+// defaultContainerAnnotation names the container kubectl reads logs from when
+// a pod has several and none is asked for.
+const defaultContainerAnnotation = "kubectl.kubernetes.io/default-container"
+
+// gvkCRD identifies a CustomResourceDefinition in a manifest batch.
+var gvkCRD = schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}
+
+// The resources the lab reads and writes by GVR. Kinds outside the core and
+// apps groups (a HelmRelease, an MCPServer, a ModelConfig) resolve through
+// gvrFor from the resource name kubectl takes, so their versions are never
+// pinned here.
+var (
+	gvrNamespaces  = corev1.SchemeGroupVersion.WithResource("namespaces")
+	gvrSecrets     = corev1.SchemeGroupVersion.WithResource("secrets")
+	gvrConfigMaps  = corev1.SchemeGroupVersion.WithResource("configmaps")
+	gvrPods        = corev1.SchemeGroupVersion.WithResource("pods")
+	gvrDeployments = appsv1.SchemeGroupVersion.WithResource("deployments")
+	gvrCRDs        = gvkCRD.GroupVersion().WithResource("customresourcedefinitions")
+)
+
+// kubeClients is the client bundle behind every helper: one REST config for
+// the lab cluster, the dynamic client (every object read and write, by GVR),
+// the typed clientset (pods and their logs, the authorization and
+// authentication reviews), the RESTMapper that turns kinds and resource
+// names into GVRs and scopes, and a REST client for the non-resource paths
+// (/readyz).
+type kubeClients struct {
+	cfg       *rest.Config
+	dynamic   dynamic.Interface
+	clientset kubernetes.Interface
+	mapper    meta.RESTMapper
+	raw       rest.Interface
+	// resetMapper drops the cached discovery so the kinds registered since —
+	// a CRD the lab just applied — resolve on the next lookup.
+	resetMapper func()
+}
+
+var (
+	labKubeMu    sync.Mutex
+	labKubeCache *kubeClients
+	// newLabKube builds the bundle from the lab kubeconfig; a test seam
+	// (stubLabKube swaps in fakes).
+	newLabKube = buildLabKube
+	// clientsetFor builds the typed clientset for a config that is not the
+	// lab admin's — a user's token (tokenConfig), an impersonation
+	// (asUserConfig); a test seam.
+	clientsetFor = func(cfg *rest.Config) (kubernetes.Interface, error) {
+		return kubernetes.NewForConfig(cfg)
+	}
+)
+
+// labKube is the cached client bundle for the lab cluster, built on first
+// use from state/kubeconfig. useClusterKubeconfig drops it (resetLabKube)
+// when it rewrites that file, so a bundle never outlives the kubeconfig it
+// was built from.
+func labKube() (*kubeClients, error) {
+	labKubeMu.Lock()
+	defer labKubeMu.Unlock()
+	if labKubeCache != nil {
+		return labKubeCache, nil
+	}
+	k, err := newLabKube()
+	if err != nil {
+		return nil, err
+	}
+	labKubeCache = k
+	return k, nil
+}
+
+// resetLabKube forgets the cached bundle; the next helper rebuilds it from
+// the kubeconfig on disk.
+func resetLabKube() {
+	labKubeMu.Lock()
+	defer labKubeMu.Unlock()
+	labKubeCache = nil
+}
+
+// buildLabKube is the real bundle: the REST config from labRESTClientGetter
+// (the lab kubeconfig, QPS 50 / burst 100, the agentlab user agent), the
+// apiserver's warnings deduplicated on stderr the way kubectl prints them,
+// discovery cached in memory behind a deferred RESTMapper, and kubectl's
+// short names (deploy, cm, crd) understood by the mapper.
+func buildLabKube() (*kubeClients, error) {
+	quietKlog(os.Getenv(helmDebugEnv) != "")
+	cfg, err := labRESTClientGetter("").ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("loading the lab kubeconfig: %w", err)
+	}
+	cfg.WarningHandler = rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{Deduplicate: true})
+	dyn, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cs, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	cached := memory.NewMemCacheClient(dc)
+	deferred := restmapper.NewDeferredDiscoveryRESTMapper(cached)
+	return &kubeClients{
+		cfg:       cfg,
+		dynamic:   dyn,
+		clientset: cs,
+		mapper:    restmapper.NewShortcutExpander(deferred, cached, func(string) {}),
+		raw:       cs.Discovery().RESTClient(),
+		resetMapper: func() {
+			cached.Invalidate()
+			deferred.Reset()
+		},
+	}, nil
+}
+
+// resource is the dynamic client for one GVR, in a namespace or at the
+// cluster level ("" — a cluster-scoped kind, or every namespace for a list).
+func (k *kubeClients) resource(gvr schema.GroupVersionResource, ns string) dynamic.ResourceInterface {
+	if ns == "" {
+		return k.dynamic.Resource(gvr)
+	}
+	return k.dynamic.Resource(gvr).Namespace(ns)
+}
+
+// describe words a resource for an error: "secrets agent-platform/dex-ca",
+// "namespaces demo".
+func describe(gvr schema.GroupVersionResource, ns, name string) string {
+	if ns == "" {
+		return gvr.Resource + " " + name
+	}
+	return gvr.Resource + " " + ns + "/" + name
+}
+
+// gvrFor resolves the resource argument kubectl takes — "secrets", "deploy",
+// "crd", "helmreleases.helm.toolkit.fluxcd.io" — to the GVR the apiserver
+// serves it under, preferred version first, through discovery. A fully
+// qualified name is tried as resource.version.group before resource.group,
+// as kubectl does, so a group with dots in it resolves.
+func gvrFor(resourceArg string) (schema.GroupVersionResource, error) {
+	k, err := labKube()
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return k.gvrFor(resourceArg)
+}
+
+func (k *kubeClients) gvrFor(resourceArg string) (schema.GroupVersionResource, error) {
+	fully, gr := schema.ParseResourceArg(resourceArg)
+	if fully != nil {
+		if gvrs, err := k.mapper.ResourcesFor(*fully); err == nil && len(gvrs) > 0 {
+			return gvrs[0], nil
+		}
+	}
+	gvrs, err := k.mapper.ResourcesFor(gr.WithVersion(""))
+	if err != nil {
+		return schema.GroupVersionResource{}, fmt.Errorf("the apiserver serves no resource %q: %w", resourceArg, err)
+	}
+	return gvrs[0], nil
+}
+
+// applyResult is what one server-side apply did: the object, and whether it
+// was created or changed (its resourceVersion moved) — a re-apply that
+// changes nothing is not a change.
+type applyResult struct {
+	gvk       schema.GroupVersionKind
+	namespace string
+	name      string
+	changed   bool
+}
+
+// String words the object the way kubectl's apply lines do:
+// "deployment.apps/dex", "namespace/demo".
+func (r applyResult) String() string {
+	kind := strings.ToLower(r.gvk.Kind)
+	if r.gvk.Group != "" {
+		kind += "." + r.gvk.Group
+	}
+	return kind + "/" + r.name
+}
+
+// anyChanged reports whether any object of a batch was created or changed —
+// `kubectl apply` output without an "unchanged" on every line.
+func anyChanged(results []applyResult) bool {
+	return slices.ContainsFunc(results, func(r applyResult) bool { return r.changed })
+}
+
+// applyManifests is `kubectl apply -f` of a multi-document manifest: every
+// document server-side applied in order, empty documents skipped, a List
+// expanded. A CustomResourceDefinition in the batch is applied and, before
+// the first object after it, the apiserver is given up to crdEstablishTimeout
+// to serve its kinds (with the mapper reset so it sees them) — so a manifest
+// may carry a CRD and its custom resources together. Errors name the object.
+func applyManifests(ctx context.Context, manifests []byte) ([]applyResult, error) {
+	objs, err := decodeManifests(manifests)
+	if err != nil {
+		return nil, err
+	}
+	k, err := labKube()
+	if err != nil {
+		return nil, err
+	}
+	var results []applyResult
+	var pendingCRDs []*unstructured.Unstructured
+	for _, obj := range objs {
+		isCRD := obj.GroupVersionKind().GroupKind() == gvkCRD.GroupKind()
+		if !isCRD && len(pendingCRDs) > 0 {
+			if err := k.awaitCRDs(ctx, pendingCRDs); err != nil {
+				return results, err
+			}
+			pendingCRDs = nil
+		}
+		res, err := k.apply(ctx, obj)
+		if err != nil {
+			return results, err
+		}
+		results = append(results, res)
+		if isCRD {
+			pendingCRDs = append(pendingCRDs, obj)
+		}
+	}
+	if len(pendingCRDs) > 0 {
+		if err := k.awaitCRDs(ctx, pendingCRDs); err != nil {
+			return results, err
+		}
+	}
+	return results, nil
+}
+
+// decodeManifests splits a multi-document YAML (or JSON) manifest into
+// objects, in order: empty documents (`---` with nothing, or comments only)
+// are skipped, a List is expanded into its items, and a document without
+// apiVersion and kind is refused by its position.
+func decodeManifests(manifests []byte) ([]*unstructured.Unstructured, error) {
+	dec := utilyaml.NewYAMLOrJSONDecoder(bufio.NewReader(bytes.NewReader(manifests)), 4096)
+	var objs []*unstructured.Unstructured
+	for i := 1; ; i++ {
+		var ext runtime.RawExtension
+		err := dec.Decode(&ext)
+		if errors.Is(err, io.EOF) {
+			return objs, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("manifest document %d: %w", i, err)
+		}
+		raw := bytes.TrimSpace(ext.Raw)
+		if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+			continue
+		}
+		u := &unstructured.Unstructured{}
+		if err := u.UnmarshalJSON(raw); err != nil {
+			return nil, fmt.Errorf("manifest document %d: %w", i, err)
+		}
+		if u.IsList() {
+			err := u.EachListItem(func(o runtime.Object) error {
+				item, ok := o.(*unstructured.Unstructured)
+				if !ok {
+					return fmt.Errorf("manifest document %d: List item of type %T", i, o)
+				}
+				objs = append(objs, item)
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if u.GetKind() == "" || u.GetAPIVersion() == "" {
+			return nil, fmt.Errorf("manifest document %d (%s) has no apiVersion/kind", i, u.GetName())
+		}
+		objs = append(objs, u)
+	}
+}
+
+// apply server-side applies one object: its kind resolved to a resource and
+// a scope through the mapper (a namespace-scoped object without a namespace
+// goes to defaultNamespace, as kubectl's would), then a forced apply under
+// applyFieldManager. The object is read first so the result can say whether
+// the apply created or changed it.
+func (k *kubeClients) apply(ctx context.Context, obj *unstructured.Unstructured) (applyResult, error) {
+	gvk := obj.GroupVersionKind()
+	res := applyResult{gvk: gvk, name: obj.GetName()}
+	if res.name == "" {
+		return res, fmt.Errorf("%s has no metadata.name", gvk.Kind)
+	}
+	mapping, err := k.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return res, fmt.Errorf("%s %s: %w (ensure the CRDs are installed first)", gvk.Kind, res.name, err)
+	}
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		res.namespace = obj.GetNamespace()
+		if res.namespace == "" {
+			res.namespace = defaultNamespace
+			obj.SetNamespace(defaultNamespace)
+		}
+	}
+	client := k.resource(mapping.Resource, res.namespace)
+	before, err := client.Get(ctx, res.name, metav1.GetOptions{})
+	switch {
+	case apierrors.IsNotFound(err):
+		before = nil
+	case err != nil:
+		return res, fmt.Errorf("reading %s before applying it: %w", res, err)
+	}
+	body, err := json.Marshal(obj.Object)
+	if err != nil {
+		return res, fmt.Errorf("encoding %s: %w", res, err)
+	}
+	force := true
+	after, err := client.Patch(ctx, res.name, types.ApplyPatchType, body, metav1.PatchOptions{
+		FieldManager: applyFieldManager,
+		Force:        &force,
+	})
+	if err != nil {
+		return res, fmt.Errorf("applying %s: %w", res, err)
+	}
+	res.changed = before == nil || before.GetResourceVersion() != after.GetResourceVersion()
+	return res, nil
+}
+
+// applyTyped server-side applies a typed object (a corev1.Namespace, a
+// corev1.Secret) built in code: converted to its wire form with the
+// apiVersion/kind it carries, minus the empty creationTimestamp and status
+// the conversion emits, which are nobody's intent.
+func applyTyped(ctx context.Context, obj runtime.Object) (applyResult, error) {
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return applyResult{}, err
+	}
+	u := &unstructured.Unstructured{Object: raw}
+	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(u.Object, "status")
+	k, err := labKube()
+	if err != nil {
+		return applyResult{}, err
+	}
+	return k.apply(ctx, u)
+}
+
+// awaitCRDs waits until the apiserver serves every kind the given
+// CustomResourceDefinitions define (each served version resolving through
+// the mapper, reset before every try), bounded by crdEstablishTimeout — the
+// gap between a CRD being accepted and its endpoints existing, in which an
+// apply of one of its objects fails with "no matches for kind".
+func (k *kubeClients) awaitCRDs(ctx context.Context, crds []*unstructured.Unstructured) error {
+	type served struct {
+		gk       schema.GroupKind
+		versions []string
+	}
+	var want []served
+	for _, crd := range crds {
+		group, _, _ := unstructured.NestedString(crd.Object, "spec", "group")
+		kind, _, _ := unstructured.NestedString(crd.Object, "spec", "names", "kind")
+		versions, _, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
+		s := served{gk: schema.GroupKind{Group: group, Kind: kind}}
+		for _, v := range versions {
+			m, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			if on, found, _ := unstructured.NestedBool(m, "served"); found && !on {
+				continue
+			}
+			if name, _, _ := unstructured.NestedString(m, "name"); name != "" {
+				s.versions = append(s.versions, name)
+			}
+		}
+		want = append(want, s)
+	}
+	var missing string
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, crdEstablishTimeout, true, func(context.Context) (bool, error) {
+		k.resetMapper()
+		for _, s := range want {
+			for _, v := range s.versions {
+				if _, err := k.mapper.RESTMapping(s.gk, v); err != nil {
+					missing = s.gk.String() + " " + v
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("the apiserver does not serve %s %s after its CustomResourceDefinition was applied", missing, crdEstablishTimeout)
+	}
+	return nil
+}
+
+// getObject is `kubectl get <resource> <name> -o json`: the object as it is,
+// for the caller to read fields off with unstructured.Nested* and the
+// condition helpers. A read that fails carries the apiserver's words (a
+// NotFound stays recognisable through apierrors.IsNotFound).
+func getObject(ctx context.Context, gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+	k, err := labKube()
+	if err != nil {
+		return nil, err
+	}
+	obj, err := k.resource(gvr, ns).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", describe(gvr, ns, name), err)
+	}
+	return obj, nil
+}
+
+// listObjects is `kubectl get <resource> [-l selector]` in a namespace, or
+// across all of them with ns "".
+func listObjects(ctx context.Context, gvr schema.GroupVersionResource, ns, labelSelector string) ([]unstructured.Unstructured, error) {
+	k, err := labKube()
+	if err != nil {
+		return nil, err
+	}
+	list, err := k.resource(gvr, ns).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing %s: %w", describe(gvr, ns, labelSelector), err)
+	}
+	return list.Items, nil
+}
+
+// objectExists reports whether the object is there: false without error for
+// a NotFound, an error for anything else the read ran into.
+func objectExists(ctx context.Context, gvr schema.GroupVersionResource, ns, name string) (bool, error) {
+	_, err := getObject(ctx, gvr, ns, name)
+	switch {
+	case err == nil:
+		return true, nil
+	case apierrors.IsNotFound(err):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+// condition returns the status.conditions entry of the given type, or nil.
+func condition(obj *unstructured.Unstructured, condType string) map[string]any {
+	conds, _, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	for _, c := range conds {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _, _ := unstructured.NestedString(m, "type"); t == condType {
+			return m
+		}
+	}
+	return nil
+}
+
+// conditionStatus is `{.status.conditions[?(@.type=="<type>")].status}` —
+// "True", "False", "Unknown", or "" when the condition is not there yet.
+func conditionStatus(obj *unstructured.Unstructured, condType string) string {
+	if c := condition(obj, condType); c != nil {
+		s, _, _ := unstructured.NestedString(c, "status")
+		return s
+	}
+	return ""
+}
+
+// conditionMessage is `{.status.conditions[?(@.type=="<type>")].message}`.
+func conditionMessage(obj *unstructured.Unstructured, condType string) string {
+	if c := condition(obj, condType); c != nil {
+		s, _, _ := unstructured.NestedString(c, "message")
+		return s
+	}
+	return ""
+}
+
+// deleteObject is `kubectl delete <resource> <name> --ignore-not-found`: a
+// missing object is success. With waitGone > 0 it is the CLI's default wait
+// too — polling until the object is gone (finalizers run, a namespace's
+// contents drained), failing once waitGone passes; 0 is `--wait=false`.
+func deleteObject(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, waitGone time.Duration) error {
+	k, err := labKube()
+	if err != nil {
+		return err
+	}
+	client := k.resource(gvr, ns)
+	propagation := metav1.DeletePropagationBackground
+	err = client.Delete(ctx, name, metav1.DeleteOptions{PropagationPolicy: &propagation})
+	switch {
+	case apierrors.IsNotFound(err):
+		return nil
+	case err != nil:
+		return fmt.Errorf("deleting %s: %w", describe(gvr, ns, name), err)
+	}
+	if waitGone <= 0 {
+		return nil
+	}
+	err = wait.PollUntilContextTimeout(ctx, pollInterval, waitGone, true, func(ctx context.Context) (bool, error) {
+		_, err := client.Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			return true, nil
+		case err != nil:
+			return false, fmt.Errorf("reading %s while waiting for its deletion: %w", describe(gvr, ns, name), err)
+		}
+		return false, nil
+	})
+	if wait.Interrupted(err) {
+		return fmt.Errorf("%s is still there %s after its deletion was requested (a finalizer is holding it: `kubectl get %s -o yaml`)",
+			describe(gvr, ns, name), waitGone, describe(gvr, ns, name))
+	}
+	return err
+}
+
+// patchObject is `kubectl patch <resource> <name> --type=<merge|json|strategic> -p <body>`.
+func patchObject(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, pt types.PatchType, body []byte) error {
+	k, err := labKube()
+	if err != nil {
+		return err
+	}
+	if _, err := k.resource(gvr, ns).Patch(ctx, name, pt, body, metav1.PatchOptions{FieldManager: applyFieldManager}); err != nil {
+		return fmt.Errorf("patching %s: %w", describe(gvr, ns, name), err)
+	}
+	return nil
+}
+
+// restartDeployment is `kubectl rollout restart deployment/<name>`: the
+// restartedAt annotation stamped into the pod template, which rolls the
+// pods. Pair it with waitDeploymentRolledOut to wait for the new ones.
+func restartDeployment(ctx context.Context, ns, name string) error {
+	patch := fmt.Sprintf(`{"spec":{"template":{"metadata":{"annotations":{%q:%q}}}}}`,
+		restartedAtAnnotation, time.Now().UTC().Format(time.RFC3339))
+	return patchObject(ctx, gvrDeployments, ns, name, types.MergePatchType, []byte(patch))
+}
+
+// waitDeploymentRolledOut is `kubectl rollout status deployment/<name>
+// --timeout=<timeout>`: kubectl's own condition (deploymentRolloutStatus),
+// polled, its progress lines printed as they change, and its failure — the
+// deadline, or the Deployment's own progress deadline exceeded — worded
+// with what was last seen.
+func waitDeploymentRolledOut(ctx context.Context, ns, name string, timeout time.Duration) error {
+	k, err := labKube()
+	if err != nil {
+		return err
+	}
+	var last string
+	err = wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		obj, err := k.resource(gvrDeployments, ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("reading %s: %w", describe(gvrDeployments, ns, name), err)
+		}
+		d := &appsv1.Deployment{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, d); err != nil {
+			return false, fmt.Errorf("reading %s: %w", describe(gvrDeployments, ns, name), err)
+		}
+		msg, done, err := deploymentRolloutStatus(d)
+		if err != nil {
+			return false, err
+		}
+		if msg != last {
+			note("%s", msg)
+			last = msg
+		}
+		return done, nil
+	})
+	if wait.Interrupted(err) {
+		return fmt.Errorf("%s did not roll out within %s (%s); check `kubectl -n %s get pods`",
+			describe(gvrDeployments, ns, name), timeout, last, ns)
+	}
+	return err
+}
+
+// deploymentRolloutStatus is kubectl's rollout-status verdict on a
+// Deployment (k8s.io/kubectl polymorphichelpers.DeploymentStatusViewer): a
+// progress line and whether the rollout is complete — the controller has
+// observed the current generation, every replica is updated, no old replica
+// is left, every updated replica is available — or an error once the
+// Deployment's progress deadline is exceeded.
+func deploymentRolloutStatus(d *appsv1.Deployment) (string, bool, error) {
+	if d.Generation > d.Status.ObservedGeneration {
+		return "Waiting for deployment spec update to be observed...", false, nil
+	}
+	for _, c := range d.Status.Conditions {
+		if c.Type == appsv1.DeploymentProgressing && c.Reason == "ProgressDeadlineExceeded" {
+			return "", false, fmt.Errorf("deployment %q exceeded its progress deadline", d.Name)
+		}
+	}
+	if d.Spec.Replicas != nil && d.Status.UpdatedReplicas < *d.Spec.Replicas {
+		return fmt.Sprintf("Waiting for deployment %q rollout to finish: %d out of %d new replicas have been updated...",
+			d.Name, d.Status.UpdatedReplicas, *d.Spec.Replicas), false, nil
+	}
+	if d.Status.Replicas > d.Status.UpdatedReplicas {
+		return fmt.Sprintf("Waiting for deployment %q rollout to finish: %d old replicas are pending termination...",
+			d.Name, d.Status.Replicas-d.Status.UpdatedReplicas), false, nil
+	}
+	if d.Status.AvailableReplicas < d.Status.UpdatedReplicas {
+		return fmt.Sprintf("Waiting for deployment %q rollout to finish: %d of %d updated replicas are available...",
+			d.Name, d.Status.AvailableReplicas, d.Status.UpdatedReplicas), false, nil
+	}
+	return fmt.Sprintf("deployment %q successfully rolled out", d.Name), true, nil
+}
+
+// waitCondition is `kubectl wait --for=condition=<type>[=<status>]
+// --timeout=<timeout> <resource>/<name>`: polled until the condition reads
+// the wanted status ("True" for the CLI's bare form). A read that fails ends
+// the wait with the apiserver's words; the deadline reports the last status
+// and message seen.
+func waitCondition(ctx context.Context, gvr schema.GroupVersionResource, ns, name, condType, condStatus string, timeout time.Duration) error {
+	var lastStatus, lastMessage string
+	err := wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		obj, err := getObject(ctx, gvr, ns, name)
+		if err != nil {
+			return false, err
+		}
+		lastStatus, lastMessage = conditionStatus(obj, condType), conditionMessage(obj, condType)
+		return lastStatus == condStatus, nil
+	})
+	if wait.Interrupted(err) {
+		return fmt.Errorf("%s never reached %s=%s within %s (last status %q: %s)",
+			describe(gvr, ns, name), condType, condStatus, timeout, lastStatus, lastMessage)
+	}
+	return err
+}
+
+// tokenConfig is a REST config that authenticates to the lab apiserver with
+// ONLY the given bearer token — the endpoint and CA from state/kubeconfig,
+// no client certificate. Needed because the kind kubeconfig ships the admin
+// client certificate, and a client cert always wins over a bearer token: a
+// config that carried both would keep authenticating as kubernetes-admin
+// (kubeconfig.go). What `--kubeconfig=<token kubeconfig>` did for kubectl.
+func tokenConfig(token string) (*rest.Config, error) {
+	kc, err := clientcmd.LoadFromFile(labKubeconfig())
+	if err != nil {
+		return nil, fmt.Errorf("loading the lab kubeconfig: %w", err)
+	}
+	var cluster *clientcmdapi.Cluster
+	if ctx := kc.Contexts[kc.CurrentContext]; ctx != nil {
+		cluster = kc.Clusters[ctx.Cluster]
+	}
+	if cluster == nil {
+		for _, c := range kc.Clusters {
+			cluster = c
+			break
+		}
+	}
+	if cluster == nil {
+		return nil, fmt.Errorf("the lab kubeconfig %s names no cluster", labKubeconfig())
+	}
+	cfg := &rest.Config{
+		Host: cluster.Server,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData:     cluster.CertificateAuthorityData,
+			CAFile:     cluster.CertificateAuthority,
+			ServerName: cluster.TLSServerName,
+		},
+		BearerToken: token,
+	}
+	return tuneRESTConfig(cfg), nil
+}
+
+// asUserConfig is the lab admin's REST config impersonating a principal —
+// kubectl's `--as=<user>`; for a ServiceAccount the apiserver adds its groups
+// itself, as it does for kubectl.
+func asUserConfig(username string) (*rest.Config, error) {
+	k, err := labKube()
+	if err != nil {
+		return nil, err
+	}
+	cfg := rest.CopyConfig(k.cfg)
+	cfg.Impersonate = rest.ImpersonationConfig{UserName: username}
+	return cfg, nil
+}
+
+// canI is `kubectl auth can-i <verb> <resource> [-n <ns>]` as the identity
+// cfg authenticates as: a SelfSubjectAccessReview. The resource argument is
+// kubectl's ("pods", "deployments", "helmreleases.helm.toolkit.fluxcd.io")
+// and resolves to its API group through discovery, as kubectl's does. ns ""
+// is every namespace (`--all-namespaces`); kubectl without -n asks in the
+// kubeconfig's namespace, defaultNamespace here.
+func canI(ctx context.Context, cfg *rest.Config, verb, resourceArg, ns string) (bool, error) {
+	gvr, err := gvrFor(resourceArg)
+	if err != nil {
+		return false, err
+	}
+	cs, err := clientsetFor(cfg)
+	if err != nil {
+		return false, err
+	}
+	review := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: ns,
+				Verb:      verb,
+				Group:     gvr.Group,
+				Resource:  gvr.Resource,
+			},
+		},
+	}
+	result, err := cs.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, review, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("can-i %s %s: %w", verb, resourceArg, err)
+	}
+	return result.Status.Allowed, nil
+}
+
+// canIList is `kubectl auth can-i --list [-n <ns>]` as the identity cfg
+// authenticates as: a SelfSubjectRulesReview, the rules as the apiserver
+// returns them (ruleRows words them the way kubectl prints them).
+func canIList(ctx context.Context, cfg *rest.Config, ns string) (*authorizationv1.SubjectRulesReviewStatus, error) {
+	cs, err := clientsetFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	review := &authorizationv1.SelfSubjectRulesReview{
+		Spec: authorizationv1.SelfSubjectRulesReviewSpec{Namespace: ns},
+	}
+	result, err := cs.AuthorizationV1().SelfSubjectRulesReviews().Create(ctx, review, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("can-i --list in %s: %w", ns, err)
+	}
+	return &result.Status, nil
+}
+
+// ruleRows words a rules review the way `kubectl auth can-i --list` prints
+// its rows, one per resource: "<resource>[.<group>]  <non-resource URLs>
+// <resource names>  <verbs>" — a resource rule starts with the resource
+// (selfsubjectaccessreviews.authorization.k8s.io, pods), a non-resource
+// rule with its URLs in brackets ([/healthz]).
+func ruleRows(status *authorizationv1.SubjectRulesReviewStatus) []string {
+	var rows []string
+	for _, rule := range status.ResourceRules {
+		groups := rule.APIGroups
+		if len(groups) == 0 {
+			groups = []string{""}
+		}
+		for _, group := range groups {
+			for _, resource := range rule.Resources {
+				name := resource
+				if group != "" {
+					name += "." + group
+				}
+				rows = append(rows, fmt.Sprintf("%s  []  %v  %v", name, rule.ResourceNames, rule.Verbs))
+			}
+		}
+	}
+	for _, rule := range status.NonResourceRules {
+		rows = append(rows, fmt.Sprintf("%v  []  %v", rule.NonResourceURLs, rule.Verbs))
+	}
+	return rows
+}
+
+// whoAmI is `kubectl auth whoami` as the identity cfg authenticates as: the
+// username and groups the apiserver attributes to it (a SelfSubjectReview) —
+// the proof that a Dex token is accepted and what it maps to.
+func whoAmI(ctx context.Context, cfg *rest.Config) (string, []string, error) {
+	cs, err := clientsetFor(cfg)
+	if err != nil {
+		return "", nil, err
+	}
+	review, err := cs.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
+	if err != nil {
+		return "", nil, fmt.Errorf("whoami: %w", err)
+	}
+	return review.Status.UserInfo.Username, review.Status.UserInfo.Groups, nil
+}
+
+// targetPods resolves a logs target to pods, sorted by name: "deploy/<name>"
+// (or "deployment/<name>") through the Deployment's selector, "pod/<name>"
+// that pod, anything else a label selector (`-l app=dex`).
+func (k *kubeClients) targetPods(ctx context.Context, ns, target string) ([]corev1.Pod, error) {
+	pods := k.clientset.CoreV1().Pods(ns)
+	if name, ok := strings.CutPrefix(target, "pod/"); ok {
+		pod, err := pods.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", describe(gvrPods, ns, name), err)
+		}
+		return []corev1.Pod{*pod}, nil
+	}
+	selector := target
+	name, isDeploy := strings.CutPrefix(target, "deploy/")
+	if !isDeploy {
+		name, isDeploy = strings.CutPrefix(target, "deployment/")
+	}
+	if isDeploy {
+		d, err := k.clientset.AppsV1().Deployments(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", describe(gvrDeployments, ns, name), err)
+		}
+		sel, err := metav1.LabelSelectorAsSelector(d.Spec.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("%s has an unusable selector: %w", describe(gvrDeployments, ns, name), err)
+		}
+		selector = sel.String()
+	}
+	list, err := pods.List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, fmt.Errorf("listing pods in %s matching %q: %w", ns, selector, err)
+	}
+	if len(list.Items) == 0 {
+		return nil, fmt.Errorf("no pods in %s match %s", ns, target)
+	}
+	slices.SortFunc(list.Items, func(a, b corev1.Pod) int { return strings.Compare(a.Name, b.Name) })
+	return list.Items, nil
+}
+
+// logContainers picks the containers to read logs from: the named one when
+// given (refused when the pod has no such container), else kubectl's default
+// container when the pod annotates one, else all of the pod's containers.
+func logContainers(pod *corev1.Pod, container string) ([]string, error) {
+	var names []string
+	for _, c := range pod.Spec.Containers {
+		names = append(names, c.Name)
+	}
+	switch {
+	case container != "":
+		if !slices.Contains(names, container) {
+			return nil, fmt.Errorf("pod %s has no container %q (containers: %s)", pod.Name, container, strings.Join(names, ", "))
+		}
+		return []string{container}, nil
+	case len(names) > 1 && slices.Contains(names, pod.Annotations[defaultContainerAnnotation]):
+		return []string{pod.Annotations[defaultContainerAnnotation]}, nil
+	default:
+		return names, nil
+	}
+}
+
+// logStream is one container's log stream and the prefix its lines carry
+// when several streams are interleaved.
+type logStream struct {
+	pod, container, prefix string
+}
+
+// logStreams lists the (pod, container) streams a target and container
+// choice resolve to, prefixed with "[pod/container] " once there is more
+// than one.
+func (k *kubeClients) logStreams(ctx context.Context, ns, target, container string) ([]logStream, error) {
+	pods, err := k.targetPods(ctx, ns, target)
+	if err != nil {
+		return nil, err
+	}
+	var streams []logStream
+	for i := range pods {
+		containers, err := logContainers(&pods[i], container)
+		if err != nil {
+			return nil, err
+		}
+		for _, c := range containers {
+			streams = append(streams, logStream{pod: pods[i].Name, container: c})
+		}
+	}
+	if len(streams) > 1 {
+		for i := range streams {
+			streams[i].prefix = "[" + streams[i].pod + "/" + streams[i].container + "] "
+		}
+	}
+	return streams, nil
+}
+
+// copyLines writes r to w line by line, each line prefixed.
+func copyLines(w io.Writer, r io.Reader, prefix string) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		if _, err := fmt.Fprintf(w, "%s%s\n", prefix, sc.Text()); err != nil {
+			return err
+		}
+	}
+	return sc.Err()
+}
+
+// podLogs is `kubectl logs <target> [-c <container>] [--since=<since>]`: the
+// logs of every pod the target resolves to (targetPods), of the given
+// container or the pod's (logContainers), prefixed per stream when there are
+// several, since the given duration ago when since > 0.
+func podLogs(ctx context.Context, ns, target, container string, since time.Duration) (string, error) {
+	k, err := labKube()
+	if err != nil {
+		return "", err
+	}
+	streams, err := k.logStreams(ctx, ns, target, container)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for _, s := range streams {
+		opts := &corev1.PodLogOptions{Container: s.container}
+		if since > 0 {
+			secs := int64(since.Seconds())
+			opts.SinceSeconds = &secs
+		}
+		rc, err := k.clientset.CoreV1().Pods(ns).GetLogs(s.pod, opts).Stream(ctx)
+		if err != nil {
+			return b.String(), fmt.Errorf("logs of pod %s/%s (%s): %w", ns, s.pod, s.container, err)
+		}
+		err = copyLines(&b, rc, s.prefix)
+		_ = rc.Close()
+		if err != nil {
+			return b.String(), err
+		}
+	}
+	return b.String(), nil
+}
+
+// streamLogs is `kubectl logs -f <target>`: every stream the target resolves
+// to followed concurrently into w, lines prefixed with the pod and container
+// when there is more than one, until every stream ends or ctx is done.
+func streamLogs(ctx context.Context, ns, target string, w io.Writer) error {
+	k, err := labKube()
+	if err != nil {
+		return err
+	}
+	streams, err := k.logStreams(ctx, ns, target, "")
+	if err != nil {
+		return err
+	}
+	var mu sync.Mutex // one writer at a time, so lines never interleave mid-way
+	var wg sync.WaitGroup
+	errs := make(chan error, len(streams))
+	for _, s := range streams {
+		wg.Go(func() {
+			rc, err := k.clientset.CoreV1().Pods(ns).GetLogs(s.pod, &corev1.PodLogOptions{Container: s.container, Follow: true}).Stream(ctx)
+			if err != nil {
+				errs <- fmt.Errorf("logs of pod %s/%s (%s): %w", ns, s.pod, s.container, err)
+				return
+			}
+			defer func() { _ = rc.Close() }()
+			sc := bufio.NewScanner(rc)
+			sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+			for sc.Scan() {
+				mu.Lock()
+				_, err := fmt.Fprintf(w, "%s%s\n", s.prefix, sc.Text())
+				mu.Unlock()
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+	if ctx.Err() != nil {
+		return nil
+	}
+	return <-errs
+}
+
+// podStateSummary words where a pod is for a probe's failure: its phase and
+// the first container's waiting reason ("ImagePullBackOff: ...") or exit
+// code.
+func podStateSummary(pod *corev1.Pod) string {
+	if pod == nil {
+		return "never observed"
+	}
+	s := string(pod.Status.Phase)
+	for _, c := range pod.Status.ContainerStatuses {
+		switch {
+		case c.State.Waiting != nil:
+			s += ": " + c.State.Waiting.Reason
+			if c.State.Waiting.Message != "" {
+				s += ": " + c.State.Waiting.Message
+			}
+		case c.State.Terminated != nil:
+			s += fmt.Sprintf(": exit code %d", c.State.Terminated.ExitCode)
+			if c.State.Terminated.Reason != "" && c.State.Terminated.Reason != "Completed" && c.State.Terminated.Reason != "Error" {
+				s += " (" + c.State.Terminated.Reason + ")"
+			}
+		}
+	}
+	return s
+}
+
+// runProbePod is `kubectl run <name> --image=<image> --restart=Never --rm -i
+// --command -- <command...>`: a pod that runs the command once, waited for
+// until it succeeds or fails (bounded by timeout), its combined output read
+// from the container log, the pod deleted afterwards — whatever happened. A
+// leftover of the same name from an interrupted run is removed first. The
+// output is returned with the error too: a probe's diagnosis is in what it
+// printed.
+func runProbePod(ctx context.Context, ns, name, image string, command []string, timeout time.Duration) (string, error) {
+	k, err := labKube()
+	if err != nil {
+		return "", err
+	}
+	pods := k.clientset.CoreV1().Pods(ns)
+	propagation := metav1.DeletePropagationBackground
+	deleteOpts := metav1.DeleteOptions{PropagationPolicy: &propagation}
+	if err := pods.Delete(ctx, name, deleteOpts); err != nil && !apierrors.IsNotFound(err) {
+		return "", fmt.Errorf("removing the leftover probe pod %s/%s: %w", ns, name, err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := pods.Get(ctx, name, metav1.GetOptions{})
+		return apierrors.IsNotFound(err), nil
+	}); err != nil {
+		return "", fmt.Errorf("the leftover probe pod %s/%s is still there %s after its deletion was requested", ns, name, timeout)
+	}
+	pod := &corev1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"app.kubernetes.io/managed-by": applyFieldManager}},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name:            probeContainer,
+				Image:           image,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         command,
+			}},
+		},
+	}
+	if _, err := pods.Create(ctx, pod, metav1.CreateOptions{FieldManager: applyFieldManager}); err != nil {
+		return "", fmt.Errorf("creating probe pod %s/%s: %w", ns, name, err)
+	}
+	defer func() {
+		// Best effort, on a context of its own: the caller's may be done.
+		cleanup, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = pods.Delete(cleanup, name, deleteOpts)
+	}()
+	var last *corev1.Pod
+	waitErr := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		p, err := pods.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		last = p
+		return p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed, nil
+	})
+	out := ""
+	if rc, err := pods.GetLogs(name, &corev1.PodLogOptions{Container: probeContainer}).Stream(ctx); err == nil {
+		raw, _ := io.ReadAll(rc)
+		_ = rc.Close()
+		out = string(raw)
+	}
+	switch {
+	case waitErr != nil:
+		return out, fmt.Errorf("probe pod %s/%s did not finish within %s (%s)", ns, name, timeout, podStateSummary(last))
+	case last.Status.Phase == corev1.PodFailed:
+		return out, fmt.Errorf("probe pod %s/%s failed (%s)", ns, name, podStateSummary(last))
+	}
+	return out, nil
+}
+
+// rawGet is `kubectl get --raw=<path>`: a non-resource path of the apiserver
+// (/readyz, /version), as bytes.
+func rawGet(ctx context.Context, path string) ([]byte, error) {
+	k, err := labKube()
+	if err != nil {
+		return nil, err
+	}
+	out, err := k.raw.Get().AbsPath(path).DoRaw(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+	return out, nil
+}
+
+// The lab's own idempotent writes of core objects, built in code rather than
+// rendered — a namespace, a Secret from files, a TLS Secret — and the one
+// read next to them. Server-side applied like everything else, so re-runs
+// are clean no-ops.
+
+// ensureNamespace idempotently creates a namespace.
+func ensureNamespace(ns string) error {
+	_, err := applyTyped(context.Background(), &corev1.Namespace{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{Name: ns},
+	})
+	return err
+}
+
+// ensureSecretFromFiles idempotently applies a generic (Opaque) Secret whose
+// data keys are the contents of the given files — `kubectl create secret
+// generic --from-file=<key>=<path>`.
+func ensureSecretFromFiles(ns, name string, files map[string]string) error {
+	data := make(map[string][]byte, len(files))
+	for key, path := range files {
+		raw, err := os.ReadFile(path) // #nosec G304 -- lab-owned cert paths chosen by the caller
+		if err != nil {
+			return fmt.Errorf("secret %s/%s key %s: %w", ns, name, key, err)
+		}
+		data[key] = raw
+	}
+	return ensureSecret(ns, name, corev1.SecretTypeOpaque, data)
+}
+
+// ensureTLSSecret idempotently applies a kubernetes.io/tls Secret from a
+// cert and key file — the type the Gateway API's certificateRefs require,
+// which ensureSecretFromFiles's generic secrets are not.
+func ensureTLSSecret(ns, name, certPath, keyPath string) error {
+	cert, err := os.ReadFile(certPath) // #nosec G304 -- lab-owned cert paths chosen by the caller
+	if err != nil {
+		return fmt.Errorf("tls secret %s/%s: %w", ns, name, err)
+	}
+	key, err := os.ReadFile(keyPath) // #nosec G304 -- lab-owned cert paths chosen by the caller
+	if err != nil {
+		return fmt.Errorf("tls secret %s/%s: %w", ns, name, err)
+	}
+	return ensureSecret(ns, name, corev1.SecretTypeTLS, map[string][]byte{
+		corev1.TLSCertKey:       cert,
+		corev1.TLSPrivateKeyKey: key,
+	})
+}
+
+func ensureSecret(ns, name string, secretType corev1.SecretType, data map[string][]byte) error {
+	_, err := applyTyped(context.Background(), &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Type:       secretType,
+		Data:       data,
+	})
+	return err
+}
+
+// secretHasKey reports whether a secret exists and carries the given data key.
+func secretHasKey(ns, name, key string) bool {
+	secret, err := getObject(context.Background(), gvrSecrets, ns, name)
+	if err != nil {
+		return false
+	}
+	value, _, _ := unstructured.NestedString(secret.Object, "data", key)
+	return value != ""
+}

--- a/internal/lab/kube_test.go
+++ b/internal/lab/kube_test.go
@@ -1,0 +1,1006 @@
+package lab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	restfake "k8s.io/client-go/rest/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// The embedded client is tested against client-go's fakes: the dynamic fake
+// for every object read and write, the typed fake for pods, logs and the
+// reviews, a REST mapper built from a fixed list (the fake discovery serves
+// none), and a fake REST client for the non-resource paths. No apiserver, no
+// envtest. What the fakes cannot do — server-side apply's field management
+// and resourceVersion bookkeeping — fakeApply stands in for, so the
+// created/changed/unchanged verdict is exercised.
+
+// Names the fixtures share; constants so the linter's literal count stays
+// quiet.
+const (
+	testNS         = "demo"
+	widgetGroup    = "example.com"
+	widgetKind     = "Widget"
+	fakeLogLine    = "fake logs"
+	fakeKindServer = "https://127.0.0.1:34547"
+	appLabel       = "app"
+	fieldStatus    = "status"
+	fieldType      = "type"
+	condReady      = "Ready"
+	condFalse      = "False"
+	verbGet        = "get"
+	verbList       = "list"
+	verbCreate     = "create"
+)
+
+var (
+	widgetGVK = schema.GroupVersionKind{Group: widgetGroup, Version: "v1", Kind: widgetKind}
+	widgetGVR = schema.GroupVersionResource{Group: widgetGroup, Version: "v1", Resource: "widgets"}
+)
+
+// fakeLab is a kubeClients bundle on fakes, installed as the lab's client for
+// one test, with the knobs the tests turn: how often the mapper was reset,
+// how often /readyz was asked, and a hook run on every mapper reset (the
+// CRD-wait test registers its kind there).
+type fakeLab struct {
+	*kubeClients
+	dyn     *dynamicfake.FakeDynamicClient
+	cs      *kubefake.Clientset
+	mapper  *meta.DefaultRESTMapper
+	resets  int
+	readyz  int
+	onReset func(f *fakeLab)
+}
+
+// stubLabKube makes k the lab's client bundle for the test — whatever
+// useClusterKubeconfig resets in between, the next labKube() rebuilds it
+// from this seam.
+func stubLabKube(t *testing.T, k *kubeClients) {
+	t.Helper()
+	prev := newLabKube
+	newLabKube = func() (*kubeClients, error) { return k, nil }
+	resetLabKube()
+	t.Cleanup(func() {
+		newLabKube = prev
+		resetLabKube()
+	})
+}
+
+// newFakeLab builds the fake bundle, seeded with objects (typed or
+// unstructured; they land in the dynamic fake) and installs it.
+func newFakeLab(t *testing.T, objects ...runtime.Object) *fakeLab {
+	t.Helper()
+	sch := runtime.NewScheme()
+	if err := corev1.AddToScheme(sch); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(sch); err != nil {
+		t.Fatal(err)
+	}
+	// Seeds land in the tracker as they are given, so typed ones are turned
+	// into what the apiserver hands the dynamic client: unstructured, with
+	// their apiVersion/kind.
+	seeds := make([]runtime.Object, 0, len(objects))
+	for _, obj := range objects {
+		if _, ok := obj.(*unstructured.Unstructured); ok {
+			seeds = append(seeds, obj)
+			continue
+		}
+		gvks, _, err := sch.ObjectKinds(obj)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		if err != nil {
+			t.Fatal(err)
+		}
+		u := &unstructured.Unstructured{Object: raw}
+		u.SetGroupVersionKind(gvks[0])
+		seeds = append(seeds, u)
+	}
+	// The dynamic fake wants a scheme of unstructured kinds (a typed List
+	// type would refuse the unstructured items); the typed scheme above only
+	// names the seeds' kinds.
+	usch := runtime.NewScheme()
+	for gvk := range sch.AllKnownTypes() {
+		if strings.HasSuffix(gvk.Kind, "List") {
+			usch.AddKnownTypeWithName(gvk, &unstructured.UnstructuredList{})
+		} else {
+			usch.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+		}
+	}
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(usch, map[schema.GroupVersionResource]string{
+		gvrCRDs:   "CustomResourceDefinitionList",
+		widgetGVR: "WidgetList",
+	}, seeds...)
+	dyn.PrependReactor("patch", "*", fakeApply(dyn.Tracker()))
+
+	mapper := meta.NewDefaultRESTMapper(nil)
+	for _, gvk := range []schema.GroupVersionKind{
+		corev1.SchemeGroupVersion.WithKind("Namespace"),
+		corev1.SchemeGroupVersion.WithKind("Node"),
+		gvkCRD,
+	} {
+		mapper.Add(gvk, meta.RESTScopeRoot)
+	}
+	for _, gvk := range []schema.GroupVersionKind{
+		corev1.SchemeGroupVersion.WithKind("Secret"),
+		corev1.SchemeGroupVersion.WithKind("ConfigMap"),
+		corev1.SchemeGroupVersion.WithKind("Pod"),
+		appsv1.SchemeGroupVersion.WithKind(kindDeployment),
+	} {
+		mapper.Add(gvk, meta.RESTScopeNamespace)
+	}
+
+	f := &fakeLab{dyn: dyn, cs: kubefake.NewClientset(), mapper: mapper}
+	f.kubeClients = &kubeClients{
+		cfg:       &rest.Config{Host: fakeKindServer, TLSClientConfig: rest.TLSClientConfig{CertData: []byte("admin")}},
+		dynamic:   dyn,
+		clientset: f.cs,
+		mapper:    mapper,
+		raw: &restfake.RESTClient{
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+			Client: restfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				if req.URL.Path == "/readyz" {
+					f.readyz++
+					return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("ok"))}, nil
+				}
+				return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("404 page not found"))}, nil
+			}),
+		},
+		resetMapper: func() {
+			f.resets++
+			if f.onReset != nil {
+				f.onReset(f)
+			}
+		},
+	}
+	stubLabKube(t, f.kubeClients)
+	return f
+}
+
+// fakeApply stands in for the apiserver's server-side apply on the dynamic
+// fake, whose tracker keeps no resourceVersion: a missing object is created
+// at resourceVersion 1; an existing one is replaced by what was applied and
+// gets a new resourceVersion only when that differs from what is stored. It
+// also insists on the lab's field manager and Force — the contract every
+// apply of the lab must meet.
+func fakeApply(tracker clienttesting.ObjectTracker) clienttesting.ReactionFunc {
+	return func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patch, ok := action.(clienttesting.PatchActionImpl)
+		if !ok || patch.GetPatchType() != types.ApplyPatchType {
+			return false, nil, nil
+		}
+		opts := patch.PatchOptions
+		if opts.FieldManager != applyFieldManager || opts.Force == nil || !*opts.Force {
+			return true, nil, fmt.Errorf("apply without the lab's forced field manager: %+v", opts)
+		}
+		applied := &unstructured.Unstructured{}
+		if err := applied.UnmarshalJSON(patch.GetPatch()); err != nil {
+			return true, nil, err
+		}
+		gvr, ns, name := patch.GetResource(), patch.GetNamespace(), patch.GetName()
+		existing, err := tracker.Get(gvr, ns, name)
+		switch {
+		case apierrors.IsNotFound(err):
+			applied.SetResourceVersion("1")
+			if err := tracker.Create(gvr, applied, ns); err != nil {
+				return true, nil, err
+			}
+		case err != nil:
+			return true, nil, err
+		default:
+			current, ok := existing.(*unstructured.Unstructured)
+			if !ok {
+				return true, nil, fmt.Errorf("tracker holds a %T", existing)
+			}
+			applied.SetResourceVersion(current.GetResourceVersion())
+			if !reflect.DeepEqual(applied.Object, current.Object) {
+				rv, _ := strconv.Atoi(current.GetResourceVersion())
+				applied.SetResourceVersion(strconv.Itoa(rv + 1))
+			}
+			if err := tracker.Update(gvr, applied, ns); err != nil {
+				return true, nil, err
+			}
+		}
+		obj, err := tracker.Get(gvr, ns, name)
+		return true, obj, err
+	}
+}
+
+// stored reads an object back from the dynamic fake.
+func (f *fakeLab) stored(t *testing.T, gvr schema.GroupVersionResource, ns, name string) *unstructured.Unstructured {
+	t.Helper()
+	obj, err := f.dyn.Tracker().Get(gvr, ns, name)
+	if err != nil {
+		t.Fatalf("%s: %v", describe(gvr, ns, name), err)
+	}
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("%s: stored as %T", describe(gvr, ns, name), obj)
+	}
+	return u
+}
+
+const (
+	nsManifest = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+`
+	opaqueManifest = `apiVersion: v1
+kind: Secret
+metadata:
+  name: creds
+type: Opaque
+data:
+  greeting: aGk=
+`
+)
+
+func deployManifest(image string) string {
+	return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: demo
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: dex
+          image: ` + image + "\n"
+}
+
+// TestDecodeManifests: a multi-document manifest splits in order; an empty
+// document (a bare separator), a comments-only one and a leading separator
+// are skipped; a List expands into its items; a document without a kind is
+// refused by its position.
+func TestDecodeManifests(t *testing.T) {
+	manifest := "---\n" + nsManifest + "---\n\n---\n# only a comment\n---\n" + opaqueManifest + "---\n" + `apiVersion: v1
+kind: List
+items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: a
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: b
+`
+	objs, err := decodeManifests([]byte(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, o := range objs {
+		got = append(got, o.GetKind()+"/"+o.GetName())
+	}
+	want := []string{"Namespace/demo", "Secret/creds", "ConfigMap/a", "ConfigMap/b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("decoded %v, want %v", got, want)
+	}
+	if objs[0].GetName() != testNS || objs[1].GetName() != "creds" {
+		t.Errorf("objects lost their names: %v", got)
+	}
+
+	if _, err := decodeManifests([]byte(nsManifest + "---\nmetadata:\n  name: nokind\n")); err == nil || !strings.Contains(err.Error(), "document 2") {
+		t.Errorf("a document without a kind must be refused by position, got %v", err)
+	}
+	if objs, err := decodeManifests(nil); err != nil || len(objs) != 0 {
+		t.Errorf("nothing decodes to nothing, got %v %v", objs, err)
+	}
+}
+
+// TestApplyManifestsChanged: the first apply creates every object (a
+// namespace-scoped one without a namespace lands in default), a re-apply of
+// the same manifest changes nothing, and a manifest that differs in one
+// object changes that one only. Every write goes out as a forced apply
+// under the lab's field manager — fakeApply refuses anything else.
+func TestApplyManifestsChanged(t *testing.T) {
+	f := newFakeLab(t)
+	ctx := context.Background()
+	manifest := nsManifest + "---\n" + opaqueManifest + "---\n" + deployManifest("dex:1")
+
+	results, err := applyManifests(ctx, []byte(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, r := range results {
+		got = append(got, fmt.Sprintf("%s ns=%s changed=%v", r, r.namespace, r.changed))
+	}
+	want := []string{"namespace/demo ns= changed=true", "secret/creds ns=default changed=true", "deployment.apps/dex ns=demo changed=true"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("first apply = %v, want %v", got, want)
+	}
+	if !anyChanged(results) {
+		t.Error("anyChanged must report the creations")
+	}
+	if secret := f.stored(t, gvrSecrets, defaultNamespace, "creds"); secret.GetNamespace() != defaultNamespace {
+		t.Errorf("the namespace-less secret landed in %q, want %s", secret.GetNamespace(), defaultNamespace)
+	}
+
+	results, err = applyManifests(ctx, []byte(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if anyChanged(results) {
+		t.Errorf("a re-apply of the same manifest reported a change: %+v", results)
+	}
+
+	results, err = applyManifests(ctx, []byte(manifest[:len(manifest)-len("dex:1\n")]+"dex:2\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if want := r.gvk.Kind == kindDeployment; r.changed != want {
+			t.Errorf("%s changed=%v, want %v", r, r.changed, want)
+		}
+	}
+	if img, _, _ := unstructured.NestedString(f.stored(t, gvrDeployments, testNS, componentDex).Object, "spec", "template", "spec", "containers"); img != "" {
+		t.Errorf("containers is a list, not a string: %q", img)
+	}
+}
+
+// TestApplyManifestsCRDThenCR: a batch that carries a CRD and one of its
+// objects applies both — after the CRD the mapper is reset until the new
+// kind resolves (here: on the second reset), and only then is the object
+// applied. A kind no CRD introduced fails naming it and the fix.
+func TestApplyManifestsCRDThenCR(t *testing.T) {
+	f := newFakeLab(t)
+	f.onReset = func(f *fakeLab) {
+		if f.resets >= 2 {
+			f.mapper.Add(widgetGVK, meta.RESTScopeNamespace)
+		}
+	}
+	crd := `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+    plural: widgets
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: false
+      storage: false
+`
+	widget := `apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+  namespace: demo
+spec:
+  size: 3
+`
+	results, err := applyManifests(context.Background(), []byte(crd+"---\n"+widget))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 2 || results[0].gvk != gvkCRD || results[1].gvk != widgetGVK {
+		t.Fatalf("results = %+v", results)
+	}
+	if f.resets != 2 {
+		t.Errorf("mapper reset %d times, want 2 (the miss, then the hit)", f.resets)
+	}
+	if size, _, _ := unstructured.NestedInt64(f.stored(t, widgetGVR, testNS, "w").Object, "spec", "size"); size != 3 {
+		t.Errorf("widget spec.size = %d, want 3 (integers must survive the decode)", size)
+	}
+
+	f2 := newFakeLab(t)
+	_, err = applyManifests(context.Background(), []byte(widget))
+	if err == nil {
+		t.Fatal("an unknown kind must fail the apply")
+	}
+	for _, want := range []string{"Widget w", "no matches for kind", "ensure the CRDs are installed first"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("unknown-kind error %q lacks %q", err, want)
+		}
+	}
+	if f2.resets != 0 {
+		t.Errorf("no CRD in the batch, yet the mapper was reset %d times", f2.resets)
+	}
+}
+
+// TestEnsureHelpers: the lab's own core objects — a namespace, a generic
+// secret from files, a TLS secret — are applied typed, without the empty
+// creationTimestamp/status the conversion emits, and secretHasKey reads the
+// result.
+func TestEnsureHelpers(t *testing.T) {
+	f := newFakeLab(t)
+	dir := t.TempDir()
+	certPath, keyPath := filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")
+	for path, content := range map[string]string{certPath: "CERT", keyPath: "KEY"} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := ensureNamespace(testNS); err != nil {
+		t.Fatal(err)
+	}
+	ns := f.stored(t, gvrNamespaces, "", testNS)
+	if _, has := ns.Object[fieldStatus]; has {
+		t.Errorf("namespace applied with a status: %v", ns.Object)
+	}
+	if _, has, _ := unstructured.NestedFieldNoCopy(ns.Object, "metadata", "creationTimestamp"); has {
+		t.Errorf("namespace applied with a creationTimestamp: %v", ns.Object)
+	}
+	if err := ensureNamespace(testNS); err != nil {
+		t.Fatalf("re-ensuring the namespace: %v", err)
+	}
+
+	if err := ensureSecretFromFiles(testNS, "dex-ca", map[string]string{"ca.crt": certPath}); err != nil {
+		t.Fatal(err)
+	}
+	ca := f.stored(t, gvrSecrets, testNS, "dex-ca")
+	if typ, _, _ := unstructured.NestedString(ca.Object, "type"); typ != string(corev1.SecretTypeOpaque) {
+		t.Errorf("generic secret type = %q", typ)
+	}
+	if data, _, _ := unstructured.NestedString(ca.Object, "data", "ca.crt"); data != "Q0VSVA==" {
+		t.Errorf("data.ca.crt = %q, want the file base64-encoded", data)
+	}
+	if err := ensureSecretFromFiles(testNS, "dex-ca", map[string]string{"ca.crt": filepath.Join(dir, "missing")}); err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Errorf("a missing file must fail by name, got %v", err)
+	}
+
+	if err := ensureTLSSecret(testNS, "edge", certPath, keyPath); err != nil {
+		t.Fatal(err)
+	}
+	tls := f.stored(t, gvrSecrets, testNS, "edge")
+	if typ, _, _ := unstructured.NestedString(tls.Object, "type"); typ != string(corev1.SecretTypeTLS) {
+		t.Errorf("tls secret type = %q, want %s", typ, corev1.SecretTypeTLS)
+	}
+	if key, _, _ := unstructured.NestedString(tls.Object, "data", corev1.TLSPrivateKeyKey); key != "S0VZ" {
+		t.Errorf("data.tls.key = %q", key)
+	}
+
+	if !secretHasKey(testNS, "edge", corev1.TLSCertKey) {
+		t.Error("secretHasKey misses tls.crt")
+	}
+	if secretHasKey(testNS, "edge", "nope") || secretHasKey(testNS, "absent", corev1.TLSCertKey) {
+		t.Error("secretHasKey reports a key or a secret that is not there")
+	}
+}
+
+// TestGetListExists: reads through the dynamic client by GVR, the NotFound
+// kept recognisable, a list filtered by label.
+func TestGetListExists(t *testing.T) {
+	newFakeLab(t,
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: testNS, Labels: map[string]string{appLabel: "x"}}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: testNS}},
+	)
+	ctx := context.Background()
+	obj, err := getObject(ctx, gvrConfigMaps, testNS, "a")
+	if err != nil || obj.GetName() != "a" {
+		t.Fatalf("getObject = %v, %v", obj, err)
+	}
+	_, err = getObject(ctx, gvrConfigMaps, testNS, "zzz")
+	if err == nil || !apierrors.IsNotFound(err) || !strings.Contains(err.Error(), "configmaps demo/zzz") {
+		t.Errorf("missing object: err = %v, want a NotFound naming it", err)
+	}
+	for name, want := range map[string]bool{"a": true, "zzz": false} {
+		if exists, err := objectExists(ctx, gvrConfigMaps, testNS, name); err != nil || exists != want {
+			t.Errorf("objectExists(%s) = %v, %v; want %v", name, exists, err, want)
+		}
+	}
+	items, err := listObjects(ctx, gvrConfigMaps, testNS, appLabel+"=x")
+	if err != nil || len(items) != 1 || items[0].GetName() != "a" {
+		t.Errorf("listObjects(app=x) = %v, %v", items, err)
+	}
+	items, err = listObjects(ctx, gvrConfigMaps, "", "")
+	if err != nil || len(items) != 2 {
+		t.Errorf("listObjects(all) = %d items, %v", len(items), err)
+	}
+}
+
+// TestDeleteObjectWait: deleting what is not there is success; a delete that
+// waits returns once the object is gone; one that never goes fails after
+// the bound, naming the object.
+func TestDeleteObjectWait(t *testing.T) {
+	f := newFakeLab(t, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: testNS}})
+	ctx := context.Background()
+	if err := deleteObject(ctx, gvrConfigMaps, testNS, "nope", time.Second); err != nil {
+		t.Errorf("deleting a missing object: %v, want success", err)
+	}
+	if err := deleteObject(ctx, gvrConfigMaps, testNS, "a", time.Second); err != nil {
+		t.Errorf("deleting with a wait: %v", err)
+	}
+	if _, err := f.dyn.Tracker().Get(gvrConfigMaps, testNS, "a"); !apierrors.IsNotFound(err) {
+		t.Errorf("object still stored after the delete: %v", err)
+	}
+
+	// A finalizer that never lets go: the delete is accepted, the object stays.
+	held := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "held", Namespace: testNS}}
+	f2 := newFakeLab(t, held)
+	f2.dyn.PrependReactor("delete", "configmaps", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, nil
+	})
+	err := deleteObject(ctx, gvrConfigMaps, testNS, "held", 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("an object that never goes must fail the wait")
+	}
+	for _, want := range []string{"configmaps demo/held", "still there", "finalizer"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("wait error %q lacks %q", err, want)
+		}
+	}
+	if err := deleteObject(ctx, gvrConfigMaps, testNS, "held", 0); err != nil {
+		t.Errorf("--wait=false must not wait: %v", err)
+	}
+}
+
+// TestDeploymentRolloutStatus is kubectl's rollout-status verdict, case by
+// case.
+func TestDeploymentRolloutStatus(t *testing.T) {
+	one := int32(1)
+	d := func(gen, observed int64, replicas, updated, available int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: componentDex, Generation: gen},
+			Spec:       appsv1.DeploymentSpec{Replicas: &one},
+			Status:     appsv1.DeploymentStatus{ObservedGeneration: observed, Replicas: replicas, UpdatedReplicas: updated, AvailableReplicas: available},
+		}
+	}
+	cases := []struct {
+		name string
+		d    *appsv1.Deployment
+		msg  string
+		done bool
+	}{
+		{"spec not observed", d(2, 1, 1, 1, 1), "spec update to be observed", false},
+		{"new replica not updated", d(1, 1, 1, 0, 0), "0 out of 1 new replicas have been updated", false},
+		{"old replica pending", d(1, 1, 2, 1, 1), "1 old replicas are pending termination", false},
+		{"updated not available", d(1, 1, 1, 1, 0), "0 of 1 updated replicas are available", false},
+		{"rolled out", d(1, 1, 1, 1, 1), `deployment "dex" successfully rolled out`, true},
+	}
+	for _, c := range cases {
+		msg, done, err := deploymentRolloutStatus(c.d)
+		if err != nil || done != c.done || !strings.Contains(msg, c.msg) {
+			t.Errorf("%s: (%q, %v, %v), want %q done=%v", c.name, msg, done, err, c.msg, c.done)
+		}
+	}
+	stuck := d(1, 1, 1, 0, 0)
+	stuck.Status.Conditions = []appsv1.DeploymentCondition{{Type: appsv1.DeploymentProgressing, Reason: "ProgressDeadlineExceeded"}}
+	if _, _, err := deploymentRolloutStatus(stuck); err == nil || !strings.Contains(err.Error(), "exceeded its progress deadline") {
+		t.Errorf("progress deadline: err = %v", err)
+	}
+}
+
+// TestWaitDeploymentRolledOut reads the Deployment through the dynamic
+// client: complete at once, a deadline with the last progress line, a
+// missing Deployment as the apiserver's NotFound.
+func TestWaitDeploymentRolledOut(t *testing.T) {
+	one := int32(1)
+	done := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: kindDeployment},
+		ObjectMeta: metav1.ObjectMeta{Name: componentDex, Namespace: testNS, Generation: 1},
+		Spec:       appsv1.DeploymentSpec{Replicas: &one},
+		Status:     appsv1.DeploymentStatus{ObservedGeneration: 1, Replicas: 1, UpdatedReplicas: 1, AvailableReplicas: 1},
+	}
+	pending := done.DeepCopy()
+	pending.Name = "slow"
+	pending.Status.AvailableReplicas = 0
+	newFakeLab(t, done, pending)
+	ctx := context.Background()
+	if err := waitDeploymentRolledOut(ctx, testNS, componentDex, time.Second); err != nil {
+		t.Errorf("a rolled-out deployment: %v", err)
+	}
+	err := waitDeploymentRolledOut(ctx, testNS, "slow", 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("a pending rollout must hit the deadline")
+	}
+	for _, want := range []string{"deployments demo/slow", "did not roll out within", "0 of 1 updated replicas are available", "kubectl -n demo get pods"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("deadline error %q lacks %q", err, want)
+		}
+	}
+	if err := waitDeploymentRolledOut(ctx, testNS, "absent", time.Second); err == nil || !apierrors.IsNotFound(err) {
+		t.Errorf("a missing deployment: %v, want the apiserver's NotFound", err)
+	}
+}
+
+// TestRestartDeployment stamps kubectl's restartedAt annotation into the pod
+// template.
+func TestRestartDeployment(t *testing.T) {
+	f := newFakeLab(t, &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: kindDeployment},
+		ObjectMeta: metav1.ObjectMeta{Name: componentDex, Namespace: testNS},
+	})
+	if err := restartDeployment(context.Background(), testNS, componentDex); err != nil {
+		t.Fatal(err)
+	}
+	stamp, _, _ := unstructured.NestedString(f.stored(t, gvrDeployments, testNS, componentDex).Object, "spec", "template", "metadata", "annotations", restartedAtAnnotation)
+	if _, err := time.Parse(time.RFC3339, stamp); err != nil {
+		t.Errorf("restartedAt = %q: %v", stamp, err)
+	}
+}
+
+// TestConditions: the Ready condition's status and message off an object, ""
+// when the condition is not there.
+func TestConditions(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		fieldStatus: map[string]any{"conditions": []any{
+			map[string]any{fieldType: "Reconciling", fieldStatus: "Unknown"},
+			map[string]any{fieldType: condReady, fieldStatus: condFalse, "message": "install retries exhausted"},
+		}},
+	}}
+	if s := conditionStatus(obj, condReady); s != condFalse {
+		t.Errorf("Ready status = %q", s)
+	}
+	if m := conditionMessage(obj, condReady); m != "install retries exhausted" {
+		t.Errorf("Ready message = %q", m)
+	}
+	if s, m := conditionStatus(obj, "Healthy"), conditionMessage(obj, "Healthy"); s != "" || m != "" {
+		t.Errorf("absent condition = %q %q, want empty", s, m)
+	}
+	if s := conditionStatus(&unstructured.Unstructured{Object: map[string]any{}}, condReady); s != "" {
+		t.Errorf("no status at all = %q", s)
+	}
+}
+
+// TestWaitCondition: met at once; the deadline names the last status and
+// message; a missing object ends the wait with the apiserver's words.
+func TestWaitCondition(t *testing.T) {
+	ready := &unstructured.Unstructured{}
+	ready.SetAPIVersion("v1")
+	ready.SetKind("ConfigMap")
+	ready.SetNamespace(testNS)
+	ready.SetName("ok")
+	_ = unstructured.SetNestedSlice(ready.Object, []any{map[string]any{fieldType: condReady, fieldStatus: "True"}}, fieldStatus, "conditions")
+	notReady := ready.DeepCopy()
+	notReady.SetName("nope")
+	_ = unstructured.SetNestedSlice(notReady.Object, []any{map[string]any{fieldType: condReady, fieldStatus: condFalse, "message": "waiting on the model"}}, fieldStatus, "conditions")
+	newFakeLab(t, ready, notReady)
+	ctx := context.Background()
+	if err := waitCondition(ctx, gvrConfigMaps, testNS, "ok", condReady, "True", time.Second); err != nil {
+		t.Errorf("met condition: %v", err)
+	}
+	err := waitCondition(ctx, gvrConfigMaps, testNS, "nope", condReady, "True", 20*time.Millisecond)
+	if err == nil {
+		t.Fatal("an unmet condition must hit the deadline")
+	}
+	for _, want := range []string{"configmaps demo/nope", "never reached Ready=True", `"False"`, "waiting on the model"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("deadline error %q lacks %q", err, want)
+		}
+	}
+	if err := waitCondition(ctx, gvrConfigMaps, testNS, "absent", condReady, "True", time.Second); err == nil || !apierrors.IsNotFound(err) {
+		t.Errorf("a missing object: %v, want the apiserver's NotFound", err)
+	}
+}
+
+// TestGvrFor resolves kubectl's resource arguments through the mapper:
+// the API group filled in, a fully qualified name honoured, an unknown one
+// refused by name.
+func TestGvrFor(t *testing.T) {
+	newFakeLab(t)
+	for arg, want := range map[string]schema.GroupVersionResource{
+		gvrDeployments.Resource: gvrDeployments,
+		gvrSecrets.Resource:     gvrSecrets,
+		"secret":                gvrSecrets,
+		gvrDeployments.Resource + "." + gvrDeployments.Group: gvrDeployments,
+	} {
+		if got, err := gvrFor(arg); err != nil || got != want {
+			t.Errorf("gvrFor(%q) = %v, %v; want %v", arg, got, err, want)
+		}
+	}
+	if _, err := gvrFor("helmreleases.helm.toolkit.fluxcd.io"); err == nil || !strings.Contains(err.Error(), "helmreleases.helm.toolkit.fluxcd.io") {
+		t.Errorf("an unserved resource must fail by name, got %v", err)
+	}
+}
+
+// TestCanI: `auth can-i` becomes a SelfSubjectAccessReview as the given
+// identity — the verb, the resource with its API group resolved through the
+// mapper (deployments -> apps), the namespace ("" for every namespace) —
+// and the answer is the apiserver's.
+func TestCanI(t *testing.T) {
+	newFakeLab(t)
+	cs := kubefake.NewClientset()
+	var attrs []*authorizationv1.ResourceAttributes
+	cs.PrependReactor("create", "selfsubjectaccessreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		review, ok := action.(clienttesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		if !ok {
+			return true, nil, fmt.Errorf("created a %T", action.(clienttesting.CreateAction).GetObject())
+		}
+		attrs = append(attrs, review.Spec.ResourceAttributes)
+		review.Status.Allowed = review.Spec.ResourceAttributes.Verb != verbCreate
+		return true, review, nil
+	})
+	seen := stubClientsetFor(t, cs)
+	cfg := &rest.Config{Host: "https://127.0.0.1:34547", BearerToken: "tok"}
+	ctx := context.Background()
+
+	allowed, err := canI(ctx, cfg, verbCreate, gvrDeployments.Resource, "kube-system")
+	if err != nil || allowed {
+		t.Errorf("create deployments: %v, %v; want no", allowed, err)
+	}
+	allowed, err = canI(ctx, cfg, verbList, gvrPods.Resource, "")
+	if err != nil || !allowed {
+		t.Errorf("list pods --all-namespaces: %v, %v; want yes", allowed, err)
+	}
+	if _, err := canI(ctx, cfg, verbGet, "unicorns", ""); err == nil {
+		t.Error("a resource the apiserver does not serve must fail the check")
+	}
+	want := []*authorizationv1.ResourceAttributes{
+		{Namespace: "kube-system", Verb: verbCreate, Group: gvrDeployments.Group, Resource: gvrDeployments.Resource},
+		{Namespace: "", Verb: verbList, Group: "", Resource: gvrPods.Resource},
+	}
+	if !reflect.DeepEqual(attrs, want) {
+		t.Errorf("reviews sent = %+v, want %+v", attrs, want)
+	}
+	if len(*seen) != 2 || (*seen)[0] != cfg {
+		t.Errorf("the review client was not built from the caller's config: %v", *seen)
+	}
+}
+
+// stubClientsetFor makes cs the typed clientset every identity-bound helper
+// (canI, canIList, whoAmI) builds, recording the configs it was asked for.
+func stubClientsetFor(t *testing.T, cs *kubefake.Clientset) *[]*rest.Config {
+	t.Helper()
+	var seen []*rest.Config
+	prev := clientsetFor
+	clientsetFor = func(cfg *rest.Config) (kubernetes.Interface, error) {
+		seen = append(seen, cfg)
+		return cs, nil
+	}
+	t.Cleanup(func() { clientsetFor = prev })
+	return &seen
+}
+
+// TestCanIListRows: `auth can-i --list` becomes a SelfSubjectRulesReview in
+// the namespace, and its rows read like kubectl's — a resource rule by
+// resource.group, a non-resource rule by its URLs in brackets — so the
+// proof that skips selfsubject* and [...] rows works on them.
+func TestCanIListRows(t *testing.T) {
+	cs := kubefake.NewClientset()
+	var namespaces []string
+	cs.PrependReactor("create", "selfsubjectrulesreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		review, ok := action.(clienttesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectRulesReview)
+		if !ok {
+			return true, nil, errors.New("not a rules review")
+		}
+		namespaces = append(namespaces, review.Spec.Namespace)
+		review.Status = authorizationv1.SubjectRulesReviewStatus{
+			ResourceRules: []authorizationv1.ResourceRule{
+				{Verbs: []string{verbCreate}, APIGroups: []string{"authorization.k8s.io"}, Resources: []string{"selfsubjectaccessreviews", "selfsubjectrulesreviews"}},
+				{Verbs: []string{verbGet, verbList}, Resources: []string{gvrPods.Resource}},
+				{Verbs: []string{verbGet}, APIGroups: []string{gvrDeployments.Group}, Resources: []string{gvrDeployments.Resource}, ResourceNames: []string{componentDex}},
+			},
+			NonResourceRules: []authorizationv1.NonResourceRule{{Verbs: []string{verbGet}, NonResourceURLs: []string{"/healthz", "/api"}}},
+		}
+		return true, review, nil
+	})
+	stubClientsetFor(t, cs)
+	status, err := canIList(context.Background(), &rest.Config{}, "kagent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(namespaces, []string{"kagent"}) {
+		t.Errorf("review namespaces = %v", namespaces)
+	}
+	rows := ruleRows(status)
+	want := []string{
+		"selfsubjectaccessreviews.authorization.k8s.io  []  []  [create]",
+		"selfsubjectrulesreviews.authorization.k8s.io  []  []  [create]",
+		"pods  []  []  [get list]",
+		"deployments.apps  []  [dex]  [get]",
+		"[/healthz /api]  []  [get]",
+	}
+	if !reflect.DeepEqual(rows, want) {
+		t.Errorf("rows =\n%s\nwant\n%s", strings.Join(rows, "\n"), strings.Join(want, "\n"))
+	}
+}
+
+// TestWhoAmI: `auth whoami` is a SelfSubjectReview; the username and groups
+// are the apiserver's.
+func TestWhoAmI(t *testing.T) {
+	cs := kubefake.NewClientset()
+	cs.PrependReactor("create", "selfsubjectreviews", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.SelfSubjectReview{Status: authenticationv1.SelfSubjectReviewStatus{
+			UserInfo: authenticationv1.UserInfo{Username: "oidc:admin@lab.local", Groups: []string{"oidc:platform-admins", "system:authenticated"}},
+		}}, nil
+	})
+	stubClientsetFor(t, cs)
+	user, groups, err := whoAmI(context.Background(), &rest.Config{})
+	if err != nil || user != "oidc:admin@lab.local" || !reflect.DeepEqual(groups, []string{"oidc:platform-admins", "system:authenticated"}) {
+		t.Errorf("whoAmI = %q %v %v", user, groups, err)
+	}
+}
+
+// TestTokenConfig: the token-only config carries the lab endpoint and CA
+// from state/kubeconfig, the bearer token, and NO client certificate — the
+// kind kubeconfig's admin cert would win over the token — plus the lab's
+// tuning; asUserConfig keeps the admin's credentials and adds the
+// impersonated user.
+func TestTokenConfig(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(StateDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(labKubeconfigPath, []byte(fakeKindKubeconfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := tokenConfig("tok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Host != fakeKindServer || string(cfg.CAData) != "foo" {
+		t.Errorf("endpoint/CA = %q %q", cfg.Host, cfg.CAData)
+	}
+	if cfg.BearerToken != "tok" {
+		t.Errorf("bearer token = %q", cfg.BearerToken)
+	}
+	tls := cfg.TLSClientConfig
+	if tls.CertData != nil || tls.KeyData != nil || tls.CertFile != "" || tls.KeyFile != "" {
+		t.Errorf("the token config carries a client certificate: %+v", tls)
+	}
+	if cfg.QPS != 50 || cfg.Burst != 100 || !strings.HasPrefix(cfg.UserAgent, "agentlab/") {
+		t.Errorf("tuning missing: QPS %v burst %v agent %q", cfg.QPS, cfg.Burst, cfg.UserAgent)
+	}
+
+	f := newFakeLab(t)
+	as, err := asUserConfig("system:serviceaccount:agent-platform:agent-manager")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if as.Impersonate.UserName != "system:serviceaccount:agent-platform:agent-manager" {
+		t.Errorf("impersonation = %+v", as.Impersonate)
+	}
+	if string(as.CertData) != "admin" || f.cfg.Impersonate.UserName != "" {
+		t.Errorf("asUserConfig must copy the admin config, not alter it: %+v / %+v", as.TLSClientConfig, f.cfg.Impersonate)
+	}
+
+	_ = os.Remove(labKubeconfigPath)
+	if _, err := tokenConfig("tok"); err == nil || !strings.Contains(err.Error(), labKubeconfigPath) {
+		t.Errorf("a lab that is not up must fail on the kubeconfig by name, got %v", err)
+	}
+}
+
+// TestRawGet: a non-resource path through the REST client; a failure names
+// the path.
+func TestRawGet(t *testing.T) {
+	f := newFakeLab(t)
+	out, err := rawGet(context.Background(), "/readyz")
+	if err != nil || string(out) != "ok" || f.readyz != 1 {
+		t.Errorf("rawGet(/readyz) = %q, %v (asked %d times)", out, err, f.readyz)
+	}
+	if _, err := rawGet(context.Background(), "/nope"); err == nil || !strings.Contains(err.Error(), "GET /nope") {
+		t.Errorf("a 404 must fail naming the path, got %v", err)
+	}
+}
+
+// TestLogContainers: the container asked for (refused when absent),
+// kubectl's default-container annotation, else every container.
+func TestLogContainers(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "muster-0"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: componentMuster}, {Name: dexLocalhostContainer}}},
+	}
+	if got, err := logContainers(pod, dexLocalhostContainer); err != nil || !reflect.DeepEqual(got, []string{dexLocalhostContainer}) {
+		t.Errorf("named container = %v, %v", got, err)
+	}
+	if _, err := logContainers(pod, "nope"); err == nil || !strings.Contains(err.Error(), componentMuster+", "+dexLocalhostContainer) {
+		t.Errorf("an absent container must be refused naming the pod's, got %v", err)
+	}
+	if got, err := logContainers(pod, ""); err != nil || !reflect.DeepEqual(got, []string{componentMuster, dexLocalhostContainer}) {
+		t.Errorf("no choice, no annotation = %v, %v; want every container", got, err)
+	}
+	pod.Annotations = map[string]string{defaultContainerAnnotation: componentMuster}
+	if got, err := logContainers(pod, ""); err != nil || !reflect.DeepEqual(got, []string{componentMuster}) {
+		t.Errorf("default-container annotation = %v, %v", got, err)
+	}
+}
+
+// TestPodLogs: a deploy/<name> target resolves through the Deployment's
+// selector to its pods, several streams are prefixed, a single one is not,
+// and a target matching nothing says so.
+func TestPodLogs(t *testing.T) {
+	f := newFakeLab(t)
+	ctx := context.Background()
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: componentMuster, Namespace: testNS},
+		Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{appLabel: componentMuster}}},
+	}
+	pod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS, Labels: map[string]string{appLabel: componentMuster}},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: componentMuster}}},
+		}
+	}
+	for _, obj := range []runtime.Object{deploy, pod("muster-b"), pod("muster-a")} {
+		if err := f.cs.Tracker().Add(obj); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out, err := podLogs(ctx, testNS, "deploy/muster", "", 5*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "[muster-a/muster] " + fakeLogLine + "\n[muster-b/muster] " + fakeLogLine + "\n"; out != want {
+		t.Errorf("deploy logs = %q, want %q", out, want)
+	}
+	out, err = podLogs(ctx, testNS, "pod/muster-a", componentMuster, 0)
+	if err != nil || out != fakeLogLine+"\n" {
+		t.Errorf("single pod logs = %q, %v", out, err)
+	}
+	if _, err := podLogs(ctx, testNS, appLabel+"=nothing", "", 0); err == nil || !strings.Contains(err.Error(), "no pods in demo match app=nothing") {
+		t.Errorf("an empty selector must fail by selector, got %v", err)
+	}
+	var b strings.Builder
+	if err := streamLogs(ctx, testNS, appLabel+"="+componentMuster, &b); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(b.String()), "\n")
+	if len(lines) != 2 || !strings.HasSuffix(lines[0], fakeLogLine) {
+		t.Errorf("streamed = %q", b.String())
+	}
+}
+
+// TestRunProbePod: the pod is created with restartPolicy Never, waited for
+// until it finishes, its log returned, and it is deleted afterwards; a
+// failed pod returns its log with the failure.
+func TestRunProbePod(t *testing.T) {
+	f := newFakeLab(t)
+	phase := corev1.PodSucceeded
+	f.cs.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		pod, ok := action.(clienttesting.CreateAction).GetObject().(*corev1.Pod)
+		if !ok {
+			return true, nil, errors.New("not a pod")
+		}
+		if pod.Spec.RestartPolicy != corev1.RestartPolicyNever || len(pod.Spec.Containers) != 1 || pod.Spec.Containers[0].Image != "busybox" {
+			return true, nil, fmt.Errorf("unexpected probe pod spec: %+v", pod.Spec)
+		}
+		pod.Status.Phase = phase
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}}}}
+		return false, nil, nil
+	})
+	ctx := context.Background()
+	out, err := runProbePod(ctx, testNS, "probe", "busybox", []string{"wget", "-qO-", "http://host/"}, time.Second)
+	if err != nil || out != fakeLogLine {
+		t.Errorf("succeeded probe = %q, %v", out, err)
+	}
+	if _, err := f.cs.CoreV1().Pods(testNS).Get(ctx, "probe", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("the probe pod was not deleted afterwards: %v", err)
+	}
+	phase = corev1.PodFailed
+	out, err = runProbePod(ctx, testNS, "probe", "busybox", []string{"false"}, time.Second)
+	if err == nil || out != fakeLogLine || !strings.Contains(err.Error(), "failed (Failed: exit code 1)") {
+		t.Errorf("failed probe = %q, %v", out, err)
+	}
+}

--- a/internal/lab/kubeconfig.go
+++ b/internal/lab/kubeconfig.go
@@ -22,7 +22,8 @@ const (
 	// kind-<cluster> context), written by the embedded kind at cluster
 	// creation and by useClusterKubeconfig on every cluster-facing command,
 	// set as KUBECONFIG on every kubectl the lab runs (exec.go) and bound to
-	// the embedded Helm (restclient.go). The one kubeconfig the lab writes —
+	// the embedded Helm and Kubernetes client (restclient.go, kube.go). The
+	// one kubeconfig the lab writes —
 	// the user's own is never read or merged into. Under StateDir like every
 	// other generated artifact; `KUBECONFIG=state/kubeconfig kubectl ...` (or
 	// `helm ...`) is the same view from a shell.
@@ -64,8 +65,9 @@ func kindKubeconfig(clusterName string) ([]byte, error) {
 
 // useClusterKubeconfig exports the kind cluster's kubeconfig to
 // labKubeconfigPath. Every command that talks to the cluster calls it first:
-// from then on its kubectl and its embedded Helm are deterministic about the
-// cluster (the one agentlab.yaml names), and a lab that is not running fails right here
+// from then on its kubectl, its embedded Helm and its Kubernetes client are
+// deterministic about the cluster (the one agentlab.yaml names), and a lab
+// that is not running fails right here
 // instead of as an opaque kubectl error — or, worse, as a command against
 // whatever cluster the shell's own kubeconfig happens to point at. The user's
 // kubeconfig and current-context are never read or changed.
@@ -77,7 +79,13 @@ func useClusterKubeconfig(cfg *config.Config) error {
 	if err := os.MkdirAll(StateDir, 0o750); err != nil {
 		return err
 	}
-	return os.WriteFile(labKubeconfigPath, raw, 0o600)
+	if err := os.WriteFile(labKubeconfigPath, raw, 0o600); err != nil {
+		return err
+	}
+	// The embedded client (kube.go) is built from this file: a bundle built
+	// before the rewrite must not outlive it.
+	resetLabKube()
+	return nil
 }
 
 // kindClusterEntry is the cluster entry (name and server/CA) of the kind

--- a/internal/lab/kubeconfig_test.go
+++ b/internal/lab/kubeconfig_test.go
@@ -59,7 +59,8 @@ func resetKindKubeconfigCache(t *testing.T) {
 // TestUseClusterKubeconfig drives the export against a stand-in for kind's
 // kubeconfig read: the lab-owned kubeconfig lands under state/ owner-only and
 // byte-identical to what kind emitted, the very file the command constructor
-// pins kubectl to; one read serves both it and the cluster entry the token
+// pins kubectl to and the embedded client is built from (a bundle built
+// before the export is dropped); one read serves both it and the cluster entry the token
 // kubeconfigs are built from; and a cluster kind does not know fails by name
 // with kind's message instead of leaving kubectl to the shell's kubeconfig.
 func TestUseClusterKubeconfig(t *testing.T) {
@@ -68,8 +69,13 @@ func TestUseClusterKubeconfig(t *testing.T) {
 	resetKindKubeconfigCache(t)
 
 	cfg := config.Default()
+	labKubeCache = &kubeClients{} // a bundle built before the export
+	t.Cleanup(resetLabKube)
 	if err := useClusterKubeconfig(cfg); err != nil {
 		t.Fatal(err)
+	}
+	if labKubeCache != nil {
+		t.Error("the export must drop the client bundle built from the previous kubeconfig")
 	}
 	info, err := os.Stat(labKubeconfigPath)
 	if err != nil {
@@ -93,7 +99,7 @@ func TestUseClusterKubeconfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if name != "kind-agentlab" || cluster["server"] != "https://127.0.0.1:34547" {
+	if name != "kind-agentlab" || cluster["server"] != fakeKindServer {
 		t.Errorf("cluster entry = %q %v", name, cluster)
 	}
 	if *calls != 1 {

--- a/internal/lab/node.go
+++ b/internal/lab/node.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -193,12 +194,14 @@ func ensureNodeRunning(cfg *config.Config) error {
 		return fmt.Errorf("node container %s is %s and could not be started: %w;\nrun `agentlab up` again once `docker ps -a` shows it settled, or `agentlab down` to start over", node, state, err)
 	}
 	// Only a running node has a kubeconfig to export (kind reads it off the
-	// node); from here on the lab's kubectl is pinned to it.
+	// node); from here on the lab's clients are bound to it.
 	if err := useClusterKubeconfig(cfg); err != nil {
 		return err
 	}
 	if !waitFor(60, 2*time.Second, func() bool {
-		_, err := outputQuiet("kubectl", "get", "--raw=/readyz")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := rawGet(ctx, "/readyz")
 		return err == nil
 	}) {
 		return fmt.Errorf("node container %s started but its apiserver never answered /readyz; check `docker logs %s` and `docker exec %s crictl ps`, or `agentlab down` to start over", node, node, node)

--- a/internal/lab/node_test.go
+++ b/internal/lab/node_test.go
@@ -13,8 +13,8 @@ import (
 
 // installFakeTool puts a stand-in for a command on PATH: a shell script that
 // appends every invocation ("<name> <args>") to the returned log file and
-// then runs body with the arguments in $@. The same device as installFakeKind,
-// for the docker and kubectl the node recovery shells out to.
+// then runs body with the arguments in $@, for the docker the node recovery
+// shells out to.
 func installFakeTool(t *testing.T, dir, name, body string) string {
 	t.Helper()
 	bin := filepath.Join(dir, "bin")
@@ -144,17 +144,18 @@ esac`)
 }
 
 // TestEnsureNodeRunning drives Up's node check against stand-ins for docker,
-// kind's kubeconfig read and kubectl: a running node is left completely alone
-// (no start, no kubeconfig export); an exited node is started, the kubeconfig
-// exported and the apiserver probed before Up goes on; a paused node is
-// unpaused; and a node docker cannot start fails by node, state and fix
-// instead of as the opaque kubeconfig-read error it used to be.
+// kind's kubeconfig read and the apiserver: a running node is left completely
+// alone (no start, no kubeconfig export, no probe); an exited node is
+// started, the kubeconfig exported and the apiserver's /readyz probed through
+// the embedded client before Up goes on; a paused node is unpaused; and a
+// node docker cannot start fails by node, state and fix instead of as the
+// opaque kubeconfig-read error it used to be.
 func TestEnsureNodeRunning(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 	stubKindKubeconfig(t)
 	resetKindKubeconfigCache(t)
-	kubectlCalls := installFakeTool(t, dir, "kubectl", "exit 0")
+	lab := newFakeLab(t)
 	dockerCalls := installFakeTool(t, dir, "docker", `
 case "$1" in
 inspect) echo "$FAKE_NODE_STATE" ;;
@@ -177,6 +178,9 @@ esac`)
 	if _, err := os.Stat(labKubeconfigPath); !os.IsNotExist(err) {
 		t.Errorf("running node: kubeconfig export happened (%v); Up does that itself", err)
 	}
+	if lab.readyz != 0 {
+		t.Errorf("running node: the apiserver was probed %d times, want none", lab.readyz)
+	}
 
 	_ = os.Remove(dockerCalls)
 	t.Setenv("FAKE_NODE_STATE", stateExited)
@@ -189,8 +193,8 @@ esac`)
 	if raw, err := os.ReadFile(labKubeconfigPath); err != nil || string(raw) != fakeKindKubeconfig {
 		t.Errorf("exited node: kubeconfig not exported after the start (err %v)", err)
 	}
-	if log := readCalls(t, kubectlCalls); log != "kubectl get --raw=/readyz\n" {
-		t.Errorf("exited node: kubectl calls = %q, want one /readyz probe", log)
+	if lab.readyz != 1 {
+		t.Errorf("exited node: /readyz probed %d times, want once", lab.readyz)
 	}
 
 	_ = os.Remove(dockerCalls)

--- a/internal/lab/restclient.go
+++ b/internal/lab/restclient.go
@@ -26,10 +26,16 @@ func labRESTClientGetter(namespace string) genericclioptions.RESTClientGetter {
 		ns := namespace
 		flags.Namespace = &ns
 	}
-	return flags.WithWrapConfigFn(func(c *rest.Config) *rest.Config {
-		c.QPS = 50
-		c.Burst = 100
-		c.UserAgent = "agentlab/" + project.Version()
-		return c
-	})
+	return flags.WithWrapConfigFn(tuneRESTConfig)
+}
+
+// tuneRESTConfig is the lab's tuning of a REST config, whoever it
+// authenticates as: the rate limit a boot needs (client-go's default of five
+// requests a second throttles an install of the platform's size) and the
+// user agent that identifies the lab in the apiserver's audit log.
+func tuneRESTConfig(c *rest.Config) *rest.Config {
+	c.QPS = 50
+	c.Burst = 100
+	c.UserAgent = "agentlab/" + project.Version()
+	return c
 }

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -1,8 +1,8 @@
 package lab
 
 import (
+	"context"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 	"time"
@@ -38,7 +38,7 @@ func Up(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	_, rbacPath, err := renderManifest(cfg, "rbac.yaml.tmpl")
+	rbac, _, err := renderManifest(cfg, "rbac.yaml.tmpl")
 	if err != nil {
 		return err
 	}
@@ -57,11 +57,12 @@ func Up(cfg *config.Config) error {
 			return err
 		}
 	}
-	// From here on the lab's own kubectl and its embedded Helm run against the
-	// cluster's exported kubeconfig (exec.go, restclient.go). The user's own
-	// kubeconfig and current-context are never touched: the embedded kind
-	// writes the admin kubeconfig to state/kubeconfig (kind.go), and re-reading
-	// it off the node here covers a cluster that already existed too.
+	// From here on the lab's own kubectl, its embedded Helm and its Kubernetes
+	// client run against the cluster's exported kubeconfig (exec.go,
+	// restclient.go, kube.go). The user's own kubeconfig and current-context
+	// are never touched: the embedded kind writes the admin kubeconfig to
+	// state/kubeconfig (kind.go), and re-reading it off the node here covers a
+	// cluster that already existed too.
 	if err := useClusterKubeconfig(cfg); err != nil {
 		return err
 	}
@@ -88,7 +89,7 @@ func Up(cfg *config.Config) error {
 	}
 
 	step("Applying RBAC bound to OIDC groups")
-	if err := runQuiet("kubectl", "apply", "-f", rbacPath); err != nil {
+	if _, err := applyManifests(context.Background(), rbac); err != nil {
 		return err
 	}
 
@@ -116,19 +117,25 @@ func Up(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	const probeKubeconfig = ".kubeconfig.probe"
-	if err := writeTokenKubeconfig(cfg, tok, probeKubeconfig); err != nil {
+	// A config that carries ONLY the token: the admin client certificate of
+	// the kind kubeconfig would win over it (kube.go, tokenConfig).
+	probe, err := tokenConfig(tok)
+	if err != nil {
 		return err
 	}
+	var username string
+	var groups []string
 	verified := waitFor(30, 2*time.Second, func() bool {
-		_, err := outputQuiet("kubectl", "--kubeconfig="+probeKubeconfig, "auth", "whoami")
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		var err error
+		username, groups, err = whoAmI(ctx, probe)
 		return err == nil
 	})
-	_ = os.Remove(probeKubeconfig)
 	if !verified {
 		return fmt.Errorf("apiserver still rejects Dex tokens; check the apiserver log for oidc.go lines")
 	}
-	note("apiserver accepts Dex tokens")
+	note("apiserver accepts Dex tokens: %s is %s in %s", admin.Email, username, strings.Join(groups, ", "))
 
 	reportPreload(loaded)
 	if cfg.Platform.Enabled {
@@ -209,11 +216,11 @@ func ApplyDex(cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	if err := pipeInto(stamped, "kubectl", "apply", "-f", "-"); err != nil {
+	if _, err := applyManifests(context.Background(), stamped); err != nil {
 		return err
 	}
 	step("Waiting for Dex to become ready")
-	return run("kubectl", "-n", componentDex, "rollout", "status", "deployment/dex", "--timeout=120s")
+	return waitDeploymentRolledOut(context.Background(), componentDex, componentDex, 120*time.Second)
 }
 
 // kindClusterExists reports whether kind knows a cluster by that name — its


### PR DESCRIPTION
Step 3a of #101 (kubectl → client-go): the shared client layer and its first consumers.

## What

`internal/lab/kube.go` is the vocabulary the package speaks to the lab apiserver through client-go, bound to `state/kubeconfig` through `labRESTClientGetter` (the shell's `KUBECONFIG` plays no part; a lab that is not up fails on the missing file, by name). One cached bundle (`labKube()`: REST config, dynamic client, typed clientset, a discovery-backed RESTMapper cached in memory with kubectl's short names, a REST client for `/readyz`), dropped by `useClusterKubeconfig` whenever it rewrites the kubeconfig.

The helpers, all `ctx` first, every wait bounded:

- `applyManifests(ctx, []byte)` — `kubectl apply -f`: multi-document split (empty documents skipped, a List expanded), kind → resource/scope through the mapper, **server-side apply** under the field manager `agentlab` with `Force: true` (an object an earlier lab applied through kubectl carries the `kubectl-client-side-apply` manager; without Force the first re-apply would be refused as a conflict). `applyResult.changed` is what kubectl printed as created/configured/unchanged: created, or the resourceVersion moved. A CRD in the batch is applied first and the apiserver given up to 60 s to serve its kinds (mapper reset) before what follows.
- `getObject`, `listObjects`, `objectExists`, `conditionStatus`/`conditionMessage`, `gvrFor("helmreleases.helm.toolkit.fluxcd.io")` (kubectl's resource argument, group and preferred version from discovery), `deleteObject(…, waitGone)` (NotFound is success; waits like the CLI's default when asked), `patchObject`.
- `restartDeployment`, `waitDeploymentRolledOut` (kubectl's rollout-status condition, progress lines as they change), `waitCondition`.
- `tokenConfig(token)` (endpoint + CA from state/kubeconfig, bearer token only — no client cert, which would win over it), `asUserConfig(user)` (`--as`), `canI` (SelfSubjectAccessReview; the resource's group resolved as kubectl does), `canIList` + `ruleRows` (SelfSubjectRulesReview in kubectl's row shape), `whoAmI` (SelfSubjectReview).
- `podLogs`, `streamLogs` (`deploy/<name>`, `pod/<name>` or a label selector; several streams prefixed), `runProbePod` (create → Succeeded/Failed → log → delete), `rawGet`.

First consumers, so `up` proves the layer live:

- exec.go's `ensureNamespace`, `ensureSecretFromFiles`, `ensureTLSSecret`, `secretHasKey` build typed `corev1` objects and server-side apply them (the `create --dry-run | apply` trick is gone); they moved to kube.go, exec.go keeps `command()`/`kubectlBin` for the call sites not converted yet.
- node.go's `/readyz` probe is `rawGet`.
- up.go: the RBAC manifest and the stamped Dex manifest go through `applyManifests` (checksum stamping untouched), the Dex rollout through `waitDeploymentRolledOut`, the OIDC probe through `whoAmI` on a token-only `rest.Config` — the `.kubeconfig.probe` file is no longer written (`login` keeps writing `kubeconfig.oidc` for humans). The boot now prints who the admin token maps to.

`k8s.io/api` and `k8s.io/apimachinery` are direct requires (same v0.36.1 the Helm SDK pinned; no bump, no new module).

## Tests

Unit tests on client-go's fakes (`dynamic/fake`, `kubernetes/fake`, `rest/fake`, a `meta.DefaultRESTMapper` from a fixed list — the fake discovery serves none), no envtest: the apply verdict (created / changed / unchanged, forced under the lab's field manager — a stand-in reactor does the resourceVersion bookkeeping the fake tracker does not), the multi-document split incl. empty and comment-only documents and a List, CRD-then-CR ordering with the mapper reset, the typed ensure helpers, reads and lists, delete-wait (NotFound, gone, held by a finalizer), kubectl's rollout condition case by case and the bounded wait, restart, conditions, `gvrFor`, the can-i mapping (verb / group / resource / namespace, `deployments` → `apps`), `ruleRows`, whoami, the token config (no client cert, tuning), `/readyz`, log container choice, pod logs and streams, the probe pod. `TestEnsureNodeRunning` probes `/readyz` through the fake REST client; `TestUseClusterKubeconfig` checks the bundle is dropped on export.

## Measured

- Stripped linux/amd64 (`CGO_ENABLED=0 go build -trimpath -ldflags '-s -w'`): main (d4548aa) 77,869,216 B → 77,910,176 B (+41 KB).
- Modules (`go list -m all | wc -l`): 559 → 559.
- Cold `go build .` (`go clean -cache` first, back to back): main 26.2 s → branch 26.5 s (24 CPUs, the lab running).

## Verified

Isolated lab `agentlab-kube` (dex 32003, gateway 8445, muster 8096, agents 8084, backstage 7010), `$L/bin` = symlinks to `docker` and `kubectl` only (`env -i PATH=$L/bin sh -c 'command -v kind helm kubectl docker'` lists kubectl and docker), binary built from this branch:

| command | duration | result |
|---|---|---|
| `configure --defaults` | — | tools line `docker 29.7.2, kind v0.32.0 (embedded, kindest/node:v1.36.1), kubectl v1.36.4` |
| `up` (fresh cluster) | 5:09 | Dex namespace + `dex-tls` and the stamped Dex manifest server-side applied (`managedFields`: `agentlab:Apply`), rollout waited, RBAC applied, `apiserver accepts Dex tokens: admin@lab.local is oidc:admin@lab.local in oidc:platform-admins, oidc:developers, system:authenticated`; `Lab is up.` |
| `test` | 2 s | 10/10 |
| `platform-test` | 1 s | 6 PASS |
| `agents-test` | 12 s | 4 PASS |
| `toolsets-test` | 51 s | 11 PASS |
| `backstage-test` | 3 s | all sign-ins resolved and reached muster |
| `up` again (idempotent re-apply over the lab's own field manager) | 29 s | `deployment "dex" successfully rolled out` at once; `deploy/dex` generation 1 → 1 and resourceVersion 575 → 575 (the apiserver skipped the write), one ReplicaSet, the same pod |
| `down` (3 s), then `up` with **main's binary** (v0.25.x, kubectl client-side apply; 5:04), then `up` with **this binary** over that lab | 5 s | the SSA-over-CSA path this PR introduces: `deploy/dex` managers `kubectl-client-side-apply:Update` → `agentlab:Apply,kubectl-client-side-apply:Update`, **generation 1 → 1** (no roll), `deployment "dex" successfully rolled out`, RBAC applied, `apiserver accepts Dex tokens`. The run then stopped in the embedded Helm's kube-prometheus-stack upgrade — SSA conflicts `conflict with "agentlab-main"`: Helm 4's SDK derives its field manager from the binary's name (`filepath.Base(os.Args[0])`; the CLI pins `helm`), so a release installed under another name (or by the Helm CLI, v0.24.0 labs) cannot be upgraded. Pre-existing in helm.go, unrelated to this PR's paths; fixed in a follow-up PR (`fix(helm)`: the manager pinned to `helm`, conflicts forced). |
| `down` | 4 s | cluster deleted (`kind get clusters` lists only the shared lab) |

## Docs

`docs/development.md`: the kube.go layout line, the embedded-client paragraph. README and getting-started unchanged: kubectl remains a requirement until the last call sites are converted.
