### PR TITLE
fix(helm): pin the embedded Helm's field manager to helm and force conflicts on upgrade — labs from earlier releases or other binary names upgrade again

### DIFF
--- a/internal/lab/helm.go
+++ b/internal/lab/helm.go
@@ -59,6 +59,17 @@ import (
 // environment so the release is always where the CLI looks by default.
 const helmDriver = "secret"
 
+// helmFieldManager is the field manager Helm records on every object it
+// applies server-side — the CLI's "helm". The SDK's own default is the name
+// of the running binary (filepath.Base of os.Args[0]), and server-side apply
+// refuses to change a field another manager owns while a chart's zero-valued
+// fields (hostNetwork: false, initialDelaySeconds: 0) count as changed on
+// every re-apply: a release installed by a binary of another name
+// (agentlab-linux-amd64 as downloaded), or by the Helm CLI, could not be
+// upgraded — "Apply failed with N conflicts". One name for the lab and for a
+// `helm upgrade` from a shell keeps the release upgradable by both.
+const helmFieldManager = "helm"
+
 // helmDebugEnv streams the SDK's log to stderr as it happens (the CLI's
 // --debug); without it the log is kept and printed only when an operation
 // fails. The CLI's own variable, so one habit covers both.
@@ -161,6 +172,7 @@ func newHelmOp(namespace string) (*helmOp, error) {
 	log := newHelmLog()
 	quietKlog(log.live)
 	settings := helmSettings()
+	kube.ManagedFieldsManager = helmFieldManager
 	cfg := action.NewConfiguration(action.ConfigurationSetLogger(log.handler()))
 	if err := cfg.Init(labRESTClientGetter(namespace), namespace, helmDriver); err != nil {
 		return nil, fmt.Errorf("initialising the embedded Helm: %w", err)
@@ -248,7 +260,8 @@ func helmChartLabel(ref, version string) string {
 }
 
 // helmUpgradeInstall is `helm upgrade --install <release> <chart> -n <ns> -f
-// <values> --wait --timeout <timeout>` (plus --create-namespace when asked):
+// <values> --wait --timeout <timeout> --force-conflicts` (plus
+// --create-namespace when asked):
 // the release is installed when it does not exist or was uninstalled,
 // upgraded otherwise, with the CLI's defaults — server-side apply on install
 // and, on upgrade, the method the release was applied with; no
@@ -286,6 +299,7 @@ func helmUpgradeInstall(namespace, releaseName, ref, version string, vals map[st
 		install.CreateNamespace = createNamespace
 		install.Timeout = timeout
 		install.WaitStrategy = kube.StatusWatcherStrategy
+		install.ForceConflicts = true
 		// The last revision is an uninstalled one kept in history: the name
 		// is reused, as the CLI does.
 		install.Replace = uninstalled
@@ -304,6 +318,11 @@ func helmUpgradeInstall(namespace, releaseName, ref, version string, vals map[st
 	upgrade.Namespace = namespace
 	upgrade.Timeout = timeout
 	upgrade.WaitStrategy = kube.StatusWatcherStrategy
+	// The CLI's --force-conflicts: fields another manager owns are taken over
+	// rather than refused — the release of a lab installed before the manager
+	// was pinned (owned by the binary's name then) upgrades instead of
+	// failing on every zero-valued field of the chart.
+	upgrade.ForceConflicts = true
 	upgrade.MaxHistory = h.settings.MaxHistory
 	ch, err := h.loadChart(&upgrade.ChartPathOptions, ref, version)
 	if err != nil {


### PR DESCRIPTION
## Problem

The embedded Helm (`internal/lab/helm.go`, since #106) records its server-side applies under Helm 4's SDK default field manager: the name of the running binary (`filepath.Base(os.Args[0])`). The Helm CLI pins `kube.ManagedFieldsManager = "helm"`; the SDK left alone does not. Consequences, all hit on `agentlab up`/`platform` of an existing lab:

- a lab whose platform was installed by the Helm CLI (any release before v0.25.0) is owned by `helm`; the embedded Helm applies as `agentlab` → `UPGRADE FAILED: conflict occurred while applying object … Apply failed with N conflicts: conflicts with "helm"`;
- a lab installed by the binary under another name — `agentlab-linux-amd64` as downloaded, `./agentlab-v0.25.0`, a CI's path — cannot be upgraded by `agentlab`, and vice versa;
- a `helm upgrade` from a shell against a lab the binary installed conflicts the same way.

The conflicts are on identical manifests: server-side apply refuses to change a field another manager owns, and a chart's zero-valued fields (`hostNetwork: false`, `initialDelaySeconds: 0`, empty `httpHeaders`) count as changed on every re-apply, so a second manager can never apply the same chart.

Found while verifying #110 across binaries: a lab brought up by `agentlab-main` (main's binary) failed `up` with the branch binary in the kube-prometheus-stack upgrade with `conflict with "agentlab-main"` on 20 fields of 8 objects.

## Fix

- `kube.ManagedFieldsManager = "helm"` before every action configuration: the lab and a `helm` on a shell are one manager, as the CLI has it.
- `install.ForceConflicts = true` / `upgrade.ForceConflicts = true` (the CLI's `--force-conflicts`): fields another manager owns are taken over rather than refused — the transition for releases v0.25.0/v0.25.1 installed under the binary's name, and for anything else that touched a field.

## Verified

Isolated lab `agentlab-kube`, `$L/bin` = `docker` + `kubectl` symlinks:

| step | duration | result |
|---|---|---|
| `up` with **main's binary** (`agentlab-main`, i.e. the released code) | 6:00 | `deploy/kps-kube-prometheus-stack-operator` managers `agentlab-main:Apply`; `deploy/dex` `kubectl-client-side-apply:Update`, generation 1 |
| `up` with **this branch's binary** (`agentlab-fix`) over that lab | 33 s | `Lab is up.` — the kube-prometheus-stack and platform upgrades went through (before the fix this step failed with `Apply failed with N conflicts: conflicts with "agentlab-main"`); kps managers `agentlab-main:Apply,helm:Apply`; Dex `agentlab:Apply,kubectl-client-side-apply:Update`, generation 1 → 1 |
| `platform-test` | 2 s | 6 PASS |
| Helm CLI (v4.2.2 on the host, `KUBECONFIG=state/kubeconfig`) | — | `helm -n monitoring status kps` → deployed, revision 2; `helm -n agent-platform status agent-platform` → deployed, revision 2 |
| `down` | 5 s | cluster deleted; `kind get clusters` lists only the shared lab |

Unit tests and `pre-commit run --all-files` pass; the change is two knobs of the SDK, so the lab run above is the verification.
