### PR TITLE
refactor(kube): the proofs and fixtures reach the apiserver through client-go, not kubectl

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,7 +32,7 @@ in `agentlab.yaml` and `agentlab up`).
 |---|---|
 | `login [email]` | Headless login (password grant); writes `.token` and `kubeconfig.oidc` for that user. `--password` overrides the one in `agentlab.yaml`. |
 | `browser` | Log in through the real Dex login page in a browser (authorization-code flow). |
-| `test` | Assert RBAC for every configured user: a token from Dex, then `kubectl auth can-i` against the expectations of each group. |
+| `test` | Assert RBAC for every configured user: a token from Dex, then `auth can-i` reviews with that token alone (SelfSubjectAccessReviews) against the expectations of each group. |
 
 `kubectl --kubeconfig kubeconfig.oidc` after `login` is the OIDC path — the
 way to verify what a specific user can do. The kind admin context bypasses the

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -158,15 +159,16 @@ func AgentsTest(cfg *config.Config, email string) error {
 	note("HelmRelease written (OCIRepository created: %v), requestedBy=%s", created.Created.OCIRepository, created.RequestedBy)
 
 	step("The HelmRelease belongs to the user, not the ServiceAccount (managedFields)")
-	managers, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", agentsTestAgent,
-		"-o", "jsonpath={range .metadata.managedFields[*]}{.manager}{'\\n'}{end}")
+	managers, err := agentHelmReleaseManagers(agentsTestAgent)
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(managers, "agent-manager") {
+	if !slices.Contains(managers, "agent-manager") {
 		return fmt.Errorf("HelmRelease %s has no agent-manager field manager: %q", agentsTestAgent, managers)
 	}
-	events, _ := outputQuiet("kubectl", "-n", platformNamespace, "logs", "deploy/"+agentManagerMCPServer, "-c", agentManagerMCPServer, "--since=5m")
+	logCtx, cancelLogs := context.WithTimeout(context.Background(), 60*time.Second)
+	events, _ := podLogs(logCtx, platformNamespace, "deploy/"+agentManagerMCPServer, agentManagerMCPServer, 5*time.Minute)
+	cancelLogs()
 	if !strings.Contains(events, "caller="+user.Email) {
 		return fmt.Errorf("agent-manager's log carries no `caller=%s` line for the create", user.Email)
 	}
@@ -241,29 +243,17 @@ func AgentsTest(cfg *config.Config, email string) error {
 			return fmt.Errorf("%s: Forbidden, but not under the user's own name (the apiserver saw someone else): %w", viewer.Email, err)
 		}
 		note("%s: %s", viewer.Email, excerpt(err.Error(), 200))
-		if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", agentsTestAgent+"-viewer"); err == nil {
+		if agentHelmReleaseExists(agentsTestAgent + "-viewer") {
 			return fmt.Errorf("HelmRelease %s-viewer exists although the create was refused", agentsTestAgent)
 		}
 	}
 
-	step("The agent-manager ServiceAccount holds no RBAC (kubectl auth can-i --list --as=%s)", agentManagerServiceAccount)
-	rules, err := outputQuiet("kubectl", "auth", "can-i", "--list", "--as="+agentManagerServiceAccount, "-n", kagentNamespace)
+	step("The agent-manager ServiceAccount holds no RBAC (auth can-i --list --as=%s)", agentManagerServiceAccount)
+	rules, err := serviceAccountRules(agentManagerServiceAccount, kagentNamespace)
 	if err != nil {
 		return err
 	}
-	var granted []string
-	for line := range strings.SplitSeq(rules, "\n") {
-		fields := strings.Fields(line)
-		if len(fields) == 0 || fields[0] == "Resources" {
-			continue
-		}
-		// Every authenticated principal has the selfsubject* reviews and the
-		// discovery URLs; anything else is a permission of its own.
-		if strings.HasPrefix(fields[0], "selfsubject") || strings.HasPrefix(fields[0], "[") {
-			continue
-		}
-		granted = append(granted, line)
-	}
+	granted := rulesBeyondDiscovery(rules)
 	if len(granted) > 0 {
 		return fmt.Errorf("the agent-manager ServiceAccount still holds permissions in %s:\n%s", kagentNamespace, strings.Join(granted, "\n"))
 	}
@@ -295,6 +285,61 @@ func AgentsTest(cfg *config.Config, email string) error {
 	}
 	fmt.Printf("PASS: %s holds no permissions beyond discovery\n", agentManagerServiceAccount)
 	return nil
+}
+
+// serviceAccountRules is `kubectl auth can-i --list --as=<principal> -n <ns>`:
+// the rules the apiserver grants the impersonated principal in the namespace,
+// one row per resource the way the CLI prints them.
+func serviceAccountRules(principal, ns string) ([]string, error) {
+	as, err := asUserConfig(principal)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	status, err := canIList(ctx, as, ns)
+	if err != nil {
+		return nil, err
+	}
+	return ruleRows(status), nil
+}
+
+// rulesBeyondDiscovery drops the rows every authenticated principal has — the
+// selfsubject* reviews and the non-resource discovery URLs — and returns the
+// rest: permissions of the principal's own.
+func rulesBeyondDiscovery(rows []string) []string {
+	var granted []string
+	for _, row := range rows {
+		fields := strings.Fields(row)
+		if len(fields) == 0 || fields[0] == "Resources" {
+			continue
+		}
+		if strings.HasPrefix(fields[0], "selfsubject") || strings.HasPrefix(fields[0], "[") {
+			continue
+		}
+		granted = append(granted, row)
+	}
+	return granted
+}
+
+// agentHelmReleaseManagers lists the field managers on an agent's HelmRelease
+// in the kagent namespace — who wrote it.
+func agentHelmReleaseManagers(name string) ([]string, error) {
+	gvr, err := gvrFor(fluxHelmReleaseResource)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	hr, err := getObject(ctx, gvr, kagentNamespace, name)
+	if err != nil {
+		return nil, err
+	}
+	var managers []string
+	for _, entry := range hr.GetManagedFields() {
+		managers = append(managers, entry.Manager)
+	}
+	return managers, nil
 }
 
 func kept(reason string) string {

--- a/internal/lab/agentstest_test.go
+++ b/internal/lab/agentstest_test.go
@@ -1,0 +1,90 @@
+package lab
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// TestRulesBeyondDiscovery: of what `can-i --list` grants, the selfsubject*
+// reviews and the non-resource URLs are everyone's; any other row is a
+// permission of the principal's own. The CLI's header row, were it there,
+// is skipped too.
+func TestRulesBeyondDiscovery(t *testing.T) {
+	rows := ruleRows(&authorizationv1.SubjectRulesReviewStatus{
+		ResourceRules: []authorizationv1.ResourceRule{
+			{Verbs: []string{verbCreate}, APIGroups: []string{"authorization.k8s.io"}, Resources: []string{"selfsubjectaccessreviews", "selfsubjectrulesreviews"}},
+			{Verbs: []string{verbCreate}, APIGroups: []string{"authentication.k8s.io"}, Resources: []string{"selfsubjectreviews"}},
+		},
+		NonResourceRules: []authorizationv1.NonResourceRule{{Verbs: []string{verbGet}, NonResourceURLs: []string{"/healthz", "/api", "/api/*"}}},
+	})
+	if got := rulesBeyondDiscovery(append([]string{"Resources  Non-Resource URLs  Resource Names  Verbs", ""}, rows...)); len(got) != 0 {
+		t.Errorf("discovery-only rules judged as permissions: %v", got)
+	}
+	extra := ruleRows(&authorizationv1.SubjectRulesReviewStatus{ResourceRules: []authorizationv1.ResourceRule{
+		{Verbs: []string{verbGet, verbList}, APIGroups: []string{fluxHelmReleaseGVK.Group}, Resources: []string{fluxHelmReleaseGVR.Resource}},
+	}})
+	if got := rulesBeyondDiscovery(append(rows, extra...)); !reflect.DeepEqual(got, extra) {
+		t.Errorf("granted = %v, want %v", got, extra)
+	}
+}
+
+// TestServiceAccountRules: the rules review goes out impersonating the
+// ServiceAccount (kubectl's --as) in the asked namespace, on the lab admin's
+// config.
+func TestServiceAccountRules(t *testing.T) {
+	newFakeLab(t)
+	cs := kubefake.NewClientset()
+	var namespaces []string
+	cs.PrependReactor("create", "selfsubjectrulesreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		review, ok := action.(clienttesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectRulesReview)
+		if !ok {
+			return true, nil, errors.New("not a rules review")
+		}
+		namespaces = append(namespaces, review.Spec.Namespace)
+		review.Status.ResourceRules = []authorizationv1.ResourceRule{{Verbs: []string{verbGet}, Resources: []string{gvrPods.Resource}}}
+		return true, review, nil
+	})
+	seen := stubClientsetFor(t, cs)
+	rows, err := serviceAccountRules(agentManagerServiceAccount, kagentNamespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(rows, []string{"pods  []  []  [get]"}) || !reflect.DeepEqual(namespaces, []string{kagentNamespace}) {
+		t.Errorf("rows = %v in %v", rows, namespaces)
+	}
+	if len(*seen) != 1 || (*seen)[0].Impersonate.UserName != agentManagerServiceAccount || (*seen)[0].Host != fakeKindServer {
+		t.Errorf("the review was not asked as the impersonated ServiceAccount on the lab's endpoint: %+v", *seen)
+	}
+}
+
+// TestAgentHelmReleaseManagers: the field managers of the agent's HelmRelease
+// are read off metadata.managedFields — who wrote it; a missing HelmRelease
+// is the apiserver's NotFound.
+func TestAgentHelmReleaseManagers(t *testing.T) {
+	hr := customObject(fluxHelmReleaseGVK, kagentNamespace, agentsTestAgent, nil)
+	_ = unstructured.SetNestedSlice(hr.Object, []any{
+		map[string]any{"manager": agentManagerMCPServer, "operation": "Apply"},
+		map[string]any{"manager": "helm-controller", "operation": "Update", "subresource": fieldStatus},
+	}, "metadata", "managedFields")
+	newFakeLab(t, hr)
+	managers, err := agentHelmReleaseManagers(agentsTestAgent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(managers, []string{agentManagerMCPServer, "helm-controller"}) {
+		t.Errorf("managers = %v", managers)
+	}
+	if _, err := agentHelmReleaseManagers("absent"); err == nil {
+		t.Error("a missing HelmRelease must fail the read")
+	}
+	if !agentHelmReleaseExists(agentsTestAgent) || agentHelmReleaseExists("absent") {
+		t.Error("agentHelmReleaseExists disagrees with the store")
+	}
+}

--- a/internal/lab/crds_test.go
+++ b/internal/lab/crds_test.go
@@ -11,10 +11,11 @@ import (
 // versions are the fakes' — the lab itself resolves every custom kind through
 // discovery (gvrFor) and pins none.
 var (
-	gvkModelConfig  = schema.GroupVersionKind{Group: "kagent.dev", Version: "v1alpha2", Kind: "ModelConfig"}
-	gvrModelConfigs = gvkModelConfig.GroupVersion().WithResource("modelconfigs")
-	gvkAgent        = schema.GroupVersionKind{Group: "kagent.dev", Version: "v1alpha2", Kind: "Agent"}
-	gvrAgents       = gvkAgent.GroupVersion().WithResource("agents")
+	kagentGroupVersion = schema.GroupVersion{Group: "kagent.dev", Version: "v1alpha2"}
+	gvkModelConfig     = kagentGroupVersion.WithKind("ModelConfig")
+	gvrModelConfigs    = kagentGroupVersion.WithResource("modelconfigs")
+	gvkAgent           = kagentGroupVersion.WithKind("Agent")
+	gvrAgents          = kagentGroupVersion.WithResource("agents")
 )
 
 // customObject builds a seed for the dynamic fake: an object of the given

--- a/internal/lab/crds_test.go
+++ b/internal/lab/crds_test.go
@@ -1,0 +1,41 @@
+package lab
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// kagent's ModelConfig and Agent as the fakes serve them (newFakeLab registers
+// them with its mapper and the dynamic fake's list kinds, next to the
+// HelmRelease, MCPServer and Prometheus kinds kube_test.go declares). The
+// versions are the fakes' — the lab itself resolves every custom kind through
+// discovery (gvrFor) and pins none.
+var (
+	gvkModelConfig  = schema.GroupVersionKind{Group: "kagent.dev", Version: "v1alpha2", Kind: "ModelConfig"}
+	gvrModelConfigs = gvkModelConfig.GroupVersion().WithResource("modelconfigs")
+	gvkAgent        = schema.GroupVersionKind{Group: "kagent.dev", Version: "v1alpha2", Kind: "Agent"}
+	gvrAgents       = gvkAgent.GroupVersion().WithResource("agents")
+)
+
+// customObject builds a seed for the dynamic fake: an object of the given
+// kind, namespace and name, carrying the labels.
+func customObject(gvk schema.GroupVersionKind, ns, name string, labels map[string]string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	u.SetNamespace(ns)
+	u.SetName(name)
+	if len(labels) > 0 {
+		u.SetLabels(labels)
+	}
+	return u
+}
+
+// withCondition stamps one status.condition on the object and returns it.
+func withCondition(u *unstructured.Unstructured, condType, condStatus, message string) *unstructured.Unstructured {
+	cond := map[string]any{fieldType: condType, fieldStatus: condStatus}
+	if message != "" {
+		cond["message"] = message
+	}
+	_ = unstructured.SetNestedSlice(u.Object, []any{cond}, fieldStatus, "conditions")
+	return u
+}

--- a/internal/lab/fleetfixture.go
+++ b/internal/lab/fleetfixture.go
@@ -1,11 +1,14 @@
 package lab
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"slices"
 	"sort"
 	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -125,22 +128,26 @@ func ensureFleetFixture(cfg *config.Config) error {
 	names := fleetFixtureNames()
 	step("Creating the fake-fleet fixture (%d MCPServers: %s × %s)", len(names),
 		strings.Join(familyNames(), "/"), strings.Join(fleetFixtureClusters, ", "))
-	_, path, err := renderManifest(cfg, "fleet-fixture.yaml.tmpl")
+	rendered, _, err := renderManifest(cfg, "fleet-fixture.yaml.tmpl")
 	if err != nil {
 		return err
 	}
-	if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
+	ctx := context.Background()
+	if _, err := applyManifests(ctx, rendered); err != nil {
 		return err
 	}
-	existing, err := outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io",
-		"-l", fleetFixtureLabel+"="+fleetFixtureValue, "-o", "jsonpath={.items[*].metadata.name}")
+	gvr, err := gvrFor(musterMCPServerResource)
 	if err != nil {
 		return err
 	}
-	for _, name := range strings.Fields(existing) {
-		if !slices.Contains(names, name) {
+	existing, err := listObjects(ctx, gvr, platformNamespace, fleetFixtureLabel+"="+fleetFixtureValue)
+	if err != nil {
+		return err
+	}
+	for _, member := range existing {
+		if name := member.GetName(); !slices.Contains(names, name) {
 			note("removing stale fixture member %s", name)
-			if err := runQuiet("kubectl", "-n", platformNamespace, "delete", "mcpservers.muster.giantswarm.io", name); err != nil {
+			if err := deleteObject(ctx, gvr, platformNamespace, name, fixtureDeleteWait); err != nil {
 				return err
 			}
 		}
@@ -171,26 +178,28 @@ type labelledServer struct {
 
 func (s labelledServer) key() string { return s.Namespace + "/" + s.Name }
 
-// proveToolGroupLabels is the platform-test step for the label: kubectl -l
-// with the infrastructure value lists every fake-fleet member and, of the
-// lab's own CRs, nothing else; every value in the cluster is one of the two
-// the contract knows; the OAuth fixture is unlabelled (a Registered server).
-// Servers the vendored charts label (Helm-managed) are reported, not judged:
-// they appear as the charts bump to the releases that stamp the label.
+// proveToolGroupLabels is the platform-test step for the label: a label
+// selector with the infrastructure value lists every fake-fleet member and,
+// of the lab's own CRs, nothing else; every value in the cluster is one of
+// the two the contract knows; the OAuth fixture is unlabelled (a Registered
+// server). Servers the vendored charts label (Helm-managed) are reported, not
+// judged: they appear as the charts bump to the releases that stamp the label.
 func proveToolGroupLabels() error {
 	step("Tool-group label: %s=%s selects the fake-fleet fixture", toolGroupLabel, toolGroupInfrastructure)
-	labelled, err := listMCPServers("-A", "-l", toolGroupLabel)
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	labelled, err := listMCPServers(ctx, "", toolGroupLabel)
 	if err != nil {
 		return err
 	}
-	oauth, err := listMCPServers("-n", platformNamespace, "--field-selector", "metadata.name="+oauthFixtureServer)
-	if err != nil {
-		return err
-	}
-	if len(oauth) != 1 {
+	oauth, err := getMCPServer(ctx, platformNamespace, oauthFixtureServer)
+	if apierrors.IsNotFound(err) {
 		return fmt.Errorf("MCPServer %s is missing — the sign-in fixture `agentlab platform` creates", oauthFixtureServer)
 	}
-	chartLabelled, err := checkToolGroupLabels(labelled, oauth[0])
+	if err != nil {
+		return err
+	}
+	chartLabelled, err := checkToolGroupLabels(labelled, oauth)
 	if err != nil {
 		return err
 	}
@@ -249,29 +258,39 @@ func checkToolGroupLabels(labelled []labelledServer, oauth labelledServer) ([]st
 	return chartLabelled, nil
 }
 
-// listMCPServers reads muster MCPServer CRs (fully qualified: kagent ships
-// its own mcpservers.kagent.dev) with the given kubectl selectors.
-func listMCPServers(selectors ...string) ([]labelledServer, error) {
-	args := append([]string{"get", "mcpservers.muster.giantswarm.io", "-o", "json"}, selectors...)
-	raw, err := outputQuiet("kubectl", args...)
+// listMCPServers reads muster's MCPServer CRs (musterMCPServerResource, fully
+// qualified: kagent ships its own mcpservers.kagent.dev) in a namespace — or
+// in every one with ns "" — matching the label selector.
+func listMCPServers(ctx context.Context, ns, labelSelector string) ([]labelledServer, error) {
+	gvr, err := gvrFor(musterMCPServerResource)
 	if err != nil {
 		return nil, err
 	}
-	var list struct {
-		Items []struct {
-			Metadata struct {
-				Namespace string            `json:"namespace"`
-				Name      string            `json:"name"`
-				Labels    map[string]string `json:"labels"`
-			} `json:"metadata"`
-		} `json:"items"`
+	items, err := listObjects(ctx, gvr, ns, labelSelector)
+	if err != nil {
+		return nil, err
 	}
-	if err := json.Unmarshal([]byte(raw), &list); err != nil {
-		return nil, fmt.Errorf("parsing MCPServer list: %w", err)
-	}
-	out := make([]labelledServer, 0, len(list.Items))
-	for _, it := range list.Items {
-		out = append(out, labelledServer{Namespace: it.Metadata.Namespace, Name: it.Metadata.Name, Labels: it.Metadata.Labels})
+	out := make([]labelledServer, 0, len(items))
+	for i := range items {
+		out = append(out, labelledServerOf(&items[i]))
 	}
 	return out, nil
+}
+
+// getMCPServer reads one of muster's MCPServer CRs; a missing one stays an
+// apierrors.IsNotFound.
+func getMCPServer(ctx context.Context, ns, name string) (labelledServer, error) {
+	gvr, err := gvrFor(musterMCPServerResource)
+	if err != nil {
+		return labelledServer{}, err
+	}
+	obj, err := getObject(ctx, gvr, ns, name)
+	if err != nil {
+		return labelledServer{}, err
+	}
+	return labelledServerOf(obj), nil
+}
+
+func labelledServerOf(obj *unstructured.Unstructured) labelledServer {
+	return labelledServer{Namespace: obj.GetNamespace(), Name: obj.GetName(), Labels: obj.GetLabels()}
 }

--- a/internal/lab/fleetfixture_test.go
+++ b/internal/lab/fleetfixture_test.go
@@ -2,15 +2,27 @@ package lab
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The fixture-label value of the OAuth fixture and the managed-by value of a
+// chart-shipped server, as the tests seed them.
+const (
+	oauthFixtureMarker = "oauth-sign-in"
+	helmManaged        = "Helm"
 )
 
 // fixtureCR is the shape of one rendered MCPServer the tests decode into.
@@ -165,9 +177,9 @@ func TestCheckToolGroupLabels(t *testing.T) {
 		return out
 	}
 	oauth := labelledServer{Namespace: platformNamespace, Name: oauthFixtureServer,
-		Labels: map[string]string{managedByLabel: managedByAgentlabValue, fleetFixtureLabel: "oauth-sign-in"}}
+		Labels: map[string]string{managedByLabel: managedByAgentlabValue, fleetFixtureLabel: oauthFixtureMarker}}
 	helm := func(name, group string) labelledServer {
-		return labelledServer{Namespace: platformNamespace, Name: name, Labels: map[string]string{managedByLabel: "Helm", toolGroupLabel: group}}
+		return labelledServer{Namespace: platformNamespace, Name: name, Labels: map[string]string{managedByLabel: helmManaged, toolGroupLabel: group}}
 	}
 
 	t.Run("exactly the fixture", func(t *testing.T) {
@@ -220,4 +232,102 @@ func TestCheckToolGroupLabels(t *testing.T) {
 			t.Fatalf("want the labelled OAuth fixture refused, got %v", err)
 		}
 	})
+}
+
+// fakeFleetOnCluster seeds what `agentlab platform` leaves on a lab: every
+// fake-fleet member, the OAuth fixture, a chart-labelled server, and — in
+// another namespace — a server of the other group.
+func fakeFleetOnCluster() []runtime.Object {
+	var objs []runtime.Object
+	for _, name := range fleetFixtureNames() {
+		objs = append(objs, customObject(musterMCPServerGVK, platformNamespace, name, map[string]string{
+			managedByLabel: managedByAgentlabValue, fleetFixtureLabel: fleetFixtureValue, toolGroupLabel: toolGroupInfrastructure}))
+	}
+	objs = append(objs,
+		customObject(musterMCPServerGVK, platformNamespace, oauthFixtureServer, map[string]string{managedByLabel: managedByAgentlabValue, fleetFixtureLabel: oauthFixtureMarker}),
+		customObject(musterMCPServerGVK, platformNamespace, componentMCPKubernetes, map[string]string{managedByLabel: helmManaged, toolGroupLabel: toolGroupInfrastructure}),
+		customObject(musterMCPServerGVK, "elsewhere", "pro", map[string]string{managedByLabel: helmManaged, toolGroupLabel: toolGroupAgentPlatform}),
+	)
+	return objs
+}
+
+// TestListMCPServersByLabel: the tool-group listing is a label selector
+// across every namespace, the fixture's a selector in the platform
+// namespace; a single server reads by name and a missing one is the
+// apiserver's NotFound.
+func TestListMCPServersByLabel(t *testing.T) {
+	newFakeLab(t, fakeFleetOnCluster()...)
+	ctx := context.Background()
+	labelled, err := listMCPServers(ctx, "", toolGroupLabel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keys []string
+	for _, s := range labelled {
+		keys = append(keys, s.key())
+	}
+	slices.Sort(keys)
+	want := []string{"elsewhere/pro", platformNamespace + "/" + componentMCPKubernetes}
+	for _, name := range fleetFixtureNames() {
+		want = append(want, platformNamespace+"/"+name)
+	}
+	slices.Sort(want)
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("labelled = %v, want %v", keys, want)
+	}
+	members, err := listMCPServers(ctx, platformNamespace, fleetFixtureLabel+"="+fleetFixtureValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(members) != len(fleetFixtureNames()) {
+		t.Errorf("the fixture selector lists %d servers, want %d", len(members), len(fleetFixtureNames()))
+	}
+	oauth, err := getMCPServer(ctx, platformNamespace, oauthFixtureServer)
+	if err != nil || oauth.Labels[fleetFixtureLabel] != oauthFixtureMarker {
+		t.Errorf("getMCPServer = %+v, %v", oauth, err)
+	}
+	if _, err := getMCPServer(ctx, platformNamespace, "absent"); !apierrors.IsNotFound(err) {
+		t.Errorf("a missing server: %v, want the apiserver's NotFound", err)
+	}
+}
+
+// TestProveToolGroupLabelsOnCluster: the platform-test step passes on what
+// `agentlab platform` leaves behind (the chart-labelled server reported, not
+// judged), fails once the OAuth fixture is missing, and the per-server map
+// the presets proof reads carries "" for the unlabelled fixture.
+func TestProveToolGroupLabelsOnCluster(t *testing.T) {
+	f := newFakeLab(t, fakeFleetOnCluster()...)
+	if err := proveToolGroupLabels(); err != nil {
+		t.Errorf("on a complete lab: %v", err)
+	}
+	groups, err := mcpServerToolGroups()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{oauthFixtureServer: "", componentMCPKubernetes: toolGroupInfrastructure}
+	for _, name := range fleetFixtureNames() {
+		want[name] = toolGroupInfrastructure
+	}
+	if !reflect.DeepEqual(groups, want) {
+		t.Errorf("tool groups = %v, want %v", groups, want)
+	}
+	if err := f.dyn.Tracker().Delete(musterMCPServerGVR, platformNamespace, oauthFixtureServer); err != nil {
+		t.Fatal(err)
+	}
+	if err := proveToolGroupLabels(); err == nil || !strings.Contains(err.Error(), oauthFixtureServer+" is missing") {
+		t.Errorf("without the OAuth fixture: %v", err)
+	}
+}
+
+// TestLabelledServerOf reads namespace, name and labels off the object as the
+// apiserver returns it; no labels is an empty map's worth of lookups.
+func TestLabelledServerOf(t *testing.T) {
+	got := labelledServerOf(customObject(musterMCPServerGVK, platformNamespace, "x", map[string]string{toolGroupLabel: toolGroupAgentPlatform}))
+	if got.key() != platformNamespace+"/x" || got.Labels[toolGroupLabel] != toolGroupAgentPlatform {
+		t.Errorf("labelledServerOf = %+v", got)
+	}
+	bare := labelledServerOf(&unstructured.Unstructured{Object: map[string]any{"metadata": map[string]any{nameKey: "bare"}}})
+	if bare.Name != "bare" || bare.Namespace != "" || bare.Labels[toolGroupLabel] != "" {
+		t.Errorf("a bare object = %+v", bare)
+	}
 }

--- a/internal/lab/kube_test.go
+++ b/internal/lab/kube_test.go
@@ -159,6 +159,8 @@ func newFakeLab(t *testing.T, objects ...runtime.Object) *fakeLab {
 		fluxHelmReleaseGVR: "HelmReleaseList",
 		musterMCPServerGVR: "MCPServerList",
 		prometheusGVR:      "PrometheusList",
+		gvrModelConfigs:    "ModelConfigList",
+		gvrAgents:          "AgentList",
 	}, seeds...)
 	dyn.PrependReactor("patch", "*", fakeApply(dyn.Tracker()))
 
@@ -178,6 +180,10 @@ func newFakeLab(t *testing.T, objects ...runtime.Object) *fakeLab {
 		fluxHelmReleaseGVK,
 		musterMCPServerGVK,
 		prometheusGVK,
+		// kagent's ModelConfig and Agent, which the proofs read and write
+		// (crds_test.go).
+		gvkModelConfig,
+		gvkAgent,
 	} {
 		mapper.Add(gvk, meta.RESTScopeNamespace)
 	}
@@ -781,6 +787,9 @@ func TestGvrFor(t *testing.T) {
 		gvrSecrets.Resource:     gvrSecrets,
 		"secret":                gvrSecrets,
 		gvrDeployments.Resource + "." + gvrDeployments.Group: gvrDeployments,
+		fluxHelmReleaseResource:                              fluxHelmReleaseGVR,
+		musterMCPServerResource:                              musterMCPServerGVR,
+		modelConfigResource:                                  gvrModelConfigs,
 	} {
 		if got, err := gvrFor(arg); err != nil || got != want {
 			t.Errorf("gvrFor(%q) = %v, %v; want %v", arg, got, err, want)

--- a/internal/lab/models.go
+++ b/internal/lab/models.go
@@ -1,10 +1,13 @@
 package lab
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -33,6 +36,18 @@ const managedByAgentlab = "app.kubernetes.io/managed-by=agentlab"
 // extraModelsTemplate renders the lab-owned ModelConfigs.
 const extraModelsTemplate = "extra-models.yaml.tmpl"
 
+// modelConfigAcceptedPoll is the cadence of waitModelConfigAccepted's ten
+// looks (a variable so the tests need not wait it out).
+var modelConfigAcceptedPoll = 2 * time.Second
+
+// kubeReadTimeout bounds one read of the apiserver in the proofs and
+// fixtures — a status poll's look, an RBAC question, an identity probe.
+const kubeReadTimeout = 15 * time.Second
+
+// modelDeleteWait bounds how long a pruned ModelConfig or key Secret may take
+// to go away — kubectl's default delete waits too.
+const modelDeleteWait = 2 * time.Minute
+
 // ensureExtraModels reconciles the platform.extraModels entries into kagent
 // ModelConfig CRs plus their key Secrets, and prunes lab-labeled CRs whose
 // entry is gone from agentlab.yaml. Only called with the agents runtime
@@ -41,7 +56,7 @@ const extraModelsTemplate = "extra-models.yaml.tmpl"
 // ModelConfigs itself, for every backend it fronts.
 func ensureExtraModels(cfg *config.Config) error {
 	models := cfg.Platform.ExtraModels
-	_, path, err := renderManifestWith(cfg, extraModelsTemplate, func(d *tmplData) { d.ExtraModels = models })
+	rendered, _, err := renderManifestWith(cfg, extraModelsTemplate, func(d *tmplData) { d.ExtraModels = models })
 	if err != nil {
 		return err
 	}
@@ -57,7 +72,7 @@ func ensureExtraModels(cfg *config.Config) error {
 		}
 	}
 	if len(models) > 0 {
-		if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
+		if _, err := applyManifests(context.Background(), rendered); err != nil {
 			return err
 		}
 	}
@@ -82,7 +97,11 @@ func ensureModelKeySecret(m config.ExtraModel) error {
 	if !m.NeedsSecret() {
 		return nil
 	}
-	if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "secret", m.SecretName()); err == nil {
+	exists, err := objectExists(context.Background(), gvrSecrets, kagentNamespace, m.SecretName())
+	if err != nil {
+		return err
+	}
+	if exists {
 		note("secret %s/%s already exists, leaving it alone (delete it and re-run to rotate)", kagentNamespace, m.SecretName())
 		return nil
 	}
@@ -96,17 +115,9 @@ func ensureModelKeySecret(m config.ExtraModel) error {
 	default:
 		key = os.Getenv(m.APIKeyEnv)
 	}
-	// Applied via stdin so the key never appears in a process's argv.
-	manifest := fmt.Sprintf(`apiVersion: v1
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-type: Opaque
-stringData:
-  %s: %q
-`, m.SecretName(), kagentNamespace, m.SecretKey(), key)
-	if err := pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-"); err != nil {
+	// Applied in-process: the key never appears in a process's argv or in a
+	// rendered file.
+	if err := ensureSecret(kagentNamespace, m.SecretName(), corev1.SecretTypeOpaque, map[string][]byte{m.SecretKey(): []byte(key)}); err != nil {
 		return err
 	}
 	if key != placeholderAPIKey {
@@ -120,26 +131,31 @@ stringData:
 // gone from the host server they were wired from — so a removal is a real
 // removal on the next run.
 func pruneExtraModels(want []config.ExtraModel) error {
-	out, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource,
-		"-l", managedByAgentlab, "-o", "jsonpath={.items[*].metadata.name}")
+	ctx := context.Background()
+	gvr, err := gvrFor(modelConfigResource)
 	if err != nil {
-		return nil // no CRD / no namespace: nothing lab-owned to prune
+		return nil // no CRD: nothing lab-owned to prune
+	}
+	existing, err := listObjects(ctx, gvr, kagentNamespace, managedByAgentlab)
+	if err != nil {
+		return nil // no namespace: nothing lab-owned to prune
 	}
 	keep := map[string]bool{}
 	for _, m := range want {
 		keep[m.Name] = true
 	}
-	for _, name := range strings.Fields(out) {
+	for _, mc := range existing {
+		name := mc.GetName()
 		if keep[name] {
 			continue
 		}
 		note("pruning model config %s (removed from %s or gone from its host server)", name, config.File)
-		if err := runQuiet("kubectl", "-n", kagentNamespace, "delete", modelConfigResource, name); err != nil {
+		if err := deleteObject(ctx, gvr, kagentNamespace, name, modelDeleteWait); err != nil {
 			return err
 		}
-		// Its key Secret rides along; --ignore-not-found because keyless
+		// Its key Secret rides along; a missing one is fine — keyless
 		// providers never had one.
-		if err := runQuiet("kubectl", "-n", kagentNamespace, "delete", "secret", "kagent-"+name, "--ignore-not-found"); err != nil {
+		if err := deleteObject(ctx, gvrSecrets, kagentNamespace, "kagent-"+name, modelDeleteWait); err != nil {
 			return err
 		}
 	}
@@ -162,12 +178,13 @@ func extraModelsHint(models []config.ExtraModel) string {
 // waitModelConfigAccepted polls one ModelConfig until the controller accepts
 // it — the machine check that the provider/model/Secret combination is one
 // the runtime can mount, before anyone debugs it from a failing agent pod.
+// A read that fails is reported as such, with the apiserver's words, never as
+// an empty status.
 func waitModelConfigAccepted(name string) error {
 	var status string
 	var readErr error
-	accepted := waitFor(10, 2*time.Second, func() bool {
-		status, readErr = outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, name,
-			"-o", `jsonpath={.status.conditions[?(@.type=="Accepted")].status}`)
+	accepted := waitFor(10, modelConfigAcceptedPoll, func() bool {
+		status, readErr = modelConfigCondition(name, "Accepted")
 		return readErr == nil && status == "True"
 	})
 	if !accepted {
@@ -176,4 +193,20 @@ func waitModelConfigAccepted(name string) error {
 	}
 	note("ModelConfig %s: Accepted", name)
 	return nil
+}
+
+// modelConfigCondition reads one condition's status off a ModelConfig ("" while
+// the controller has not written it).
+func modelConfigCondition(name, condType string) (string, error) {
+	gvr, err := gvrFor(modelConfigResource)
+	if err != nil {
+		return "", err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	obj, err := getObject(ctx, gvr, kagentNamespace, name)
+	if err != nil {
+		return "", err
+	}
+	return conditionStatus(obj, condType), nil
 }

--- a/internal/lab/models_test.go
+++ b/internal/lab/models_test.go
@@ -3,6 +3,12 @@ package lab
 import (
 	"strings"
 	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -55,8 +61,8 @@ func TestExtraModelsTemplate(t *testing.T) {
 		t.Errorf("want %d ModelConfigs:\n%s", len(cfg.Platform.ExtraModels), out)
 	}
 
-	// No extras -> comments only, nothing to apply (the lifecycle skips
-	// kubectl apply on an empty list).
+	// No extras -> comments only, nothing to apply (the lifecycle skips the
+	// apply on an empty list).
 	cfg.Platform.ExtraModels = nil
 	raw, err = renderTemplate(cfg, "extra-models.yaml.tmpl", nil)
 	if err != nil {
@@ -64,5 +70,101 @@ func TestExtraModelsTemplate(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "kind:") {
 		t.Errorf("empty extraModels rendered objects:\n%s", raw)
+	}
+}
+
+// testKeyEnv is the env var NAME a test model entry reads its key from.
+const testKeyEnv = "AGENTLAB_TEST_KEY" // #nosec G101 -- env var NAME, not a credential
+
+// labelledModelConfig is a lab-owned ModelConfig seed (the label pruning
+// selects by).
+func labelledModelConfig(name string) *unstructured.Unstructured {
+	return customObject(gvkModelConfig, kagentNamespace, name, map[string]string{managedByLabel: managedByAgentlabValue})
+}
+
+// TestWaitModelConfigAccepted: the poll ends on Accepted=True; an unaccepted
+// ModelConfig reports the last status it read; a read that fails reports the
+// failure with the apiserver's words — a NotFound stays one — instead of an
+// empty status.
+func TestWaitModelConfigAccepted(t *testing.T) {
+	prev := modelConfigAcceptedPoll
+	modelConfigAcceptedPoll = time.Millisecond
+	t.Cleanup(func() { modelConfigAcceptedPoll = prev })
+	newFakeLab(t,
+		withCondition(labelledModelConfig("ok"), "Accepted", "True", ""),
+		withCondition(labelledModelConfig("nope"), "Accepted", condFalse, "no such provider"),
+	)
+	if err := waitModelConfigAccepted("ok"); err != nil {
+		t.Errorf("accepted: %v", err)
+	}
+	err := waitModelConfigAccepted("nope")
+	if err == nil || !strings.Contains(err.Error(), `ModelConfig nope never reached Accepted (last status: "False")`) {
+		t.Errorf("unaccepted: %v", err)
+	}
+	err = waitModelConfigAccepted("absent")
+	if err == nil || !apierrors.IsNotFound(err) || !strings.Contains(err.Error(), "modelconfigs kagent/absent") {
+		t.Errorf("a failed read must surface the apiserver's words, got %v", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "last status") {
+		t.Errorf("a failed read must not pose as a status: %v", err)
+	}
+}
+
+// TestPruneExtraModels: lab-labelled ModelConfigs not among the wanted
+// entries go, with their key Secrets; the wanted ones and the chart's own
+// unlabelled default stay.
+func TestPruneExtraModels(t *testing.T) {
+	f := newFakeLab(t,
+		labelledModelConfig("keep"), labelledModelConfig("drop"),
+		customObject(gvkModelConfig, kagentNamespace, "default-model-config", nil),
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kagent-keep", Namespace: kagentNamespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kagent-drop", Namespace: kagentNamespace}},
+	)
+	if err := pruneExtraModels([]config.ExtraModel{{Name: "keep"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.dyn.Tracker().Get(gvrModelConfigs, kagentNamespace, "drop"); !apierrors.IsNotFound(err) {
+		t.Errorf("drop still there: %v", err)
+	}
+	if _, err := f.dyn.Tracker().Get(gvrSecrets, kagentNamespace, "kagent-drop"); !apierrors.IsNotFound(err) {
+		t.Errorf("kagent-drop still there: %v", err)
+	}
+	for _, kept := range []string{"keep", "default-model-config"} {
+		f.stored(t, gvrModelConfigs, kagentNamespace, kept)
+	}
+	f.stored(t, gvrSecrets, kagentNamespace, "kagent-keep")
+}
+
+// TestEnsureModelKeySecret: an existing key Secret is left alone; a missing
+// one is applied with the env var's value under the provider's canonical
+// key, or with the placeholder when the entry names no variable.
+func TestEnsureModelKeySecret(t *testing.T) {
+	f := newFakeLab(t, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kagent-existing", Namespace: kagentNamespace},
+		Data: map[string][]byte{"OPENAI_API_KEY": []byte("old")}})
+	if err := ensureModelKeySecret(config.ExtraModel{Name: "existing", Provider: config.ProviderOpenAI, APIKeyEnv: testKeyEnv}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _, _ := unstructured.NestedString(f.stored(t, gvrSecrets, kagentNamespace, "kagent-existing").Object, "data", "OPENAI_API_KEY"); got != "b2xk" {
+		t.Errorf("the existing Secret was rewritten: data %q", got)
+	}
+	t.Setenv(testKeyEnv, "sk-test")
+	if err := ensureModelKeySecret(config.ExtraModel{Name: "fresh", Provider: config.ProviderOpenAI, APIKeyEnv: testKeyEnv}); err != nil {
+		t.Fatal(err)
+	}
+	fresh := f.stored(t, gvrSecrets, kagentNamespace, "kagent-fresh")
+	if got, _, _ := unstructured.NestedString(fresh.Object, "data", "OPENAI_API_KEY"); got != "c2stdGVzdA==" {
+		t.Errorf("kagent-fresh data = %q, want the env var's value", got)
+	}
+	if err := ensureModelKeySecret(config.ExtraModel{Name: "keyless", Provider: config.ProviderOpenAI}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _, _ := unstructured.NestedString(f.stored(t, gvrSecrets, kagentNamespace, "kagent-keyless").Object, "data", "OPENAI_API_KEY"); got != "YWdlbnRsYWItcGxhY2Vob2xkZXI=" {
+		t.Errorf("kagent-keyless data = %q, want the placeholder", got)
+	}
+	if err := ensureModelKeySecret(config.ExtraModel{Name: "ollama", Provider: config.ProviderOllama}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.dyn.Tracker().Get(gvrSecrets, kagentNamespace, "kagent-ollama"); !apierrors.IsNotFound(err) {
+		t.Errorf("a keyless provider must get no Secret: %v", err)
 	}
 }

--- a/internal/lab/models_test.go
+++ b/internal/lab/models_test.go
@@ -148,12 +148,12 @@ func TestEnsureModelKeySecret(t *testing.T) {
 		t.Errorf("the existing Secret was rewritten: data %q", got)
 	}
 	t.Setenv(testKeyEnv, "sk-test")
-	if err := ensureModelKeySecret(config.ExtraModel{Name: "fresh", Provider: config.ProviderOpenAI, APIKeyEnv: testKeyEnv}); err != nil {
+	if err := ensureModelKeySecret(config.ExtraModel{Name: "newkey", Provider: config.ProviderOpenAI, APIKeyEnv: testKeyEnv}); err != nil {
 		t.Fatal(err)
 	}
-	fresh := f.stored(t, gvrSecrets, kagentNamespace, "kagent-fresh")
+	fresh := f.stored(t, gvrSecrets, kagentNamespace, "kagent-newkey")
 	if got, _, _ := unstructured.NestedString(fresh.Object, "data", "OPENAI_API_KEY"); got != "c2stdGVzdA==" {
-		t.Errorf("kagent-fresh data = %q, want the env var's value", got)
+		t.Errorf("kagent-newkey data = %q, want the env var's value", got)
 	}
 	if err := ensureModelKeySecret(config.ExtraModel{Name: "keyless", Provider: config.ProviderOpenAI}); err != nil {
 		t.Fatal(err)

--- a/internal/lab/modelstest.go
+++ b/internal/lab/modelstest.go
@@ -2,6 +2,7 @@ package lab
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,6 +11,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -204,11 +207,11 @@ func ModelsTest(cfg *config.Config, email, backendName, model string) error {
 	if err := waitModelConfigAccepted(mcName); err != nil {
 		return err
 	}
-	spec, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName,
-		"-o", `jsonpath={.spec.provider} {.spec.model} {.spec.ollama.host}{.spec.openAI.baseUrl} backend={.metadata.labels.model-manager\.giantswarm\.io/backend} managed-by={.metadata.labels.app\.kubernetes\.io/managed-by}`)
+	mc, err := readKagentObject(modelConfigResource, mcName)
 	if err != nil {
 		return err
 	}
+	spec := modelConfigSummary(mc)
 	// model-manager writes the native keyless Ollama provider for ollama and
 	// the OpenAI provider on /api/v1 (placeholder key) for lemonade.
 	wantProvider, providerNote := config.ProviderOllama, "keyless native provider"
@@ -304,11 +307,8 @@ func ModelsTest(cfg *config.Config, email, backendName, model string) error {
 	if err := api.deleteModel(model, backendName); err != nil {
 		return err
 	}
-	if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName); err == nil {
-		gone := waitFor(15, 2*time.Second, func() bool {
-			_, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", modelConfigResource, mcName)
-			return err != nil
-		})
+	if modelConfigExists(mcName) {
+		gone := waitFor(15, 2*time.Second, func() bool { return !modelConfigExists(mcName) })
 		if !gone {
 			return fmt.Errorf("ModelConfig %s survived the delete", mcName)
 		}
@@ -492,14 +492,18 @@ spec:
     modelConfig: %s
     systemMessage: You are a terse assistant. Answer in one short line.
 `, modelsTestAgent, kagentNamespace, modelConfig)
-	if err := pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-"); err != nil {
+	ctx := context.Background()
+	agents, err := gvrFor(kagentAgentResource)
+	if err != nil {
+		return "", err
+	}
+	if _, err := applyManifests(ctx, []byte(manifest)); err != nil {
 		return "", err
 	}
 	defer func() {
-		_ = runQuiet("kubectl", "-n", kagentNamespace, "delete", "agents.kagent.dev", modelsTestAgent, "--ignore-not-found", "--wait=false")
+		_ = deleteObject(ctx, agents, kagentNamespace, modelsTestAgent, 0)
 	}()
-	if err := runQuiet("kubectl", "-n", kagentNamespace, "wait", "--for=condition=Ready", "--timeout=240s",
-		"agents.kagent.dev/"+modelsTestAgent); err != nil {
+	if err := waitCondition(ctx, agents, kagentNamespace, modelsTestAgent, "Ready", "True", 240*time.Second); err != nil {
 		return "", fmt.Errorf("agent %s never became Ready: %w", modelsTestAgent, err)
 	}
 	// The pod may report Ready a moment before the ADK listens; a short retry
@@ -517,6 +521,27 @@ spec:
 		return "", fmt.Errorf("A2A turn against %s failed: %w", modelsTestAgent, lastErr)
 	}
 	return reply, nil
+}
+
+// modelConfigExists reports whether the ModelConfig is there; a read that
+// fails counts as absent, as the CLI probe's non-zero exit did.
+func modelConfigExists(name string) bool {
+	_, err := readKagentObject(modelConfigResource, name)
+	return err == nil
+}
+
+// modelConfigSummary words a ModelConfig the way the proof's jsonpath did:
+// "<provider> <model> <ollama host or openAI baseUrl> backend=<backend label>
+// managed-by=<managed-by label>" — the string the provider and label
+// assertions read.
+func modelConfigSummary(mc *unstructured.Unstructured) string {
+	provider, _, _ := unstructured.NestedString(mc.Object, "spec", "provider")
+	model, _, _ := unstructured.NestedString(mc.Object, "spec", "model")
+	ollamaHost, _, _ := unstructured.NestedString(mc.Object, "spec", "ollama", "host")
+	openAIBaseURL, _, _ := unstructured.NestedString(mc.Object, "spec", "openAI", "baseUrl")
+	labels := mc.GetLabels()
+	return fmt.Sprintf("%s %s %s%s backend=%s managed-by=%s", provider, model, ollamaHost, openAIBaseURL,
+		labels["model-manager.giantswarm.io/backend"], labels[managedByLabel])
 }
 
 // a2aSend posts one JSON-RPC message/send and returns the agent's text: the

--- a/internal/lab/oauthfixture.go
+++ b/internal/lab/oauthfixture.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -60,6 +63,9 @@ const (
 	// server that answered 401 — muster's api.StateAuthRequired, spelled the
 	// CRD way.
 	mcpServerStateAuthRequired = "Auth Required"
+	// fixtureDeleteWait bounds how long a removed fixture member may take to
+	// go away — kubectl's default delete waits too.
+	fixtureDeleteWait = 2 * time.Minute
 )
 
 // ensureOAuthFixture applies the fixture and waits until muster reports it
@@ -70,11 +76,11 @@ const (
 // a minute, measured.
 func ensureOAuthFixture(cfg *config.Config) error {
 	step("Creating the OAuth sign-in fixture (MCPServer %s)", oauthFixtureServer)
-	_, path, err := renderManifest(cfg, "oauth-fixture.yaml.tmpl")
+	rendered, _, err := renderManifest(cfg, "oauth-fixture.yaml.tmpl")
 	if err != nil {
 		return err
 	}
-	if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
+	if _, err := applyManifests(context.Background(), rendered); err != nil {
 		return err
 	}
 	return waitMCPServerState(oauthFixtureServer, oauthFixtureHealthyStates...)
@@ -289,8 +295,7 @@ func completeSignIn(challengeURL string, user *config.User) error {
 // the lab's state is not the proof's verdict.
 func restartOAuthFixture() {
 	stamp := time.Now().UTC().Format(time.RFC3339)
-	if err := runQuiet("kubectl", "-n", platformNamespace, "patch", "mcpservers.muster.giantswarm.io", oauthFixtureServer,
-		"--type", "merge", "-p", fmt.Sprintf(`{"spec":{"restartRequestedAt":%q}}`, stamp)); err != nil {
+	if err := requestOAuthFixtureRestart(stamp); err != nil {
 		note("could not request a restart of %s (%v); it reads Connected until the signed-in session's token expires", oauthFixtureServer, err)
 		return
 	}
@@ -299,4 +304,17 @@ func restartOAuthFixture() {
 		return
 	}
 	note("%s back to Auth Required", oauthFixtureServer)
+}
+
+// requestOAuthFixtureRestart merge-patches spec.restartRequestedAt on the
+// fixture's MCPServer with the given stamp.
+func requestOAuthFixtureRestart(stamp string) error {
+	gvr, err := gvrFor(musterMCPServerResource)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	body := fmt.Sprintf(`{"spec":{"restartRequestedAt":%q}}`, stamp)
+	return patchObject(ctx, gvr, platformNamespace, oauthFixtureServer, types.MergePatchType, []byte(body))
 }

--- a/internal/lab/test.go
+++ b/internal/lab/test.go
@@ -1,26 +1,27 @@
 package lab
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
+
+	"k8s.io/client-go/rest"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
 
 // Test is the end-to-end RBAC proof: every configured user gets a real token
-// from Dex and a set of `kubectl auth can-i` assertions driven purely by the
-// `groups` claim in the id_token.
+// from Dex and a set of `auth can-i` assertions (SelfSubjectAccessReviews as
+// that user, token only) driven purely by the `groups` claim in the id_token.
 func Test(cfg *config.Config) error {
 	if err := useClusterKubeconfig(cfg); err != nil {
 		return err
 	}
 	pass, fail := 0, 0
 
-	check := func(kubeconfig, desc, expect string, canIArgs ...string) {
-		args := append([]string{"--kubeconfig=" + kubeconfig, "auth", "can-i"}, canIArgs...)
-		got, _ := outputQuiet("kubectl", args...)
-		got = strings.TrimSpace(got)
+	check := func(user *rest.Config, desc, expect string, canIArgs ...string) {
+		got := canIAnswer(user, canIArgs)
 		if got == expect {
 			fmt.Printf("  \033[32mPASS\033[0m  %-46s (can-i %s = %s)\n", desc, strings.Join(canIArgs, " "), got)
 			pass++
@@ -38,33 +39,32 @@ func Test(cfg *config.Config) error {
 		}
 
 		fmt.Printf("\n=== %s ===\n", u.Email)
-		kubeconfig := ".kubeconfig." + u.Username
-		if err := writeTokenKubeconfig(cfg, token, kubeconfig); err != nil {
+		// The token alone: the kind kubeconfig's admin client certificate
+		// would win over it (kubeconfig.go).
+		user, err := tokenConfig(token)
+		if err != nil {
 			return err
 		}
-		defer func() { _ = os.Remove(kubeconfig) }()
 
-		whoami, _ := outputQuiet("kubectl", "--kubeconfig="+kubeconfig, "auth", "whoami",
-			"-o", "jsonpath={.status.userInfo.username}  {.status.userInfo.groups}")
-		fmt.Printf("  identity: %s\n", whoami)
+		fmt.Printf("  identity: %s\n", identityLine(user))
 
 		// Assertions per effective role. Group membership is configurable in
 		// agentlab.yaml but the group -> role mapping is fixed by the lab RBAC,
 		// so the strongest group decides what to assert.
 		switch {
 		case u.HasGroup("platform-admins"):
-			check(kubeconfig, "cluster-admin: list nodes", "yes", "get", "nodes")
-			check(kubeconfig, "cluster-admin: create ns", "yes", "create", "namespaces")
-			check(kubeconfig, "cluster-admin: write anywhere", "yes", "create", "deployments", "-n", "kube-system")
+			check(user, "cluster-admin: list nodes", "yes", "get", "nodes")
+			check(user, "cluster-admin: create ns", "yes", "create", "namespaces")
+			check(user, "cluster-admin: write anywhere", "yes", "create", "deployments", "-n", "kube-system")
 		case u.HasGroup("developers"):
-			check(kubeconfig, "not a cluster admin", "no", "get", "nodes")
-			check(kubeconfig, "cannot create namespaces", "no", "create", "namespaces")
-			check(kubeconfig, "can write in ns/demo", "yes", "create", "deployments", "-n", "demo")
-			check(kubeconfig, "cannot write in ns/default", "no", "create", "deployments", "-n", "default")
+			check(user, "not a cluster admin", "no", "get", "nodes")
+			check(user, "cannot create namespaces", "no", "create", "namespaces")
+			check(user, "can write in ns/demo", "yes", "create", "deployments", "-n", "demo")
+			check(user, "cannot write in ns/default", "no", "create", "deployments", "-n", "default")
 		case u.HasGroup("viewers"):
-			check(kubeconfig, "read-only: list pods cluster-wide", "yes", "list", "pods", "--all-namespaces")
-			check(kubeconfig, "read-only: cannot create", "no", "create", "deployments", "-n", "demo")
-			check(kubeconfig, "read-only: cannot delete", "no", "delete", "pods", "-n", "kube-system")
+			check(user, "read-only: list pods cluster-wide", "yes", "list", "pods", "--all-namespaces")
+			check(user, "read-only: cannot create", "no", "create", "deployments", "-n", "demo")
+			check(user, "read-only: cannot delete", "no", "delete", "pods", "-n", "kube-system")
 		default:
 			fmt.Println("  (no lab groups; nothing to assert)")
 		}
@@ -77,4 +77,65 @@ func Test(cfg *config.Config) error {
 		return fmt.Errorf("%d RBAC assertions failed", fail)
 	}
 	return nil
+}
+
+// canIQuestion maps the arguments of `kubectl auth can-i <verb> <resource>
+// [-n <namespace> | --all-namespaces]` — the shape the assertions above are
+// written in — to what canI asks: without a namespace flag the question is
+// asked in the kubeconfig's namespace (defaultNamespace, as kubectl does),
+// --all-namespaces / -A in every namespace ("").
+func canIQuestion(args []string) (verb, resource, ns string, err error) {
+	if len(args) < 2 {
+		return "", "", "", fmt.Errorf("can-i needs a verb and a resource, got %q", args)
+	}
+	verb, resource, ns = args[0], args[1], defaultNamespace
+	for i := 2; i < len(args); i++ {
+		switch args[i] {
+		case "-n", "--namespace":
+			if i+1 >= len(args) {
+				return "", "", "", fmt.Errorf("can-i %s: %s without a namespace", strings.Join(args, " "), args[i])
+			}
+			i++
+			ns = args[i]
+		case "--all-namespaces", "-A":
+			ns = ""
+		default:
+			return "", "", "", fmt.Errorf("can-i %s: unsupported argument %q", strings.Join(args, " "), args[i])
+		}
+	}
+	return verb, resource, ns, nil
+}
+
+// canIAnswer answers one can-i question the way the CLI prints it — "yes" or
+// "no" — as the identity user authenticates as; a question that could not be
+// asked reads as the error, which no expectation matches.
+func canIAnswer(user *rest.Config, canIArgs []string) string {
+	verb, resource, ns, err := canIQuestion(canIArgs)
+	if err != nil {
+		return "error: " + err.Error()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	allowed, err := canI(ctx, user, verb, resource, ns)
+	if err != nil {
+		return "error: " + err.Error()
+	}
+	if allowed {
+		return "yes"
+	}
+	return "no"
+}
+
+// identityLine is what the apiserver makes of the token: the username and the
+// groups (as a JSON list, the way kubectl's jsonpath printed them), or the
+// probe's failure.
+func identityLine(user *rest.Config) string {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	username, groups, err := whoAmI(ctx, user)
+	if err != nil {
+		return fmt.Sprintf("(whoami failed: %v)", err)
+	}
+	raw, _ := json.Marshal(groups)
+	return username + "  " + string(raw)
 }

--- a/internal/lab/test_test.go
+++ b/internal/lab/test_test.go
@@ -1,0 +1,123 @@
+package lab
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubefake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// resourceNodes is the cluster-scoped resource the admin assertions ask about.
+const resourceNodes = "nodes"
+
+// TestCanIQuestion: the assertions are written in kubectl's `auth can-i`
+// argument shape, and each maps to exactly one SelfSubjectAccessReview — no
+// namespace flag asks in the kubeconfig's namespace (default), -n in that
+// namespace, --all-namespaces / -A in every namespace; anything else is
+// refused rather than silently ignored.
+func TestCanIQuestion(t *testing.T) {
+	for _, tc := range []struct {
+		args               []string
+		verb, resource, ns string
+	}{
+		{[]string{verbGet, resourceNodes}, verbGet, resourceNodes, defaultNamespace},
+		{[]string{verbCreate, gvrDeployments.Resource, "-n", "kube-public"}, verbCreate, gvrDeployments.Resource, "kube-public"},
+		{[]string{verbCreate, gvrDeployments.Resource, "--namespace", testNS}, verbCreate, gvrDeployments.Resource, testNS},
+		{[]string{verbList, gvrPods.Resource, "--all-namespaces"}, verbList, gvrPods.Resource, ""},
+		{[]string{verbList, gvrPods.Resource, "-A"}, verbList, gvrPods.Resource, ""},
+	} {
+		verb, resource, ns, err := canIQuestion(tc.args)
+		if err != nil || verb != tc.verb || resource != tc.resource || ns != tc.ns {
+			t.Errorf("canIQuestion(%v) = %q %q %q %v, want %q %q %q", tc.args, verb, resource, ns, err, tc.verb, tc.resource, tc.ns)
+		}
+	}
+	for _, bad := range [][]string{{verbGet}, {verbGet, gvrPods.Resource, "-n"}, {verbGet, gvrPods.Resource, "--as=someone"}, nil} {
+		if _, _, _, err := canIQuestion(bad); err == nil {
+			t.Errorf("canIQuestion(%v) must be refused", bad)
+		}
+	}
+}
+
+// TestCanIAnswer: the answer is the CLI's "yes"/"no" as the token's identity,
+// the namespace of each question as canIQuestion maps it; a question that
+// cannot be asked (a resource the apiserver does not serve) is an error
+// answer no expectation matches.
+func TestCanIAnswer(t *testing.T) {
+	newFakeLab(t)
+	cs := kubefake.NewClientset()
+	var attrs []*authorizationv1.ResourceAttributes
+	cs.PrependReactor("create", "selfsubjectaccessreviews", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		review, ok := action.(clienttesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		if !ok {
+			return true, nil, fmt.Errorf("created a %T", action.(clienttesting.CreateAction).GetObject())
+		}
+		attrs = append(attrs, review.Spec.ResourceAttributes)
+		review.Status.Allowed = review.Spec.ResourceAttributes.Verb != verbCreate
+		return true, review, nil
+	})
+	seen := stubClientsetFor(t, cs)
+	user := &rest.Config{Host: fakeKindServer, BearerToken: "user-token"}
+
+	if got := canIAnswer(user, []string{verbGet, resourceNodes}); got != "yes" {
+		t.Errorf("get nodes = %q, want yes", got)
+	}
+	if got := canIAnswer(user, []string{verbCreate, resourceNamespaces}); got != "no" {
+		t.Errorf("create namespaces = %q, want no", got)
+	}
+	if got := canIAnswer(user, []string{verbList, gvrPods.Resource, "--all-namespaces"}); got != "yes" {
+		t.Errorf("list pods --all-namespaces = %q, want yes", got)
+	}
+	if got := canIAnswer(user, []string{verbCreate, gvrDeployments.Resource, "-n", testNS}); got != "no" {
+		t.Errorf("create deployments -n demo = %q, want no", got)
+	}
+	for _, bad := range [][]string{{verbGet, "unicorns"}, {verbGet}} {
+		if got := canIAnswer(user, bad); !strings.HasPrefix(got, "error: ") {
+			t.Errorf("can-i %v = %q, want an error answer", bad, got)
+		}
+	}
+	want := []*authorizationv1.ResourceAttributes{
+		{Namespace: defaultNamespace, Verb: verbGet, Group: "", Resource: resourceNodes},
+		{Namespace: defaultNamespace, Verb: verbCreate, Group: "", Resource: resourceNamespaces},
+		{Namespace: "", Verb: verbList, Group: "", Resource: gvrPods.Resource},
+		{Namespace: testNS, Verb: verbCreate, Group: gvrDeployments.Group, Resource: gvrDeployments.Resource},
+	}
+	if !reflect.DeepEqual(attrs, want) {
+		t.Errorf("reviews sent = %+v, want %+v", attrs, want)
+	}
+	for _, cfg := range *seen {
+		if cfg != user {
+			t.Errorf("a review was not asked as the user's token config: %+v", cfg)
+		}
+	}
+}
+
+// TestIdentityLine: the identity line is the username and the groups the way
+// kubectl's jsonpath printed them (a JSON list), or the probe's failure.
+func TestIdentityLine(t *testing.T) {
+	cs := kubefake.NewClientset()
+	cs.PrependReactor("create", "selfsubjectreviews", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.SelfSubjectReview{Status: authenticationv1.SelfSubjectReviewStatus{
+			UserInfo: authenticationv1.UserInfo{Username: "oidc:viewer@lab.local", Groups: []string{"oidc:viewers", "oidc:developers"}},
+		}}, nil
+	})
+	stubClientsetFor(t, cs)
+	if got, want := identityLine(&rest.Config{}), `oidc:viewer@lab.local  ["oidc:viewers","oidc:developers"]`; got != want {
+		t.Errorf("identityLine = %q, want %q", got, want)
+	}
+
+	refused := kubefake.NewClientset()
+	refused.PrependReactor("create", "selfsubjectreviews", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("Unauthorized")
+	})
+	stubClientsetFor(t, refused)
+	if got := identityLine(&rest.Config{}); !strings.Contains(got, "whoami failed") || !strings.Contains(got, "Unauthorized") {
+		t.Errorf("a refused probe reads %q, want the failure and its cause", got)
+	}
+}

--- a/internal/lab/toolsetstest.go
+++ b/internal/lab/toolsetstest.go
@@ -1,12 +1,15 @@
 package lab
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
 	"sync"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -54,6 +57,11 @@ const (
 	toolsetTestDefaultModel   = "default-model-config"
 	toolsetTestAgentSystemMsg = "You are a test agent of the agentlab toolset proof. Do exactly what the message asks, tersely."
 )
+
+// kagentAgentResource is kagent's Agent as a resource argument, fully
+// qualified so a same-named kind in another group can never be meant (the
+// Flux HelmRelease every agent is rendered from is fluxHelmReleaseResource).
+const kagentAgentResource = "agents.kagent.dev"
 
 // ToolsetsTestOptions tunes the proof.
 type ToolsetsTestOptions struct {
@@ -210,12 +218,12 @@ func toolsetsCleanup(s *musterSession, toolPrefix string) {
 	for _, name := range names {
 		if _, err := s.callServerTool(toolPrefix+"get_agent", map[string]any{nameKey: name}); err != nil {
 			// Not known to agent-manager: a HelmRelease may still exist.
-			_ = runQuiet("kubectl", "-n", kagentNamespace, "delete", "helmrelease", name, "--ignore-not-found", "--wait=false")
+			deleteAgentHelmRelease(name)
 			continue
 		}
 		if _, err := s.callServerTool(toolPrefix+"delete_agent", map[string]any{nameKey: name, "force": true}); err != nil {
 			note("cleanup: delete_agent %s: %v", name, err)
-			_ = runQuiet("kubectl", "-n", kagentNamespace, "delete", "helmrelease", name, "--ignore-not-found", "--wait=false")
+			deleteAgentHelmRelease(name)
 		}
 		removed = true
 	}
@@ -256,7 +264,7 @@ func proveAgentManagerToolset(s *musterSession, toolPrefix, modelConfig string) 
 		}
 	}
 	note("refused: %s", excerpt(err.Error(), 220))
-	if _, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", toolsetsAgentReadOnly); err == nil {
+	if agentHelmReleaseExists(toolsetsAgentReadOnly) {
 		return fmt.Errorf("HelmRelease %s exists although the create was refused", toolsetsAgentReadOnly)
 	}
 
@@ -315,24 +323,75 @@ type agentCR struct {
 // waitAgentCR waits for helm-controller to render the Agent behind a
 // HelmRelease and returns it.
 func waitAgentCR(name string) (*agentCR, error) {
-	var raw string
+	var agent *unstructured.Unstructured
 	found := waitFor(40, 3*time.Second, func() bool {
-		out, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "agents.kagent.dev", name, "-o", "json")
+		obj, err := readKagentObject(kagentAgentResource, name)
 		if err != nil {
 			return false
 		}
-		raw = out
+		agent = obj
 		return true
 	})
 	if !found {
-		status, _ := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", name, "-o", "jsonpath={.status.conditions[?(@.type==\"Ready\")].message}")
+		status := ""
+		if hr, err := readKagentObject(fluxHelmReleaseResource, name); err == nil {
+			status = conditionMessage(hr, "Ready")
+		} else {
+			status = err.Error()
+		}
 		return nil, fmt.Errorf("no Agent %s rendered from its HelmRelease within 2 min (Ready: %s)", name, excerpt(status, 200))
 	}
-	var cr agentCR
-	if err := json.Unmarshal([]byte(raw), &cr); err != nil {
+	cr, err := agentCRFrom(agent)
+	if err != nil {
 		return nil, fmt.Errorf("parsing agent %s: %w", name, err)
 	}
+	return cr, nil
+}
+
+// agentCRFrom reads the part of a kagent Agent the proof looks at off the
+// object as the apiserver returned it.
+func agentCRFrom(obj *unstructured.Unstructured) (*agentCR, error) {
+	raw, err := json.Marshal(obj.Object)
+	if err != nil {
+		return nil, err
+	}
+	var cr agentCR
+	if err := json.Unmarshal(raw, &cr); err != nil {
+		return nil, err
+	}
 	return &cr, nil
+}
+
+// readKagentObject reads one object of the given resource (a kubectl resource
+// argument) in the kagent namespace, bounded by kubeReadTimeout.
+func readKagentObject(resourceArg, name string) (*unstructured.Unstructured, error) {
+	gvr, err := gvrFor(resourceArg)
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	return getObject(ctx, gvr, kagentNamespace, name)
+}
+
+// agentHelmReleaseExists reports whether an agent's HelmRelease is there; a
+// read that fails counts as absent, as the CLI probe's non-zero exit did.
+func agentHelmReleaseExists(name string) bool {
+	_, err := readKagentObject(fluxHelmReleaseResource, name)
+	return err == nil
+}
+
+// deleteAgentHelmRelease removes an agent's HelmRelease without waiting for
+// helm-controller's uninstall (`--ignore-not-found --wait=false`); best
+// effort, for the cleanup paths.
+func deleteAgentHelmRelease(name string) {
+	gvr, err := gvrFor(fluxHelmReleaseResource)
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	_ = deleteObject(ctx, gvr, kagentNamespace, name, 0)
 }
 
 // toolsetHeaderOf returns the X-Muster-Toolset value on the agent's muster
@@ -355,16 +414,31 @@ func toolsetHeaderOf(cr *agentCR) (string, error) {
 
 // helmReleaseToolset reads the top-level toolset value of a HelmRelease.
 func helmReleaseToolset(name string) ([]string, bool, error) {
-	out, err := outputQuiet("kubectl", "-n", kagentNamespace, "get", "helmrelease", name, "-o", "jsonpath={.spec.values.toolset}")
+	hr, err := readKagentObject(fluxHelmReleaseResource, name)
 	if err != nil {
 		return nil, false, err
 	}
-	if strings.TrimSpace(out) == "" {
+	return toolsetValue(hr)
+}
+
+// toolsetValue is `{.spec.values.toolset}` of a HelmRelease: the list and
+// whether the value is set at all; anything but a list of strings is refused.
+func toolsetValue(hr *unstructured.Unstructured) ([]string, bool, error) {
+	value, found, err := unstructured.NestedFieldNoCopy(hr.Object, "spec", "values", "toolset")
+	if err != nil || !found || value == nil {
 		return nil, false, nil
 	}
-	var toolset []string
-	if err := json.Unmarshal([]byte(out), &toolset); err != nil {
-		return nil, false, fmt.Errorf("HelmRelease %s values.toolset is not a string list: %q", name, out)
+	items, ok := value.([]any)
+	if !ok {
+		return nil, false, fmt.Errorf("HelmRelease %s values.toolset is not a string list: %v", hr.GetName(), value)
+	}
+	toolset := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false, fmt.Errorf("HelmRelease %s values.toolset is not a string list: %v", hr.GetName(), value)
+		}
+		toolset = append(toolset, s)
 	}
 	return toolset, true, nil
 }
@@ -442,7 +516,7 @@ spec:
     modelConfig:
       name: %s
 `, toolsetsAgentLegacy, kagentNamespace, kagentFluxServiceAccount, kagentNamespace, toolsetsAgentLegacy, toolsetTestAgentSystemMsg, modelConfig)
-	if err := pipeInto([]byte(hr), "kubectl", "apply", "-f", "-"); err != nil {
+	if _, err := applyManifests(context.Background(), []byte(hr)); err != nil {
 		return err
 	}
 	cr, err := waitAgentCR(toolsetsAgentLegacy)
@@ -885,16 +959,15 @@ func namesOutside(reported, toolset, catalogue []string) (outside, unknown []str
 // mcpServerToolGroups maps every MCPServer of the platform namespace to its
 // tool-group label ("" when unlabelled).
 func mcpServerToolGroups() (map[string]string, error) {
-	out, err := outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io", "-o",
-		"jsonpath={range .items[*]}{.metadata.name}={.metadata.labels['agent-platform\\.giantswarm\\.io/tool-group']}{\"\\n\"}{end}")
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	servers, err := listMCPServers(ctx, platformNamespace, "")
 	if err != nil {
 		return nil, err
 	}
-	labels := map[string]string{}
-	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
-		if name, value, ok := strings.Cut(line, "="); ok {
-			labels[name] = value
-		}
+	labels := make(map[string]string, len(servers))
+	for _, s := range servers {
+		labels[s.Name] = s.Labels[toolGroupLabel]
 	}
 	return labels, nil
 }

--- a/internal/lab/toolsetstest_portal.go
+++ b/internal/lab/toolsetstest_portal.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,6 +9,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -297,8 +300,7 @@ func proveToolsetPortal(cfg *config.Config, user *config.User) ([]string, error)
 	if err != nil {
 		return nil, err
 	}
-	image, _ := outputQuiet("kubectl", "-n", platformNamespace, "get", "deploy", "backstage", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
-	note("portal image %s", strings.TrimSpace(image))
+	note("portal image %s", deploymentImage(platformNamespace, componentBackstage))
 
 	step("The Tools step's backend calls: presets, live resolution, unmatched selectors (/api/muster/tools/filter)")
 	presets, err := portalFilterTools(ps, nil, true)
@@ -462,4 +464,26 @@ func scaffold(ps *portalSession, manifest, releaseName string) (string, error) {
 		return "", fmt.Errorf("scaffolder task %s ended %q:\n%s", task.ID, state, excerpt(string(events), 600))
 	}
 	return task.ID, nil
+}
+
+// deploymentImage is the image of a Deployment's first container — what
+// `kubectl get deploy -o jsonpath={.spec.template.spec.containers[0].image}`
+// printed — or "" when the Deployment cannot be read (a note, not a verdict).
+func deploymentImage(ns, name string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	d, err := getObject(ctx, gvrDeployments, ns, name)
+	if err != nil {
+		return ""
+	}
+	containers, _, _ := unstructured.NestedSlice(d.Object, "spec", "template", "spec", "containers")
+	if len(containers) == 0 {
+		return ""
+	}
+	first, ok := containers[0].(map[string]any)
+	if !ok {
+		return ""
+	}
+	image, _, _ := unstructured.NestedString(first, "image")
+	return image
 }

--- a/internal/lab/toolsetstest_test.go
+++ b/internal/lab/toolsetstest_test.go
@@ -6,8 +6,14 @@ import (
 	"strings"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/giantswarm/agentlab/internal/config"
 )
+
+// workflowIncidentTriage is a workflow selector the toolset fixtures share.
+const workflowIncidentTriage = "workflow:incident-triage"
 
 // The fixture pins Dex as its authorization server with the platform client,
 // and ships the Secret that client is read from.
@@ -143,7 +149,7 @@ func TestNamesOutside(t *testing.T) {
 // The composed manifest is the composer's shape: OCIRepository first, then
 // the HelmRelease with the top-level toolset value.
 func TestComposeAgentManifest(t *testing.T) {
-	m := composeAgentManifest("probe", "default-model-config", []string{presetReadOnly, "workflow:incident-triage"})
+	m := composeAgentManifest("probe", "default-model-config", []string{presetReadOnly, workflowIncidentTriage})
 	docs := strings.Split(m, "\n---\n")
 	if len(docs) != 2 || !strings.Contains(docs[0], "kind: OCIRepository") || !strings.Contains(docs[1], "kind: HelmRelease") {
 		t.Fatalf("wanted OCIRepository then HelmRelease, got:\n%s", m)
@@ -152,7 +158,7 @@ func TestComposeAgentManifest(t *testing.T) {
 		"url: oci://gsoci.azurecr.io/charts/giantswarm/agent",
 		"semver: x.x.x",
 		"name: probe\n  namespace: kagent",
-		`toolset: ["preset:read-only", "workflow:incident-triage"]`,
+		`toolset: ["preset:read-only", "` + workflowIncidentTriage + `"]`,
 		"modelConfig:\n      name: default-model-config",
 	} {
 		if !strings.Contains(m, want) {
@@ -194,5 +200,115 @@ func TestParseMCPResponsePicksTheResponseFrame(t *testing.T) {
 	}
 	if _, err := parseMCPResponse([]byte("nothing here")); err == nil {
 		t.Fatal("garbage must fail")
+	}
+}
+
+// helmReleaseWithToolset seeds an agent's HelmRelease carrying the top-level
+// toolset value (nil for one applied without it).
+func helmReleaseWithToolset(name string, toolset []any) *unstructured.Unstructured {
+	hr := customObject(fluxHelmReleaseGVK, kagentNamespace, name, nil)
+	if toolset != nil {
+		_ = unstructured.SetNestedSlice(hr.Object, toolset, "spec", "values", "toolset")
+	}
+	return hr
+}
+
+// TestHelmReleaseToolset: the value is read off spec.values.toolset as a
+// list of strings, reported unset when the HelmRelease carries none, refused
+// when it is not a string list; a missing HelmRelease is the apiserver's
+// NotFound.
+func TestHelmReleaseToolset(t *testing.T) {
+	odd := customObject(fluxHelmReleaseGVK, kagentNamespace, "odd", nil)
+	_ = unstructured.SetNestedField(odd.Object, "preset:read-only", "spec", "values", "toolset")
+	newFakeLab(t,
+		helmReleaseWithToolset(toolsetsAgentReadOnly, []any{presetReadOnly, workflowIncidentTriage}),
+		helmReleaseWithToolset(toolsetsAgentLegacy, nil),
+		odd,
+	)
+	toolset, set, err := helmReleaseToolset(toolsetsAgentReadOnly)
+	if err != nil || !set || !reflect.DeepEqual(toolset, []string{presetReadOnly, workflowIncidentTriage}) {
+		t.Errorf("read-only agent: %v %v %v", toolset, set, err)
+	}
+	if toolset, set, err := helmReleaseToolset(toolsetsAgentLegacy); err != nil || set || toolset != nil {
+		t.Errorf("legacy agent: %v %v %v, want unset", toolset, set, err)
+	}
+	if _, _, err := helmReleaseToolset("odd"); err == nil || !strings.Contains(err.Error(), "is not a string list") {
+		t.Errorf("a scalar toolset: %v, want the refusal", err)
+	}
+	if _, _, err := helmReleaseToolset("absent"); !apierrors.IsNotFound(err) {
+		t.Errorf("a missing HelmRelease: %v, want the apiserver's NotFound", err)
+	}
+}
+
+// TestWaitAgentCR: the Agent is decoded as the apiserver returns it, its
+// muster tool entry's header read; an Agent without a tool entry has no
+// header to read.
+func TestWaitAgentCR(t *testing.T) {
+	agent := customObject(gvkAgent, kagentNamespace, toolsetsAgentReadOnly, nil)
+	_ = unstructured.SetNestedSlice(agent.Object, []any{map[string]any{
+		fieldType:     "McpServer",
+		"headersFrom": []any{map[string]any{nameKey: toolsetHeader, "value": presetReadOnly}},
+		"mcpServer":   map[string]any{nameKey: componentMuster},
+	}}, "spec", "declarative", "tools")
+	none := customObject(gvkAgent, kagentNamespace, toolsetsAgentNone, nil)
+	_ = unstructured.SetNestedSlice(none.Object, []any{}, "spec", "declarative", "tools")
+	newFakeLab(t, agent, none)
+
+	cr, err := waitAgentCR(toolsetsAgentReadOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header, err := toolsetHeaderOf(cr)
+	if err != nil || header != presetReadOnly {
+		t.Errorf("header = %q, %v", header, err)
+	}
+	if cr.Spec.Declarative.Tools[0].MCPServer == nil || cr.Spec.Declarative.Tools[0].MCPServer.Name != componentMuster {
+		t.Errorf("mcpServer entry lost: %+v", cr.Spec.Declarative.Tools)
+	}
+	cr, err = waitAgentCR(toolsetsAgentNone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := toolsetHeaderOf(cr); err == nil || len(cr.Spec.Declarative.Tools) != 0 {
+		t.Errorf("an agent without a tool entry: %+v, %v", cr.Spec.Declarative.Tools, err)
+	}
+}
+
+// TestDeleteAgentHelmRelease: the cleanup's delete is --ignore-not-found
+// --wait=false — a present HelmRelease goes, a missing one is no failure.
+func TestDeleteAgentHelmRelease(t *testing.T) {
+	f := newFakeLab(t, helmReleaseWithToolset(toolsetsAgentFull, []any{presetFull}))
+	if !agentHelmReleaseExists(toolsetsAgentFull) {
+		t.Fatal("seed not visible")
+	}
+	deleteAgentHelmRelease(toolsetsAgentFull)
+	deleteAgentHelmRelease("absent")
+	if _, err := f.dyn.Tracker().Get(fluxHelmReleaseGVR, kagentNamespace, toolsetsAgentFull); !apierrors.IsNotFound(err) {
+		t.Errorf("HelmRelease still there: %v", err)
+	}
+	if agentHelmReleaseExists(toolsetsAgentFull) {
+		t.Error("agentHelmReleaseExists still true after the delete")
+	}
+}
+
+// TestModelConfigSummary: the summary is the proof's jsonpath line —
+// provider, model, the endpoint field the provider uses, the backend and
+// managed-by labels — so the provider and label assertions read it as before.
+func TestModelConfigSummary(t *testing.T) {
+	mc := customObject(gvkModelConfig, kagentNamespace, "qwen", map[string]string{
+		"model-manager.giantswarm.io/backend": "ollama", managedByLabel: modelManagerMCPServer})
+	_ = unstructured.SetNestedField(mc.Object, config.ProviderOllama, "spec", "provider")
+	_ = unstructured.SetNestedField(mc.Object, "qwen2.5:0.5b", "spec", "model")
+	_ = unstructured.SetNestedField(mc.Object, "http://host:11434", "spec", "ollama", "host")
+	if got, want := modelConfigSummary(mc), "Ollama qwen2.5:0.5b http://host:11434 backend=ollama managed-by=model-manager"; got != want {
+		t.Errorf("summary = %q, want %q", got, want)
+	}
+	bare := customObject(gvkModelConfig, kagentNamespace, "bare", nil)
+	if got, want := modelConfigSummary(bare), "   backend= managed-by="; got != want {
+		t.Errorf("bare summary = %q, want %q", got, want)
+	}
+	newFakeLab(t, mc)
+	if !modelConfigExists("qwen") || modelConfigExists("absent") {
+		t.Error("modelConfigExists disagrees with the store")
 	}
 }


### PR DESCRIPTION
Step 3b of #101, the proofs-and-fixtures half: `test`, `agents-test`, `toolsets-test` (both halves), `models-test`, the extra-model reconciliation (`models.go`) and the fake-fleet and OAuth sign-in fixtures no longer shell out to `kubectl` — every one of their 34 call sites goes through the client-go layer (`internal/lab/kube.go`). The lifecycle files (`up`/`down`/`platform`/observability/kagent workarounds/logs) are the sibling step; `kubectl` itself leaves Preflight and the docs in the closing step.

What changed, by proof:

- **`test`** — each `auth can-i <verb> <resource> [-n ns | --all-namespaces]` expectation is a `SelfSubjectAccessReview` as the user's token alone (`tokenConfig`), the arguments mapped as kubectl mapped them (no `-n` = the kubeconfig's namespace `default`, `--all-namespaces` = every namespace); the identity line is a `SelfSubjectReview`. The per-user `.kubeconfig.<user>` files are no longer written (`login` keeps writing `kubeconfig.oidc` for humans). Output unchanged: the same PASS/FAIL lines, `identity: <user>  ["group", …]`.
- **`agents-test`** — the HelmRelease's `managedFields[*].manager`, the agent-manager log (`podLogs deploy/agent-manager -c agent-manager --since=5m`), the refused viewer's HelmRelease probe, and `auth can-i --list --as=<ServiceAccount> -n kagent` as an impersonating `SelfSubjectRulesReview` + `ruleRows`, with the same discovery-only filter.
- **`toolsets-test`** — HelmRelease existence probes and `--ignore-not-found --wait=false` deletes, the Agent CR read and decode, the Ready-condition message fallback, `.spec.values.toolset`, the legacy HelmRelease applied server-side, the MCPServer tool-group map from a list; the portal half reads the Backstage image off the Deployment.
- **`models-test`** — ModelConfig reads (the summary line the provider/label assertions parse is rebuilt from the object), existence polls, the probe Agent applied server-side, deleted `--wait=false`, and `wait --for=condition=Ready --timeout=240s` as `waitCondition`.
- **`models.go`** — the rendered ModelConfigs applied from the bytes `renderManifestWith` returns, the key Secret through `ensureSecret` (the key never touches argv or a file), pruning as a labelled list + bounded deletes, the Accepted poll through `conditionStatus` — `notReached`'s contract kept: a failed read surfaces the apiserver's message, never an empty status.
- **fixtures** — the fleet and OAuth manifests applied from the rendered bytes, stale members listed by label and deleted, the tool-group proof as a label-selector list across namespaces + a by-name read (NotFound = the existing "is missing" message), the fixture restart a merge patch.

A trap the first lab run found, fixed on main by #114 (the lifecycle half met it too; this PR carries no `kube.go` change after the rebase): the OAuth fixture — the first in-process apply of a kind the chart's CRDs introduce — failed with `no matches for kind "MCPServer"`. The RESTMapper's discovery cache is filled once per process, and client-go's deferred mapper retries a miss only while that cache is still empty (`memCacheClient.Fresh()` is "populated at all"), so a CRD the embedded Helm installs mid-run stayed unknown for the rest of the run; kubectl never meets this because every invocation starts with an empty cache. `restMapping`/`gvrFor` refresh discovery once on a no-match and look again.

New in the tests (`k8s.io/client-go` fakes, the recipe of `kube_test.go`; `newFakeLab` learned the MCPServer, ModelConfig, Agent and HelmRelease kinds): the can-i argument mapping and answers, the identity line, the rules filter and the impersonated review, the managed-fields read, the tool-group listing and the full `proveToolGroupLabels` on a seeded lab, the ModelConfig Accepted poll (met / never / read fails → apiserver's words), pruning, the key Secret, the HelmRelease toolset value, the Agent decode, the cleanup delete, the ModelConfig summary.

Measured (release recipe `CGO_ENABLED=0 go build -trimpath -ldflags '-s -w'`, 24 CPUs):

- stripped linux/amd64, base `268da13` (#114) → this branch: 77,971,616 B → 77,988,000 B (+16 KB)
- modules (`go list -m all | wc -l`): 559 → 559
- cold `go build .` (private `GOCACHE`, back to back on a quiet machine): 24.6 s → 23.8 s
- released `agentlab-linux-amd64` (v0.25.5): 78,598,306 B (v0.25.4: 78,586,018 B), cosign bundle attached — the tag pipeline's first `go-build` failed on the forms flake #116 (unrelated; the same commit passed on `main`) and was rerun from failed

Verified on an isolated lab (`agentlab-kube2`; `$L/bin` = `docker` and `kubectl` symlinks only — no kind, no helm; `env -i PATH=$L/bin /bin/sh -c 'command -v kind helm kubectl docker'` lists kubectl and docker alone; kubectl stays for the lifecycle files this PR does not touch):

- `configure --defaults` (a host Ollama and a Lemonade answered, so model-manager came on), `up` — the first run built the cluster, Dex, RBAC and the platform (6:03) and then failed on the OAuth fixture with the stale-mapper miss described above; with the refresh in place `up` over the running lab completed in 0:38 (fixtures Auth Required, Backstage up), and after `down` a fresh `up` with the final binary took 5:43 (343 s) — the mapper built before the chart's CRDs, the fixtures applied after the install, the refresh taken on the live apiserver (`managedFields` of the fixtures: `agentlab:Apply`).
- `test` 10/10 in 1 s — the identity lines unchanged (`oidc:admin@lab.local  ["oidc:platform-admins","oidc:developers","system:authenticated"]`), no `.kubeconfig.<user>` file written.
- `platform-test` 6/6 in 2 s (the tool-group step lists the six members by label selector and reports `agent-manager=agent-platform, mcp-kubernetes=infrastructure, model-manager=agent-platform` as chart-labelled).
- `agents-test` 4/4 in 12 s (`managedFields` read, the agent-manager log through `podLogs`, the ServiceAccount's rules review: nothing beyond discovery).
- `toolsets-test` 11/11 in 53 s (Agent CR reads, HelmRelease `values.toolset`, the legacy HelmRelease applied in-process, the tool-group map behind the shipped presets, the portal image `backstage:0.244.0`).
- `backstage-test` OK in 4 s; `models-test` 4/4 in 46 s (ollama: pull → ModelConfig `qwen2-5-0-5b` Accepted → agent turn "Pong!" → unload → delete; the ModelConfig summary line and the probe Agent's Ready wait on the new path).
- `down` 3 s; the whole set repeated on that fresh lab: test 10/10 (0 s), platform-test 6/6 (2 s), agents-test 4/4 (15 s), toolsets-test 11/11 (53 s), backstage-test OK (3 s), models-test 4/4 (45 s).
- After the rebase onto #114 (the two halves of step 3b merged; the fake-lab tables and the shared constants unified, the duplicate refresh fix dropped): `down`, a fresh `up` with the merged tree's binary 5:13 (313 s; all eleven MCPServers Auth Required — the lifecycle half's reads and this half's fixture applies in one process), then the whole set again: test 10/10 (1 s), platform-test 6/6 (1 s), agents-test 4/4 (12 s), toolsets-test 11/11 (77 s), backstage-test OK (3 s), models-test 4/4 (43 s), `down`.

The proofs are fast now because nothing forks: what used to be a `kubectl` process per question is one API call.


