### PR TITLE
refactor(kube): lifecycle and platform steps talk to the apiserver through client-go, not kubectl

### DIFF
--- a/internal/lab/adk.go
+++ b/internal/lab/adk.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,8 +10,14 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
 	"github.com/giantswarm/agentlab/internal/config"
 )
+
+// kagentControllerConfigMap is the controller's ConfigMap in the kagent
+// namespace; its IMAGE_REGISTRY and IMAGE_TAG compose the runtime image.
+const kagentControllerConfigMap = "kagent-controller"
 
 // healADKImages works around HACKS.md U8: kagent-controller composes the
 // runtime image for `runtime: go` agents from its own release tag —
@@ -28,15 +35,16 @@ import (
 // Only the go runtime is healed: the lab's create flow deploys the `agent`
 // chart, whose runtime defaults to (and stays) go.
 func healADKImages(cfg *config.Config) {
-	registry, err := outputQuiet("kubectl", "-n", "kagent", "get", "cm", "kagent-controller",
-		"-o", "jsonpath={.data.IMAGE_REGISTRY}")
-	if err != nil || registry == "" {
+	var registry, tag string
+	if cm, err := getObject(context.Background(), gvrConfigMaps, kagentNamespace, kagentControllerConfigMap); err == nil {
+		registry, _, _ = unstructured.NestedString(cm.Object, "data", "IMAGE_REGISTRY")
+		tag, _, _ = unstructured.NestedString(cm.Object, "data", "IMAGE_TAG")
+	}
+	if registry == "" {
 		note("cannot read kagent's IMAGE_REGISTRY; skipping the ADK image heal (HACKS.md U8)")
 		return
 	}
-	tag, err := outputQuiet("kubectl", "-n", "kagent", "get", "cm", "kagent-controller",
-		"-o", "jsonpath={.data.IMAGE_TAG}")
-	if err != nil || tag == "" {
+	if tag == "" {
 		note("cannot read kagent's IMAGE_TAG; skipping the ADK image heal (HACKS.md U8)")
 		return
 	}

--- a/internal/lab/anthropic.go
+++ b/internal/lab/anthropic.go
@@ -1,8 +1,10 @@
 package lab
 
 import (
-	"fmt"
+	"context"
 	"os"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // AnthropicKeyEnv is where the lab reads the Anthropic API key from at deploy
@@ -19,7 +21,8 @@ const AnthropicKeyEnv = "ANTHROPIC_API_KEY"
 // error: everything boots without the key, the AI features just stay
 // unconfigured until the secret exists.
 func ensureAnthropicSecret(ns, name string) (created bool, err error) {
-	if _, err := outputQuiet("kubectl", "-n", ns, "get", "secret", name); err == nil {
+	ctx := context.Background()
+	if exists, err := objectExists(ctx, gvrSecrets, ns, name); err == nil && exists {
 		note("secret %s/%s already exists, leaving it alone (delete it and re-run to rotate)", ns, name)
 		return false, nil
 	}
@@ -30,17 +33,9 @@ func ensureAnthropicSecret(ns, name string) (created bool, err error) {
 		note("  kubectl -n %s create secret generic %s --from-literal=%s=...", ns, name, AnthropicKeyEnv)
 		return false, nil
 	}
-	// Applied via stdin so the key never appears in a process's argv.
-	manifest := fmt.Sprintf(`apiVersion: v1
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-type: Opaque
-stringData:
-  %s: %q
-`, name, ns, AnthropicKeyEnv, key)
-	if err := pipeInto([]byte(manifest), "kubectl", "apply", "-f", "-"); err != nil {
+	// Applied in-process, so the key never appears in a process's argv or in
+	// a file.
+	if err := ensureSecret(ns, name, corev1.SecretTypeOpaque, map[string][]byte{AnthropicKeyEnv: []byte(key)}); err != nil {
 		return false, err
 	}
 	note("created secret %s/%s from $%s", ns, name, AnthropicKeyEnv)

--- a/internal/lab/down.go
+++ b/internal/lab/down.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -42,6 +43,20 @@ const (
 	platformUninstallTimeout   = 10 * time.Minute
 	legacyFluxUninstallTimeout = 5 * time.Minute
 	kpsUninstallTimeout        = 5 * time.Minute
+	// mcpPrometheusDeleteTimeout bounds the wait for helm-controller to
+	// uninstall the lab's mcp-prometheus release behind its HelmRelease.
+	mcpPrometheusDeleteTimeout = 3 * time.Minute
+	// namespaceDeleteTimeout bounds the wait for a namespace to be gone — its
+	// contents drained, their finalizers run — the wait `kubectl delete
+	// namespace` performs by default, which the CLI leaves unbounded.
+	namespaceDeleteTimeout = 5 * time.Minute
+)
+
+// The Flux resources the lab's own mcp-prometheus release consists of, as
+// kubectl's resource arguments (fully qualified: the group has dots).
+const (
+	fluxHelmReleaseResource   = "helmreleases.helm.toolkit.fluxcd.io"
+	fluxOCIRepositoryResource = "ocirepositories.source.toolkit.fluxcd.io"
 )
 
 // PlatformDown removes the agent platform and the observability releases,
@@ -60,12 +75,15 @@ func PlatformDown(cfg *config.Config) error {
 	if err := useClusterKubeconfig(cfg); err != nil {
 		return err
 	}
-	if _, err := outputQuiet("kubectl", "-n", platformNamespace, "get", "helmreleases.helm.toolkit.fluxcd.io", mcpPrometheusRelease); err == nil {
+	ctx := context.Background()
+	if mcpPrometheusReleaseExists(ctx) {
 		step("Uninstalling mcp-prometheus (its HelmRelease, while the engine still runs)")
-		_ = runQuiet("kubectl", "-n", platformNamespace, "delete", "helmreleases.helm.toolkit.fluxcd.io", mcpPrometheusRelease,
-			"--ignore-not-found", "--wait", "--timeout=3m")
-		_ = runQuiet("kubectl", "-n", platformNamespace, "delete", "ocirepositories.source.toolkit.fluxcd.io", mcpPrometheusRelease,
-			"--ignore-not-found")
+		if gvr, err := gvrFor(fluxHelmReleaseResource); err == nil {
+			_ = deleteObject(ctx, gvr, platformNamespace, mcpPrometheusRelease, mcpPrometheusDeleteTimeout)
+		}
+		if gvr, err := gvrFor(fluxOCIRepositoryResource); err == nil {
+			_ = deleteObject(ctx, gvr, platformNamespace, mcpPrometheusRelease, 0)
+		}
 	}
 	if helmReleaseExists(platformNamespace, platformRelease) {
 		step("Uninstalling the platform (the chart's ordered teardown: releases, then the engine)")
@@ -77,8 +95,8 @@ func PlatformDown(cfg *config.Config) error {
 		// Best-effort, unwaited: the namespace delete below takes the rest.
 		_ = helmUninstall(observabilityNamespace, kpsRelease, false, kpsUninstallTimeout)
 	}
-	_ = runQuiet("kubectl", "delete", "namespace", observabilityNamespace, "--ignore-not-found")
-	if err := run("kubectl", "delete", "namespace", platformNamespace, "--ignore-not-found"); err != nil {
+	_ = deleteNamespace(ctx, observabilityNamespace)
+	if err := deleteNamespace(ctx, platformNamespace); err != nil {
 		return err
 	}
 	// What an earlier agentlab installed next to the umbrella: its own Flux
@@ -92,9 +110,38 @@ func PlatformDown(cfg *config.Config) error {
 		if err := helmUninstall(legacyFluxNamespace, legacyFluxRelease, true, legacyFluxUninstallTimeout); err != nil {
 			return err
 		}
-		if err := run("kubectl", "delete", "namespace", legacyFluxNamespace, "--ignore-not-found"); err != nil {
+		if err := deleteNamespace(ctx, legacyFluxNamespace); err != nil {
 			return err
 		}
 	}
+	return nil
+}
+
+// mcpPrometheusReleaseExists reports whether the lab's mcp-prometheus
+// HelmRelease is on the cluster. A cluster without the Flux CRDs (no platform
+// was ever installed) has none, whatever the read said.
+func mcpPrometheusReleaseExists(ctx context.Context) bool {
+	gvr, err := gvrFor(fluxHelmReleaseResource)
+	if err != nil {
+		return false
+	}
+	exists, err := objectExists(ctx, gvr, platformNamespace, mcpPrometheusRelease)
+	return err == nil && exists
+}
+
+// deleteNamespace is `kubectl delete namespace <ns> --ignore-not-found`: a
+// namespace that is not there is success, and one that is gets deleted and
+// waited for — the CLI's default wait, bounded by namespaceDeleteTimeout —
+// so what follows (a reinstall, the next uninstall) meets no Terminating
+// namespace.
+func deleteNamespace(ctx context.Context, ns string) error {
+	exists, err := objectExists(ctx, gvrNamespaces, "", ns)
+	if err != nil || !exists {
+		return err
+	}
+	if err := deleteObject(ctx, gvrNamespaces, "", ns, namespaceDeleteTimeout); err != nil {
+		return err
+	}
+	note("namespace %s deleted", ns)
 	return nil
 }

--- a/internal/lab/down_test.go
+++ b/internal/lab/down_test.go
@@ -1,0 +1,43 @@
+package lab
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestDeleteNamespace: a namespace that is not there is success, one that is
+// gets deleted and waited for.
+func TestDeleteNamespace(t *testing.T) {
+	f := newFakeLab(t, &corev1.Namespace{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Namespace"},
+		ObjectMeta: metav1.ObjectMeta{Name: observabilityNamespace},
+	})
+	ctx := context.Background()
+	if err := deleteNamespace(ctx, "absent"); err != nil {
+		t.Errorf("a missing namespace must be success: %v", err)
+	}
+	if err := deleteNamespace(ctx, observabilityNamespace); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.dyn.Tracker().Get(gvrNamespaces, "", observabilityNamespace); !apierrors.IsNotFound(err) {
+		t.Errorf("namespace still stored after the delete: %v", err)
+	}
+}
+
+// TestMCPPrometheusReleaseExists: the lab's HelmRelease is found in the
+// platform namespace and not reported for a cluster without it.
+func TestMCPPrometheusReleaseExists(t *testing.T) {
+	ctx := context.Background()
+	newFakeLab(t)
+	if mcpPrometheusReleaseExists(ctx) {
+		t.Error("no HelmRelease, yet reported as existing")
+	}
+	newFakeLab(t, fakeHelmRelease(mcpPrometheusRelease, conditionTrue, "Helm install succeeded"))
+	if !mcpPrometheusReleaseExists(ctx) {
+		t.Error("the mcp-prometheus HelmRelease is there, yet not found")
+	}
+}

--- a/internal/lab/exec.go
+++ b/internal/lab/exec.go
@@ -73,27 +73,9 @@ func cmdError(name string, args []string, err error, stderr []byte) error {
 	return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
 }
 
-// run executes a command with output streamed to the terminal.
-func run(name string, args ...string) error {
-	cmd := command(name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
 // runQuiet executes a command, showing output only if it fails.
 func runQuiet(name string, args ...string) error {
 	return pipeInto(nil, name, args...)
-}
-
-// output captures a command's stdout (stderr goes to the terminal).
-func output(name string, args ...string) (string, error) {
-	var buf bytes.Buffer
-	cmd := command(name, args...)
-	cmd.Stdout = &buf
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	return buf.String(), err
 }
 
 // outputQuiet captures stdout and keeps stderr off the terminal; for
@@ -110,17 +92,6 @@ func outputQuiet(name string, args ...string) (string, error) {
 		return stdout.String(), cmdError(name, args, err, stderr.Bytes())
 	}
 	return stdout.String(), nil
-}
-
-// outputAll captures stdout AND stderr together, for probe-style commands
-// whose diagnosis is in the error text (a probe pod's wget message).
-func outputAll(name string, args ...string) (string, error) {
-	var buf bytes.Buffer
-	cmd := command(name, args...)
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	err := cmd.Run()
-	return buf.String(), err
 }
 
 // pipeInto feeds input to a command's stdin, showing output only on failure.

--- a/internal/lab/kagentcrd.go
+++ b/internal/lab/kagentcrd.go
@@ -1,9 +1,20 @@
 package lab
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
+
+// agentCRD names kagent's Agent CustomResourceDefinition.
+const agentCRD = "agents.kagent.dev"
+
+// agentCRDVersion is the served version whose schema the create flow's
+// objects are validated against.
+const agentCRDVersion = "v1alpha2"
 
 // patchAgentCRDIconURL works around HACKS.md U11: the kagent package pins the
 // upstream 0.9.x CRDs, whose v1alpha2 Agent spec predates the A2A-card
@@ -19,37 +30,48 @@ import (
 // it) to the installed CRD. Idempotent: a no-op once the field is present, so
 // a kagent bump that carries it retires this silently.
 func patchAgentCRDIconURL() error {
-	const crd = "agents.kagent.dev"
-	present, err := outputQuiet("kubectl", "get", "crd", crd, "-o",
-		`jsonpath={.spec.versions[?(@.name=="v1alpha2")].schema.openAPIV3Schema.properties.spec.properties.iconUrl}`)
+	ctx := context.Background()
+	crd, err := getObject(ctx, gvrCRDs, "", agentCRD)
 	if err != nil {
-		return fmt.Errorf("reading the %s CRD: %w", crd, err)
+		return fmt.Errorf("reading the %s CRD: %w", agentCRD, err)
 	}
-	if strings.TrimSpace(present) != "" {
+	idx, present, names := agentCRDIconURL(crd)
+	if present {
 		note("Agent CRD already declares spec.iconUrl; the patch retired (HACKS.md U11)")
 		return nil
 	}
-	names, err := outputQuiet("kubectl", "get", "crd", crd, "-o",
-		`jsonpath={range .spec.versions[*]}{.name}{"\n"}{end}`)
-	if err != nil {
-		return fmt.Errorf("listing the %s CRD versions: %w", crd, err)
-	}
-	idx := -1
-	for i, name := range strings.Split(strings.TrimSpace(names), "\n") {
-		if name == "v1alpha2" {
-			idx = i
-			break
-		}
-	}
 	if idx < 0 {
-		return fmt.Errorf("the %s CRD serves no v1alpha2 (versions: %q)", crd, strings.TrimSpace(names))
+		return fmt.Errorf("the %s CRD serves no %s (versions: %q)", agentCRD, agentCRDVersion, strings.Join(names, "\n"))
 	}
 	patch := fmt.Sprintf(`[{"op":"add","path":"/spec/versions/%d/schema/openAPIV3Schema/properties/spec/properties/iconUrl",`+
 		`"value":{"description":"IconURL is a URL to an icon representing the agent. It is surfaced on the agent's A2A AgentCard.",`+
 		`"format":"uri","type":"string"}}]`, idx)
-	if err := runQuiet("kubectl", "patch", "crd", crd, "--type=json", "-p", patch); err != nil {
-		return fmt.Errorf("patching %s with spec.iconUrl: %w", crd, err)
+	if err := patchObject(ctx, gvrCRDs, "", agentCRD, types.JSONPatchType, []byte(patch)); err != nil {
+		return fmt.Errorf("patching %s with spec.iconUrl: %w", agentCRD, err)
 	}
 	note("Agent CRD patched with spec.iconUrl (until giantswarm/kagent#55)")
 	return nil
+}
+
+// agentCRDIconURL reads the Agent CRD's spec.versions: the index of the
+// version the create flow targets (-1 when it is not served), whether that
+// version's schema already declares spec.iconUrl, and the version names as
+// listed (for the error that names them).
+func agentCRDIconURL(crd *unstructured.Unstructured) (idx int, present bool, names []string) {
+	idx = -1
+	versions, _, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	for i, v := range versions {
+		m, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _, _ := unstructured.NestedString(m, "name")
+		names = append(names, name)
+		if name != agentCRDVersion {
+			continue
+		}
+		idx = i
+		_, present, _ = unstructured.NestedFieldNoCopy(m, "schema", "openAPIV3Schema", "properties", "spec", "properties", "iconUrl")
+	}
+	return idx, present, names
 }

--- a/internal/lab/kagentcrd_test.go
+++ b/internal/lab/kagentcrd_test.go
@@ -1,0 +1,68 @@
+package lab
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// fakeAgentCRD is kagent's Agent CRD with the given served versions, each
+// with an empty spec schema (or the given extra spec properties).
+func fakeAgentCRD(versions ...string) *unstructured.Unstructured {
+	var vs []any
+	for _, v := range versions {
+		vs = append(vs, map[string]any{
+			nameKey:  v,
+			"served": true,
+			"schema": map[string]any{"openAPIV3Schema": map[string]any{"properties": map[string]any{
+				"spec": map[string]any{"properties": map[string]any{
+					"description": map[string]any{fieldType: "string"},
+				}},
+			}}},
+		})
+	}
+	return &unstructured.Unstructured{Object: map[string]any{
+		fieldAPIVersion: gvkCRD.GroupVersion().String(),
+		fieldKind:       gvkCRD.Kind,
+		fieldMetadata:   map[string]any{nameKey: agentCRD},
+		"spec":          map[string]any{"group": "kagent.dev", "versions": vs},
+	}}
+}
+
+// TestPatchAgentCRDIconURL: the 0.9.x CRD gets spec.iconUrl added to its
+// v1alpha2 schema by index (the other version untouched), a second run finds
+// it and patches nothing, a CRD without v1alpha2 is refused by name, and a
+// missing CRD fails with the read.
+func TestPatchAgentCRDIconURL(t *testing.T) {
+	f := newFakeLab(t, fakeAgentCRD("v1alpha1", "v1alpha2"))
+	if err := patchAgentCRDIconURL(); err != nil {
+		t.Fatal(err)
+	}
+	versions, _, _ := unstructured.NestedSlice(f.stored(t, gvrCRDs, "", agentCRD).Object, "spec", "versions")
+	iconURL := func(i int) map[string]any {
+		m, _, _ := unstructured.NestedMap(versions[i].(map[string]any), "schema", "openAPIV3Schema", "properties", "spec", "properties", "iconUrl")
+		return m
+	}
+	if got := iconURL(1); got[fieldType] != "string" || got["format"] != "uri" {
+		t.Errorf("v1alpha2 spec.iconUrl = %v, want an optional uri string", got)
+	}
+	if got := iconURL(0); got != nil {
+		t.Errorf("v1alpha1 was patched too: %v", got)
+	}
+	if err := patchAgentCRDIconURL(); err != nil {
+		t.Fatal(err)
+	}
+	if n := f.patchCount(gvrCRDs); n != 1 {
+		t.Errorf("CRD patched %d times, want 1 (the second run finds the field)", n)
+	}
+
+	newFakeLab(t, fakeAgentCRD("v1alpha1"))
+	if err := patchAgentCRDIconURL(); err == nil || !strings.Contains(err.Error(), "serves no v1alpha2") {
+		t.Errorf("a CRD without v1alpha2: %v", err)
+	}
+	newFakeLab(t)
+	if err := patchAgentCRDIconURL(); err == nil || !strings.Contains(err.Error(), "reading the agents.kagent.dev CRD") {
+		t.Errorf("a missing CRD: %v", err)
+	}
+}

--- a/internal/lab/kube.go
+++ b/internal/lab/kube.go
@@ -227,7 +227,10 @@ func describe(gvr schema.GroupVersionResource, ns, name string) string {
 // "crd", "helmreleases.helm.toolkit.fluxcd.io" — to the GVR the apiserver
 // serves it under, preferred version first, through discovery. A fully
 // qualified name is tried as resource.version.group before resource.group,
-// as kubectl does, so a group with dots in it resolves.
+// as kubectl does, so a group with dots in it resolves. A miss resets the
+// cached discovery once and retries (kubectl invalidates its cache the same
+// way): the kinds a Helm install registers — a HelmRelease, an MCPServer, a
+// Prometheus — are asked for after the cache was primed by an earlier call.
 func gvrFor(resourceArg string) (schema.GroupVersionResource, error) {
 	k, err := labKube()
 	if err != nil {
@@ -237,6 +240,20 @@ func gvrFor(resourceArg string) (schema.GroupVersionResource, error) {
 }
 
 func (k *kubeClients) gvrFor(resourceArg string) (schema.GroupVersionResource, error) {
+	gvr, err := k.resourcesFor(resourceArg)
+	if err != nil {
+		k.resetMapper()
+		gvr, err = k.resourcesFor(resourceArg)
+	}
+	if err != nil {
+		return schema.GroupVersionResource{}, fmt.Errorf("the apiserver serves no resource %q: %w", resourceArg, err)
+	}
+	return gvr, nil
+}
+
+// resourcesFor is one lookup of a resource argument against the mapper as it
+// is cached now.
+func (k *kubeClients) resourcesFor(resourceArg string) (schema.GroupVersionResource, error) {
 	fully, gr := schema.ParseResourceArg(resourceArg)
 	if fully != nil {
 		if gvrs, err := k.mapper.ResourcesFor(*fully); err == nil && len(gvrs) > 0 {
@@ -245,9 +262,21 @@ func (k *kubeClients) gvrFor(resourceArg string) (schema.GroupVersionResource, e
 	}
 	gvrs, err := k.mapper.ResourcesFor(gr.WithVersion(""))
 	if err != nil {
-		return schema.GroupVersionResource{}, fmt.Errorf("the apiserver serves no resource %q: %w", resourceArg, err)
+		return schema.GroupVersionResource{}, err
 	}
 	return gvrs[0], nil
+}
+
+// restMapping resolves a kind to its resource and scope, resetting the cached
+// discovery once on a miss (see gvrFor): a custom resource is applied after
+// the chart that brought its CRD was installed, with the cache primed before.
+func (k *kubeClients) restMapping(gk schema.GroupKind, version string) (*meta.RESTMapping, error) {
+	mapping, err := k.mapper.RESTMapping(gk, version)
+	if err != nil {
+		k.resetMapper()
+		mapping, err = k.mapper.RESTMapping(gk, version)
+	}
+	return mapping, err
 }
 
 // applyResult is what one server-side apply did: the object, and whether it
@@ -374,7 +403,7 @@ func (k *kubeClients) apply(ctx context.Context, obj *unstructured.Unstructured)
 	if res.name == "" {
 		return res, fmt.Errorf("%s has no metadata.name", gvk.Kind)
 	}
-	mapping, err := k.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	mapping, err := k.restMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return res, fmt.Errorf("%s %s: %w (ensure the CRDs are installed first)", gvk.Kind, res.name, err)
 	}

--- a/internal/lab/kube_test.go
+++ b/internal/lab/kube_test.go
@@ -55,14 +55,31 @@ const (
 	fieldType      = "type"
 	condReady      = "Ready"
 	condFalse      = "False"
-	verbGet        = "get"
-	verbList       = "list"
-	verbCreate     = "create"
+	// The keys of an unstructured object the tests build by hand, and
+	// helm-controller's message for a release it gave up on.
+	fieldAPIVersion  = "apiVersion"
+	fieldKind        = "kind"
+	fieldMetadata    = "metadata"
+	fieldMessage     = "message"
+	fieldNamespace   = "namespace"
+	retriesExhausted = "install retries exhausted"
+	verbGet          = "get"
+	verbList         = "list"
+	verbCreate       = "create"
 )
 
 var (
 	widgetGVK = schema.GroupVersionKind{Group: widgetGroup, Version: "v1", Kind: widgetKind}
 	widgetGVR = schema.GroupVersionResource{Group: widgetGroup, Version: "v1", Resource: "widgets"}
+	// The custom kinds the lab reads through gvrFor, as the fake apiserver
+	// serves them: Flux's HelmRelease, muster's MCPServer, the operator's
+	// Prometheus.
+	fluxHelmReleaseGVK = schema.GroupVersionKind{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"}
+	fluxHelmReleaseGVR = fluxHelmReleaseGVK.GroupVersion().WithResource("helmreleases")
+	musterMCPServerGVK = schema.GroupVersionKind{Group: "muster.giantswarm.io", Version: "v1alpha1", Kind: "MCPServer"}
+	musterMCPServerGVR = musterMCPServerGVK.GroupVersion().WithResource("mcpservers")
+	prometheusGVK      = schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "Prometheus"}
+	prometheusGVR      = prometheusGVK.GroupVersion().WithResource("prometheuses")
 )
 
 // fakeLab is a kubeClients bundle on fakes, installed as the lab's client for
@@ -137,8 +154,11 @@ func newFakeLab(t *testing.T, objects ...runtime.Object) *fakeLab {
 		}
 	}
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(usch, map[schema.GroupVersionResource]string{
-		gvrCRDs:   "CustomResourceDefinitionList",
-		widgetGVR: "WidgetList",
+		gvrCRDs:            "CustomResourceDefinitionList",
+		widgetGVR:          "WidgetList",
+		fluxHelmReleaseGVR: "HelmReleaseList",
+		musterMCPServerGVR: "MCPServerList",
+		prometheusGVR:      "PrometheusList",
 	}, seeds...)
 	dyn.PrependReactor("patch", "*", fakeApply(dyn.Tracker()))
 
@@ -155,6 +175,9 @@ func newFakeLab(t *testing.T, objects ...runtime.Object) *fakeLab {
 		corev1.SchemeGroupVersion.WithKind("ConfigMap"),
 		corev1.SchemeGroupVersion.WithKind("Pod"),
 		appsv1.SchemeGroupVersion.WithKind(kindDeployment),
+		fluxHelmReleaseGVK,
+		musterMCPServerGVK,
+		prometheusGVK,
 	} {
 		mapper.Add(gvk, meta.RESTScopeNamespace)
 	}
@@ -433,8 +456,51 @@ spec:
 			t.Errorf("unknown-kind error %q lacks %q", err, want)
 		}
 	}
-	if f2.resets != 0 {
-		t.Errorf("no CRD in the batch, yet the mapper was reset %d times", f2.resets)
+	if f2.resets != 1 {
+		t.Errorf("the mapper was reset %d times for an unknown kind, want 1 (the miss's one retry; no CRD in the batch to wait for)", f2.resets)
+	}
+}
+
+// TestMapperMissResetsOnce: a resource or kind the cached discovery does not
+// know — the CRD arrived after the cache was primed, as the kinds a Helm
+// install brings do — resets the cache once and resolves on the retry, for
+// gvrFor and for an apply alike; a kind nobody serves costs one reset and
+// fails as before.
+func TestMapperMissResetsOnce(t *testing.T) {
+	f := newFakeLab(t)
+	f.onReset = func(f *fakeLab) { f.mapper.Add(widgetGVK, meta.RESTScopeNamespace) }
+	gvr, err := gvrFor("widgets.example.com")
+	if err != nil || gvr != widgetGVR {
+		t.Fatalf("gvrFor after the CRD arrived = %v, %v; want %v", gvr, err, widgetGVR)
+	}
+	if f.resets != 1 {
+		t.Errorf("mapper reset %d times, want 1 (the miss)", f.resets)
+	}
+	if _, err := gvrFor("widgets.example.com"); err != nil || f.resets != 1 {
+		t.Errorf("a known resource must resolve from the cache: %v, resets %d", err, f.resets)
+	}
+
+	f2 := newFakeLab(t)
+	f2.onReset = func(f *fakeLab) { f.mapper.Add(widgetGVK, meta.RESTScopeNamespace) }
+	results, err := applyManifests(context.Background(), []byte(`apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: w
+  namespace: demo
+`))
+	if err != nil || len(results) != 1 || !results[0].changed {
+		t.Fatalf("applying a kind the cache learns on reset: %+v, %v", results, err)
+	}
+	if f2.resets != 1 {
+		t.Errorf("mapper reset %d times for the apply, want 1", f2.resets)
+	}
+
+	f3 := newFakeLab(t)
+	if _, err := gvrFor("gadgets.example.com"); err == nil || !strings.Contains(err.Error(), `serves no resource "gadgets.example.com"`) {
+		t.Errorf("an unserved resource: %v", err)
+	}
+	if f3.resets != 1 {
+		t.Errorf("mapper reset %d times for an unserved resource, want 1", f3.resets)
 	}
 }
 
@@ -657,13 +723,13 @@ func TestConditions(t *testing.T) {
 	obj := &unstructured.Unstructured{Object: map[string]any{
 		fieldStatus: map[string]any{"conditions": []any{
 			map[string]any{fieldType: "Reconciling", fieldStatus: "Unknown"},
-			map[string]any{fieldType: condReady, fieldStatus: condFalse, "message": "install retries exhausted"},
+			map[string]any{fieldType: condReady, fieldStatus: condFalse, fieldMessage: retriesExhausted},
 		}},
 	}}
 	if s := conditionStatus(obj, condReady); s != condFalse {
 		t.Errorf("Ready status = %q", s)
 	}
-	if m := conditionMessage(obj, condReady); m != "install retries exhausted" {
+	if m := conditionMessage(obj, condReady); m != retriesExhausted {
 		t.Errorf("Ready message = %q", m)
 	}
 	if s, m := conditionStatus(obj, "Healthy"), conditionMessage(obj, "Healthy"); s != "" || m != "" {
@@ -685,7 +751,7 @@ func TestWaitCondition(t *testing.T) {
 	_ = unstructured.SetNestedSlice(ready.Object, []any{map[string]any{fieldType: condReady, fieldStatus: "True"}}, fieldStatus, "conditions")
 	notReady := ready.DeepCopy()
 	notReady.SetName("nope")
-	_ = unstructured.SetNestedSlice(notReady.Object, []any{map[string]any{fieldType: condReady, fieldStatus: condFalse, "message": "waiting on the model"}}, fieldStatus, "conditions")
+	_ = unstructured.SetNestedSlice(notReady.Object, []any{map[string]any{fieldType: condReady, fieldStatus: condFalse, fieldMessage: "waiting on the model"}}, fieldStatus, "conditions")
 	newFakeLab(t, ready, notReady)
 	ctx := context.Background()
 	if err := waitCondition(ctx, gvrConfigMaps, testNS, "ok", condReady, "True", time.Second); err != nil {
@@ -720,7 +786,7 @@ func TestGvrFor(t *testing.T) {
 			t.Errorf("gvrFor(%q) = %v, %v; want %v", arg, got, err, want)
 		}
 	}
-	if _, err := gvrFor("helmreleases.helm.toolkit.fluxcd.io"); err == nil || !strings.Contains(err.Error(), "helmreleases.helm.toolkit.fluxcd.io") {
+	if _, err := gvrFor("kustomizations.kustomize.toolkit.fluxcd.io"); err == nil || !strings.Contains(err.Error(), "kustomizations.kustomize.toolkit.fluxcd.io") {
 		t.Errorf("an unserved resource must fail by name, got %v", err)
 	}
 }

--- a/internal/lab/logs.go
+++ b/internal/lab/logs.go
@@ -1,40 +1,54 @@
 package lab
 
 import (
+	"context"
 	"fmt"
 	"maps"
+	"os"
+	"os/signal"
 	"slices"
 	"strings"
+	"syscall"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
 
-// logCmd is the kubectl subcommand every log target shares.
-const logCmd = "logs"
+// componentPrometheus is the lab Prometheus as a log component.
+const componentPrometheus = "prometheus"
 
-// logTargets maps each component to its `kubectl logs -f` args; the table also
-// feeds cobra's ValidArgs via LogComponents, so dispatch and completion cannot
+// logTarget is where a component's logs come from: its namespace and the
+// target streamLogs resolves to pods — a `deploy/<name>` or a label selector.
+type logTarget struct {
+	namespace, target string
+}
+
+// logTargets maps each component to its log target; the table also feeds
+// cobra's ValidArgs via LogComponents, so dispatch and completion cannot
 // drift.
-var logTargets = map[string][]string{
-	componentDex:     {"-n", componentDex, logCmd, "-l", "app=dex", "-f"},
-	componentMuster:  {"-n", platformNamespace, logCmd, "-l", "app.kubernetes.io/name=muster", "-f"},
-	"backstage":      {"-n", platformNamespace, logCmd, "-f", "deploy/backstage"},
-	"prometheus":     {"-n", observabilityNamespace, logCmd, "-l", "app.kubernetes.io/name=prometheus", "-f"},
-	"mcp-prometheus": {"-n", observabilityNamespace, logCmd, "-f", "deploy/" + mcpPrometheusRelease},
+var logTargets = map[string]logTarget{
+	componentDex:         {componentDex, "app=dex"},
+	componentMuster:      {platformNamespace, "app.kubernetes.io/name=muster"},
+	componentBackstage:   {platformNamespace, "deploy/" + componentBackstage},
+	componentPrometheus:  {observabilityNamespace, "app.kubernetes.io/name=prometheus"},
+	mcpPrometheusRelease: {observabilityNamespace, "deploy/" + mcpPrometheusRelease},
 }
 
 // LogComponents lists what Logs accepts, for cobra's ValidArgs.
 func LogComponents() []string { return slices.Sorted(maps.Keys(logTargets)) }
 
-// Logs tails the given component's logs (kubectl logs -f passthrough, against
-// the lab cluster whatever the shell's kubeconfig says).
+// Logs tails the given component's logs (`kubectl logs -f` of its pods,
+// through the embedded client against the lab cluster whatever the shell's
+// kubeconfig says) until every stream ends or the user interrupts with
+// Ctrl-C, which ends the command cleanly.
 func Logs(cfg *config.Config, component string) error {
-	args, ok := logTargets[component]
+	target, ok := logTargets[component]
 	if !ok {
 		return fmt.Errorf("unknown component %q (%s)", component, strings.Join(LogComponents(), ", "))
 	}
 	if err := useClusterKubeconfig(cfg); err != nil {
 		return err
 	}
-	return run("kubectl", args...)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return streamLogs(ctx, target.namespace, target.target, os.Stdout)
 }

--- a/internal/lab/logs_test.go
+++ b/internal/lab/logs_test.go
@@ -1,0 +1,54 @@
+package lab
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestLogTargets: every component's target resolves to pods through the
+// embedded client — the label selectors and the deploy/ targets alike — and
+// the table is what cobra completes.
+func TestLogTargets(t *testing.T) {
+	f := newFakeLab(t)
+	ctx := context.Background()
+	for component, lt := range logTargets {
+		labels := map[string]string{}
+		if name, ok := strings.CutPrefix(lt.target, "deploy/"); ok {
+			labels[appLabel] = name
+			err := f.cs.Tracker().Add(&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: lt.namespace},
+				Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: labels}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			k, v, _ := strings.Cut(lt.target, "=")
+			labels[k] = v
+		}
+		err := f.cs.Tracker().Add(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: component + "-0", Namespace: lt.namespace, Labels: labels},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: component}}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var b strings.Builder
+		if err := streamLogs(ctx, lt.namespace, lt.target, &b); err != nil {
+			t.Errorf("%s (%s in %s): %v", component, lt.target, lt.namespace, err)
+			continue
+		}
+		if !strings.Contains(b.String(), fakeLogLine) {
+			t.Errorf("%s: streamed %q", component, b.String())
+		}
+	}
+	if got, want := LogComponents(), []string{componentBackstage, componentDex, mcpPrometheusRelease, componentMuster, componentPrometheus}; !slices.Equal(got, want) {
+		t.Errorf("LogComponents = %v, want %v", got, want)
+	}
+}

--- a/internal/lab/modelmanager.go
+++ b/internal/lab/modelmanager.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -38,6 +39,10 @@ const kindDockerNetwork = "kind"
 // alpine image the umbrella already ships elsewhere (small, present in the
 // host cache after the first run, side-loaded before the probe pod).
 const probeImage = "gsoci.azurecr.io/giantswarm/alpine:3.22.1"
+
+// probePodTimeout bounds the reachability probe: the pod scheduled, its image
+// present (side-loaded first), wget's own five-second timeout inside.
+const probePodTimeout = 120 * time.Second
 
 // The version-answering paths of the servers: Ollama's whole document is
 // {"version":"..."}, Lemonade's health document carries a version field.
@@ -181,16 +186,14 @@ func preflightHostServer(cfg *config.Config, backend, endpoint string) error {
 	// the kubelet's pull under the pod-running timeout).
 	sideloadImages(cfg, hostPullImages([]string{probeImage}))
 	pod := backend + "-preflight"
-	// A leftover from an interrupted run would make `kubectl run` refuse.
-	_ = runQuiet("kubectl", "-n", platformNamespace, "delete", "pod", pod, "--ignore-not-found", "--wait=false")
-	out, err := outputAll("kubectl", "-n", platformNamespace, "run", pod,
-		"--rm", "-i", "--quiet", "--restart=Never", "--pod-running-timeout=120s",
-		"--image="+probeImage, "--image-pull-policy=IfNotPresent",
-		"--command", "--", "wget", "-qO-", "-T", "5", endpoint+healthPath(backend))
+	// One probe pod running wget (a leftover of the same name from an
+	// interrupted run is removed first); its output is the container's log,
+	// wget's error message included.
+	out, err := runProbePod(context.Background(), platformNamespace, pod, probeImage,
+		[]string{"wget", "-qO-", "-T", "5", endpoint + healthPath(backend)}, probePodTimeout)
 	if err == nil && strings.Contains(out, `"version"`) {
-		// The combined output also carries kubectl's own attach chatter
-		// ("warning: couldn't attach to pod ..., falling back to logs"), so
-		// pick the version field out of it.
+		// The health document may carry more than the version (Lemonade's
+		// does), so pick the version field out of it.
 		version := strings.TrimSpace(out)
 		if m := versionFieldRe.FindString(out); m != "" {
 			version = m

--- a/internal/lab/modelmanager_test.go
+++ b/internal/lab/modelmanager_test.go
@@ -2,12 +2,12 @@ package lab
 
 import "testing"
 
-// The preflight picks the version field out of kubectl's combined output for
-// both servers' documents: Ollama's {"version":...} and Lemonade's health
-// document, where version is one field among many.
+// The preflight picks the version field out of the probe pod's output for
+// both servers' documents: Ollama's {"version":...} alone and Lemonade's
+// health document, where version is one field among many.
 func TestVersionFieldRe(t *testing.T) {
 	cases := map[string]string{
-		"{\"version\":\"0.33.2\"}warning: couldn't attach to pod/ollama-preflight, falling back to streaming logs":      `"version":"0.33.2"`,
+		`{"version":"0.33.2"}`: `"version":"0.33.2"`,
 		`{"all_models_loaded":[],"status":"ok","telemetry":{"enabled":false},"version":"11.9.0","websocket_port":9000}`: `"version":"11.9.0"`,
 	}
 	for in, want := range cases {

--- a/internal/lab/observability.go
+++ b/internal/lab/observability.go
@@ -1,10 +1,12 @@
 package lab
 
 import (
+	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -41,6 +43,11 @@ const (
 	mcpPrometheusRelease = "mcp-prometheus"
 )
 
+// prometheusResource is the operator's Prometheus CR as kubectl's resource
+// argument — fully qualified on principle (same reason as mcpservers): other
+// charts may ship colliding kinds.
+const prometheusResource = "prometheuses.monitoring.coreos.com"
+
 // observabilityUp installs the lab Prometheus: the GS kube-prometheus-stack
 // (operator + CRDs + kube-state-metrics + node-exporter + a Prometheus
 // scraping kubelet/cAdvisor) and the edge route Backstage queries it through.
@@ -49,6 +56,7 @@ const (
 // ServiceMonitors need the operator. The MCP server for it (mcp-prometheus)
 // follows the platform — see mcpPrometheusUp.
 func observabilityUp(cfg *config.Config) error {
+	ctx := context.Background()
 	step("Installing the observability stack (kube-prometheus-stack %s)", kpsChartVersion)
 	if err := installOCIChart(cfg, kpsRelease,
 		"oci://gsoci.azurecr.io/charts/giantswarm/kube-prometheus-stack",
@@ -77,16 +85,12 @@ func observabilityUp(cfg *config.Config) error {
 	var replicas string
 	var readErr error
 	up := waitFor(40, 3*time.Second, func() bool {
-		// Fully qualified on principle (same reason as mcpservers): other
-		// charts may ship colliding kinds.
-		replicas, readErr = outputQuiet("kubectl", "-n", observabilityNamespace,
-			"get", "prometheuses.monitoring.coreos.com",
-			"-o", "jsonpath={.items[0].status.availableReplicas}")
-		n, err := strconv.Atoi(strings.TrimSpace(replicas))
+		replicas, readErr = prometheusAvailableReplicas(ctx)
+		n, err := strconv.Atoi(replicas)
 		return readErr == nil && err == nil && n >= 1
 	})
 	if !up {
-		return notReached("the Prometheus CR", "an available replica after the install", strings.TrimSpace(replicas), readErr,
+		return notReached("the Prometheus CR", "an available replica after the install", replicas, readErr,
 			fmt.Sprintf("check `kubectl -n %s get prometheus,statefulset,pods`", observabilityNamespace))
 	}
 	note("Prometheus is serving (PromQL inside the cluster: http://prometheus-operated.%s:9090)",
@@ -96,14 +100,36 @@ func observabilityUp(cfg *config.Config) error {
 	// (observability-route.yaml.tmpl); paired with the mimirEnabled override
 	// in backstage-catalog.yaml.tmpl. Applied regardless of Backstage so the
 	// endpoint is also there for humans and platform-test.
-	if _, routePath, err := renderManifest(cfg, "observability-route.yaml.tmpl"); err != nil {
+	if route, _, err := renderManifest(cfg, "observability-route.yaml.tmpl"); err != nil {
 		return err
-	} else if err := runQuiet("kubectl", "apply", "-f", routePath); err != nil {
+	} else if _, err := applyManifests(ctx, route); err != nil {
 		return err
 	}
 	note("PromQL on the edge: %s/api/v1/query (what Backstage's Deployments/Clusters metrics use)",
 		cfg.ObservabilityBaseURL())
 	return nil
+}
+
+// prometheusAvailableReplicas is `{.items[0].status.availableReplicas}` of
+// the Prometheus CRs in the observability namespace: "" while the operator
+// has not reported any, an error when there is no CR — or no CRD — to read.
+func prometheusAvailableReplicas(ctx context.Context) (string, error) {
+	gvr, err := gvrFor(prometheusResource)
+	if err != nil {
+		return "", err
+	}
+	items, err := listObjects(ctx, gvr, observabilityNamespace, "")
+	if err != nil {
+		return "", err
+	}
+	if len(items) == 0 {
+		return "", fmt.Errorf("no %s in %s yet", prometheusResource, observabilityNamespace)
+	}
+	n, found, err := unstructured.NestedInt64(items[0].Object, "status", "availableReplicas")
+	if err != nil || !found {
+		return "", nil
+	}
+	return strconv.FormatInt(n, 10), nil
 }
 
 // mcpPrometheusTemplate renders the lab's mcp-prometheus release: a Flux
@@ -122,11 +148,11 @@ const mcpPrometheusTemplate = "mcp-prometheus.yaml.tmpl"
 // CRDs and the tenant ServiceAccount come with the chart.
 func mcpPrometheusUp(cfg *config.Config) error {
 	step("Installing mcp-prometheus %s through the platform's engine", mcpPrometheusChartVersion)
-	_, path, err := renderManifest(cfg, mcpPrometheusTemplate)
+	manifest, _, err := renderManifest(cfg, mcpPrometheusTemplate)
 	if err != nil {
 		return err
 	}
-	if err := runQuiet("kubectl", "apply", "-f", path); err != nil {
+	if _, err := applyManifests(context.Background(), manifest); err != nil {
 		return err
 	}
 	var status platformReleaseStatus
@@ -144,7 +170,7 @@ func mcpPrometheusUp(cfg *config.Config) error {
 		return false
 	})
 	if !ready {
-		return notReached("HelmRelease "+mcpPrometheusRelease, "Ready", status.ready, fmt.Errorf("%s", status.message),
+		return notReached("HelmRelease "+mcpPrometheusRelease, conditionReady, status.ready, fmt.Errorf("%s", status.message),
 			fmt.Sprintf("check `kubectl -n %s describe helmrelease %s` and `kubectl -n %s get pods`", platformNamespace, mcpPrometheusRelease, observabilityNamespace))
 	}
 	return nil

--- a/internal/lab/observability_test.go
+++ b/internal/lab/observability_test.go
@@ -1,0 +1,39 @@
+package lab
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// TestPrometheusAvailableReplicas reads the operator's verdict off the
+// Prometheus CR: no CR yet is an error naming it, a CR without the field is
+// "" (no verdict), a CR with the field its count.
+func TestPrometheusAvailableReplicas(t *testing.T) {
+	ctx := context.Background()
+	newFakeLab(t)
+	if _, err := prometheusAvailableReplicas(ctx); err == nil || !strings.Contains(err.Error(), "no prometheuses.monitoring.coreos.com in monitoring yet") {
+		t.Errorf("no CR: %v", err)
+	}
+	prometheus := func(status map[string]any) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			fieldAPIVersion: prometheusGVK.GroupVersion().String(),
+			fieldKind:       prometheusGVK.Kind,
+			fieldMetadata:   map[string]any{nameKey: kpsRelease + "-prometheus", fieldNamespace: observabilityNamespace},
+		}}
+		if status != nil {
+			u.Object[fieldStatus] = status
+		}
+		return u
+	}
+	newFakeLab(t, prometheus(nil))
+	if got, err := prometheusAvailableReplicas(ctx); err != nil || got != "" {
+		t.Errorf("CR without a status: %q, %v; want \"\"", got, err)
+	}
+	newFakeLab(t, prometheus(map[string]any{"availableReplicas": int64(1)}))
+	if got, err := prometheusAvailableReplicas(ctx); err != nil || got != "1" {
+		t.Errorf("CR with one available replica: %q, %v", got, err)
+	}
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
@@ -10,6 +11,11 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -32,8 +38,35 @@ const (
 	componentMCPKubernetes = "mcp-kubernetes"
 )
 
-// conditionTrue is a Kubernetes condition's status when it holds.
-const conditionTrue = "True"
+// A Kubernetes object's Ready condition, and a condition's status when it
+// holds.
+const (
+	conditionReady = "Ready"
+	conditionTrue  = "True"
+)
+
+// The platform's generated secrets (platformSecretsName): created once and
+// then left alone — regenerating the encryption key on every run would
+// invalidate every issued token. dex-client-secret must match the
+// `agent-platform` staticClient in the Dex config.
+const (
+	platformSecretsName       = "agent-platform-secrets"
+	backstageSessionSecretKey = "backstage-session-secret"
+)
+
+// The CoreDNS Deployment the Corefile rewrite rolls, in kube-system.
+const (
+	kubeSystemNamespace = "kube-system"
+	corednsDeployment   = "coredns"
+)
+
+// musterMCPServerResource is muster's MCPServer as kubectl's resource
+// argument, fully qualified because kagent ships an MCPServer CRD of its own
+// (mcpservers.kagent.dev): the bare kind resolves to the wrong API group.
+const musterMCPServerResource = "mcpservers.muster.giantswarm.io"
+
+// musterRestartTimeout bounds the rollout of a muster pod the lab replaces.
+const musterRestartTimeout = 120 * time.Second
 
 // Leftovers of earlier agentlab versions in the lab's working directory: the
 // git-vendored agent-platform-standalone chart and the generated Helm
@@ -127,12 +160,14 @@ func platformUp(cfg *config.Config, header string) error {
 	}
 	chart := platformChartFor(cfg)
 	step("Installing %s in the lab shape (bundled Flux engine on, self-management off)", chart)
+	ctx := context.Background()
 
 	// The Gateway API CRDs are the chart's documented cluster-level
 	// prerequisite; embedded so the boot needs no network for them.
-	// Idempotent re-apply.
+	// Idempotent re-apply; the apply waits for the apiserver to serve the
+	// kinds before anything below uses them.
 	step("Installing the Gateway API CRDs (standard channel)")
-	if err := pipeInto(gatewayAPICRDs, "kubectl", "apply", "-f", "-"); err != nil {
+	if _, err := applyManifests(ctx, gatewayAPICRDs); err != nil {
 		return err
 	}
 
@@ -166,30 +201,8 @@ func platformUp(cfg *config.Config, header string) error {
 	if err := ensureTLSSecret(platformNamespace, "agent-platform-tls", edgeCert, edgeKey); err != nil {
 		return err
 	}
-	// Created once and then left alone: regenerating the encryption key on
-	// every run would invalidate every issued token. dex-client-secret must
-	// match the `agent-platform` staticClient in the Dex config.
-	if _, err := outputQuiet("kubectl", "-n", platformNamespace, "get", "secret", "agent-platform-secrets"); err != nil {
-		if err := runQuiet("kubectl", "-n", platformNamespace, "create", "secret", "generic", "agent-platform-secrets",
-			"--from-literal=dex-client-secret="+config.AgentPlatformClientSecret,
-			"--from-literal=registration-token="+randHex(32),
-			"--from-literal=oauth-encryption-key="+randBase64(32),
-			"--from-literal=valkey-password="+randHex(16),
-			"--from-literal=backstage-session-secret="+randBase64(32)); err != nil {
-			return err
-		}
-		note("created agent-platform-secrets")
-	} else {
-		note("agent-platform-secrets already exists, leaving it alone")
-		// Except for keys this version introduced: a cluster created by an
-		// older lab lacks them, and Backstage's env would fail to resolve.
-		if !secretHasKey(platformNamespace, "agent-platform-secrets", "backstage-session-secret") {
-			if err := runQuiet("kubectl", "-n", platformNamespace, "patch", "secret", "agent-platform-secrets",
-				"-p", fmt.Sprintf(`{"stringData":{"backstage-session-secret":%q}}`, randBase64(32))); err != nil {
-				return err
-			}
-			note("added backstage-session-secret to agent-platform-secrets")
-		}
+	if err := ensurePlatformSecrets(ctx); err != nil {
+		return err
 	}
 
 	// Inside pods, *.<domain> must resolve to the edge Gateway (outside, the
@@ -197,35 +210,29 @@ func platformUp(cfg *config.Config, header string) error {
 	// could never reach https://muster.<domain>/mcp. The pinned edge Service
 	// below is the rewrite's target, applied before anything resolves it.
 	step("Pointing in-cluster *.%s at the edge (CoreDNS rewrite)", cfg.Platform.Domain)
-	if _, corednsPath, err := renderManifest(cfg, "coredns.yaml.tmpl"); err != nil {
+	if coredns, _, err := renderManifest(cfg, "coredns.yaml.tmpl"); err != nil {
 		return err
-	} else if out, err := outputQuiet("kubectl", "apply", "-f", corednsPath); err != nil {
+	} else if _, err := applyRestartingOnChange(ctx, coredns, kubeSystemNamespace, corednsDeployment); err != nil {
 		return err
-	} else if !strings.Contains(out, "unchanged") {
-		if err := runQuiet("kubectl", "-n", "kube-system", "rollout", "restart", "deployment/coredns"); err != nil {
-			return err
-		}
 	}
-	if _, nodeportPath, err := renderManifest(cfg, "gateway-nodeport.yaml.tmpl"); err != nil {
+	if nodeport, _, err := renderManifest(cfg, "gateway-nodeport.yaml.tmpl"); err != nil {
 		return err
-	} else if err := runQuiet("kubectl", "apply", "-f", nodeportPath); err != nil {
+	} else if _, err := applyManifests(ctx, nodeport); err != nil {
 		return err
 	}
 
 	if cfg.Backstage.Enabled {
 		// Catalog entities + the agent create flow's scaffolder Template,
 		// mounted into the chart's Backstage; must exist before the pod starts.
-		if _, catalogPath, err := renderManifest(cfg, "backstage-catalog.yaml.tmpl"); err != nil {
+		// Backstage reads app-config at startup only, so a changed overlay
+		// (e.g. flipping platform.observability toggles mimirEnabled) needs a
+		// pod roll on re-runs: started here and absorbed by the install's wait
+		// right below; on a fresh install the deployment does not exist yet and
+		// the first pod reads the final config.
+		if catalog, _, err := renderManifest(cfg, "backstage-catalog.yaml.tmpl"); err != nil {
 			return err
-		} else if applied, err := output("kubectl", "apply", "-f", catalogPath); err != nil {
+		} else if _, err := applyRestartingOnChange(ctx, catalog, platformNamespace, componentBackstage); err != nil {
 			return err
-		} else if strings.Contains(applied, "configured") {
-			// Backstage reads app-config at startup only, so a changed overlay
-			// (e.g. flipping platform.observability toggles mimirEnabled) needs
-			// a pod roll on re-runs. Started here and absorbed by the install's
-			// --wait right below; on a fresh install the deployment does not
-			// exist yet and the first pod reads the final config.
-			_ = runQuiet("kubectl", "-n", platformNamespace, "rollout", "restart", "deploy/backstage")
 		}
 	}
 
@@ -268,7 +275,10 @@ func platformUp(cfg *config.Config, header string) error {
 	if err != nil {
 		return err
 	}
-	if _, _, err := renderManifest(cfg, "demo-workflow.yaml.tmpl"); err != nil {
+	// Rendered here, applied after the install (the Workflow CRD ships with
+	// muster), so a render error surfaces before the long wait.
+	demoWorkflow, _, err := renderManifest(cfg, "demo-workflow.yaml.tmpl")
+	if err != nil {
 		return err
 	}
 
@@ -368,7 +378,7 @@ func platformUp(cfg *config.Config, header string) error {
 	// main tab empty, which reads as "the plugin is broken" rather than
 	// "nothing to show".
 	step("Creating the demo workflow")
-	if err := runQuiet("kubectl", "apply", "-f", StateDir+"/demo-workflow.yaml"); err != nil {
+	if _, err := applyManifests(ctx, demoWorkflow); err != nil {
 		return err
 	}
 	// The per-server OAuth sign-in fixture (oauthfixture.go) — after the
@@ -501,6 +511,63 @@ func platformUp(cfg *config.Config, header string) error {
 	return nil
 }
 
+// ensurePlatformSecrets creates the platform's generated secrets once
+// (platformSecretsName) and leaves an existing Secret alone, except for the
+// keys a newer lab introduced: a cluster created by an older lab lacks them,
+// and Backstage's env would fail to resolve.
+func ensurePlatformSecrets(ctx context.Context) error {
+	exists, err := objectExists(ctx, gvrSecrets, platformNamespace, platformSecretsName)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		if err := ensureSecret(platformNamespace, platformSecretsName, corev1.SecretTypeOpaque, map[string][]byte{
+			"dex-client-secret":       []byte(config.AgentPlatformClientSecret),
+			"registration-token":      []byte(randHex(32)),
+			"oauth-encryption-key":    []byte(randBase64(32)),
+			"valkey-password":         []byte(randHex(16)),
+			backstageSessionSecretKey: []byte(randBase64(32)),
+		}); err != nil {
+			return err
+		}
+		note("created %s", platformSecretsName)
+		return nil
+	}
+	note("%s already exists, leaving it alone", platformSecretsName)
+	if !secretHasKey(platformNamespace, platformSecretsName, backstageSessionSecretKey) {
+		patch := fmt.Sprintf(`{"stringData":{%q:%q}}`, backstageSessionSecretKey, randBase64(32))
+		if err := patchObject(ctx, gvrSecrets, platformNamespace, platformSecretsName, types.MergePatchType, []byte(patch)); err != nil {
+			return err
+		}
+		note("added %s to %s", backstageSessionSecretKey, platformSecretsName)
+	}
+	return nil
+}
+
+// applyRestartingOnChange applies a manifest and, when the apply created or
+// changed anything, restarts the Deployment that reads the result at startup
+// only — CoreDNS its Corefile, Backstage its app-config overlay — so a re-run
+// with a changed render rolls the pod exactly once and an unchanged one
+// leaves it alone. A Deployment that does not exist yet is not an error: a
+// fresh install's first pod reads the final config. Reports whether it
+// restarted.
+func applyRestartingOnChange(ctx context.Context, manifest []byte, ns, deployment string) (bool, error) {
+	results, err := applyManifests(ctx, manifest)
+	if err != nil {
+		return false, err
+	}
+	if !anyChanged(results) {
+		return false, nil
+	}
+	if err := restartDeployment(ctx, ns, deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // refuseOlderLabShape stops an install onto a cluster an earlier agentlab
 // built: the standalone umbrella under the same release name, or the Flux
 // controllers the old lab installed itself in flux-system (the chart's own
@@ -558,22 +625,21 @@ type platformReleaseStatus struct {
 // component releases the meta chart rendered plus the lab's own
 // (mcp-prometheus) — with their Ready condition.
 func platformReleases() ([]platformReleaseStatus, error) {
-	out, err := outputQuiet("kubectl", "-n", platformNamespace, "get", "helmreleases.helm.toolkit.fluxcd.io",
-		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.conditions[?(@.type=="Ready")].status}{"\t"}{.status.conditions[?(@.type=="Ready")].message}{"\n"}{end}`)
+	gvr, err := gvrFor(fluxHelmReleaseResource)
 	if err != nil {
 		return nil, err
 	}
-	var releases []platformReleaseStatus
-	for line := range strings.Lines(out) {
-		fields := strings.SplitN(strings.TrimRight(line, "\n"), "\t", 3)
-		if len(fields) < 2 || fields[0] == "" {
-			continue
-		}
-		rel := platformReleaseStatus{name: fields[0], ready: fields[1]}
-		if len(fields) == 3 {
-			rel.message = fields[2]
-		}
-		releases = append(releases, rel)
+	items, err := listObjects(context.Background(), gvr, platformNamespace, "")
+	if err != nil {
+		return nil, err
+	}
+	releases := make([]platformReleaseStatus, 0, len(items))
+	for i := range items {
+		releases = append(releases, platformReleaseStatus{
+			name:    items[i].GetName(),
+			ready:   conditionStatus(&items[i], conditionReady),
+			message: conditionMessage(&items[i], conditionReady),
+		})
 	}
 	return releases, nil
 }
@@ -668,15 +734,12 @@ func waitMCPServerReachable(name string) error {
 }
 
 // waitMCPServerState polls the MCPServer CR's status.state until it reads one
-// of want. The name is fully qualified because kagent ships its own MCPServer
-// CRD (mcpservers.kagent.dev), so the bare kind resolves to the wrong API
-// group.
+// of want.
 func waitMCPServerState(name string, want ...string) error {
 	var state string
 	var readErr error
 	reached := waitFor(40, 3*time.Second, func() bool {
-		state, readErr = outputQuiet("kubectl", "-n", platformNamespace, "get", "mcpservers.muster.giantswarm.io", name,
-			"-o", "jsonpath={.status.state}")
+		state, readErr = mcpServerState(name)
 		return readErr == nil && slices.Contains(want, state)
 	})
 	if !reached {
@@ -686,6 +749,22 @@ func waitMCPServerState(name string, want ...string) error {
 	}
 	note("MCPServer %s: %s", name, state)
 	return nil
+}
+
+// mcpServerState reads one muster MCPServer's status.state in the platform
+// namespace (musterMCPServerResource): "" before muster's first reconcile,
+// the apiserver's error for a CR — or a CRD — that is not there.
+func mcpServerState(name string) (string, error) {
+	gvr, err := gvrFor(musterMCPServerResource)
+	if err != nil {
+		return "", err
+	}
+	obj, err := getObject(context.Background(), gvr, platformNamespace, name)
+	if err != nil {
+		return "", err
+	}
+	state, _, _ := unstructured.NestedString(obj.Object, "status", "state")
+	return state, nil
 }
 
 // claudeCodeHint is the "point Claude Code at it" block of the platform-up
@@ -740,10 +819,11 @@ func ensureMusterValidatesTokens(cfg *config.Config) error {
 	}
 	note("muster rejects Dex tokens (%v)", lastErr)
 	note("known muster startup flake (HACKS.md U6) — replacing the muster pod once")
-	if err := runQuiet("kubectl", "-n", platformNamespace, "rollout", "restart", "deployment/muster"); err != nil {
+	ctx := context.Background()
+	if err := restartDeployment(ctx, platformNamespace, componentMuster); err != nil {
 		return err
 	}
-	if err := runQuiet("kubectl", "-n", platformNamespace, "rollout", "status", "deployment/muster", "--timeout=120s"); err != nil {
+	if err := waitDeploymentRolledOut(ctx, platformNamespace, componentMuster, musterRestartTimeout); err != nil {
 		return err
 	}
 	// The fresh pod redoes OIDC discovery (fast: Dex and valkey are up) and

--- a/internal/lab/platform_test.go
+++ b/internal/lab/platform_test.go
@@ -1,0 +1,190 @@
+package lab
+
+import (
+	"context"
+	"encoding/base64"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// patchCount counts the patches the dynamic fake saw on one resource — the
+// restarts of a Deployment, the JSON patch of a CRD.
+func (f *fakeLab) patchCount(gvr schema.GroupVersionResource) int {
+	n := 0
+	for _, a := range f.dyn.Actions() {
+		if p, ok := a.(clienttesting.PatchActionImpl); ok && p.GetResource() == gvr {
+			n++
+		}
+	}
+	return n
+}
+
+// TestApplyRestartingOnChange: the first apply creates the ConfigMap and
+// rolls the Deployment that reads it, a re-apply of the same render changes
+// nothing and leaves the Deployment alone, a changed render rolls it again,
+// and without the Deployment (a fresh install) the apply lands and nothing
+// fails.
+func TestApplyRestartingOnChange(t *testing.T) {
+	f := newFakeLab(t, &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: kindDeployment},
+		ObjectMeta: metav1.ObjectMeta{Name: corednsDeployment, Namespace: kubeSystemNamespace},
+	})
+	ctx := context.Background()
+	corefile := func(rewrite string) []byte {
+		return []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: coredns\n  namespace: kube-system\ndata:\n  Corefile: " + rewrite + "\n")
+	}
+	restarted, err := applyRestartingOnChange(ctx, corefile("rewrite a"), kubeSystemNamespace, corednsDeployment)
+	if err != nil || !restarted {
+		t.Fatalf("first apply: restarted=%v err=%v, want a restart", restarted, err)
+	}
+	stamp, _, _ := unstructured.NestedString(f.stored(t, gvrDeployments, kubeSystemNamespace, corednsDeployment).Object,
+		"spec", "template", "metadata", "annotations", restartedAtAnnotation)
+	if stamp == "" {
+		t.Error("the Deployment carries no restartedAt stamp after the first apply")
+	}
+	restarted, err = applyRestartingOnChange(ctx, corefile("rewrite a"), kubeSystemNamespace, corednsDeployment)
+	if err != nil || restarted {
+		t.Errorf("unchanged re-apply: restarted=%v err=%v, want no restart", restarted, err)
+	}
+	if n := f.patchCount(gvrDeployments); n != 1 {
+		t.Errorf("Deployment patched %d times after an unchanged re-apply, want 1", n)
+	}
+	restarted, err = applyRestartingOnChange(ctx, corefile("rewrite b"), kubeSystemNamespace, corednsDeployment)
+	if err != nil || !restarted {
+		t.Errorf("changed render: restarted=%v err=%v, want a restart", restarted, err)
+	}
+	if n := f.patchCount(gvrDeployments); n != 2 {
+		t.Errorf("Deployment patched %d times after a changed render, want 2", n)
+	}
+
+	f2 := newFakeLab(t)
+	restarted, err = applyRestartingOnChange(ctx, corefile("rewrite a"), kubeSystemNamespace, corednsDeployment)
+	if err != nil || restarted {
+		t.Errorf("without the Deployment: restarted=%v err=%v, want neither", restarted, err)
+	}
+	if data, _, _ := unstructured.NestedString(f2.stored(t, gvrConfigMaps, kubeSystemNamespace, corednsDeployment).Object, "data", "Corefile"); data != "rewrite a" {
+		t.Errorf("the ConfigMap was not applied without the Deployment: %q", data)
+	}
+}
+
+// TestEnsurePlatformSecrets: a first run creates every key with the fixed Dex
+// client secret, a second run leaves the generated values alone, and an
+// older lab's Secret without the Backstage session key gets that key merged
+// in and nothing else touched.
+func TestEnsurePlatformSecrets(t *testing.T) {
+	f := newFakeLab(t)
+	ctx := context.Background()
+	if err := ensurePlatformSecrets(ctx); err != nil {
+		t.Fatal(err)
+	}
+	data, _, _ := unstructured.NestedMap(f.stored(t, gvrSecrets, platformNamespace, platformSecretsName).Object, "data")
+	for _, key := range []string{"dex-client-secret", "registration-token", "oauth-encryption-key", "valkey-password", backstageSessionSecretKey} {
+		if v, _ := data[key].(string); v == "" {
+			t.Errorf("the created Secret lacks %s: %v", key, data)
+		}
+	}
+	if got, want := data["dex-client-secret"], base64.StdEncoding.EncodeToString([]byte(config.AgentPlatformClientSecret)); got != want {
+		t.Errorf("dex-client-secret = %v, want the Dex static client's %v", got, want)
+	}
+	if err := ensurePlatformSecrets(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if again, _, _ := unstructured.NestedMap(f.stored(t, gvrSecrets, platformNamespace, platformSecretsName).Object, "data"); !reflect.DeepEqual(again, data) {
+		t.Errorf("a second run regenerated the secrets: %v -> %v", data, again)
+	}
+
+	f2 := newFakeLab(t, &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{Name: platformSecretsName, Namespace: platformNamespace},
+		Data:       map[string][]byte{"dex-client-secret": []byte("old")},
+	})
+	if err := ensurePlatformSecrets(ctx); err != nil {
+		t.Fatal(err)
+	}
+	old := f2.stored(t, gvrSecrets, platformNamespace, platformSecretsName)
+	if v, _, _ := unstructured.NestedString(old.Object, "stringData", backstageSessionSecretKey); v == "" {
+		t.Errorf("the session key was not merged into the older Secret: %v", old.Object)
+	}
+	if v, _, _ := unstructured.NestedString(old.Object, "data", "dex-client-secret"); v != base64.StdEncoding.EncodeToString([]byte("old")) {
+		t.Errorf("the older Secret's data was touched: %v", old.Object)
+	}
+}
+
+// fakeHelmRelease is a Flux HelmRelease in the platform namespace as
+// helm-controller leaves it: with a Ready condition, or none before the
+// first reconcile (ready "").
+func fakeHelmRelease(name, ready, message string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{Object: map[string]any{
+		fieldAPIVersion: fluxHelmReleaseGVK.GroupVersion().String(),
+		fieldKind:       fluxHelmReleaseGVK.Kind,
+		fieldMetadata:   map[string]any{nameKey: name, fieldNamespace: platformNamespace},
+	}}
+	if ready != "" {
+		u.Object[fieldStatus] = map[string]any{"conditions": []any{
+			map[string]any{fieldType: "Reconciling", fieldStatus: "Unknown"},
+			map[string]any{fieldType: condReady, fieldStatus: ready, fieldMessage: message},
+		}}
+	}
+	return u
+}
+
+// TestPlatformReleases lists the HelmReleases with their Ready condition: the
+// status and helm-controller's message, "" for a release not yet reconciled.
+func TestPlatformReleases(t *testing.T) {
+	newFakeLab(t,
+		fakeHelmRelease(componentMuster, conditionTrue, "Helm install succeeded"),
+		fakeHelmRelease(componentKagent, condFalse, retriesExhausted),
+		fakeHelmRelease("fresh", "", ""))
+	releases, err := platformReleases()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]platformReleaseStatus{}
+	for _, r := range releases {
+		got[r.name] = r
+	}
+	want := map[string]platformReleaseStatus{
+		componentMuster: {name: componentMuster, ready: conditionTrue, message: "Helm install succeeded"},
+		componentKagent: {name: componentKagent, ready: condFalse, message: retriesExhausted},
+		"fresh":         {name: "fresh"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("platformReleases = %v, want %v", got, want)
+	}
+}
+
+// TestMCPServerState reads status.state off muster's MCPServer: the state,
+// "" before the first reconcile, the apiserver's NotFound for a missing CR.
+func TestMCPServerState(t *testing.T) {
+	server := func(name, state string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{Object: map[string]any{
+			fieldAPIVersion: musterMCPServerGVK.GroupVersion().String(),
+			fieldKind:       musterMCPServerGVK.Kind,
+			fieldMetadata:   map[string]any{nameKey: name, fieldNamespace: platformNamespace},
+		}}
+		if state != "" {
+			u.Object[fieldStatus] = map[string]any{"state": state}
+		}
+		return u
+	}
+	newFakeLab(t, server("k8s", "Connected"), server("fresh", ""))
+	if state, err := mcpServerState("k8s"); err != nil || state != "Connected" {
+		t.Errorf("mcpServerState(k8s) = %q, %v", state, err)
+	}
+	if state, err := mcpServerState("fresh"); err != nil || state != "" {
+		t.Errorf("mcpServerState(fresh) = %q, %v; want \"\" before the first reconcile", state, err)
+	}
+	if _, err := mcpServerState("absent"); err == nil || !apierrors.IsNotFound(err) {
+		t.Errorf("mcpServerState(absent) = %v, want the apiserver's NotFound", err)
+	}
+}


### PR DESCRIPTION
Step 3b of #101 (kubectl → client-go), the lifecycle and platform half: `down.go`, `platform.go`, `observability.go`, `kagentcrd.go`, `adk.go`, `anthropic.go`, `modelmanager.go` and `logs.go` no longer shell out to `kubectl` — every call goes through the embedded client in `internal/lab/kube.go`. The proofs and fixtures (`test.go`, `agentstest.go`, `toolsetstest*.go`, `modelstest.go`, `models.go`, `fleetfixture.go`, `oauthfixture.go`) are converted separately; `kubectl` stays on PATH until that lands and the closer removes it from Preflight and the docs.

## What changed

- **platform.go** — the Gateway API CRDs are `applyManifests` of the embedded bytes (the apply waits for the kinds to be served); the platform secrets are `ensurePlatformSecrets` (typed Secret, server-side applied; the Backstage session key merged into an older lab's Secret with a merge patch); the CoreDNS Corefile and the Backstage catalog go through `applyRestartingOnChange` — `kubectl apply`'s created/configured/unchanged verdict is `anyChanged(results)`, and only a changed render rolls the Deployment (a Deployment that does not exist yet, the fresh install, is not an error); the NodePort Service and the demo Workflow (rendered before the install, applied after it) are plain applies; `platformReleases` lists the HelmReleases and reads the Ready condition off each; `mcpServerState` reads `.status.state`; the muster restart is `restartDeployment` + `waitDeploymentRolledOut`.
- **down.go** — the mcp-prometheus HelmRelease/OCIRepository existence probe and deletes (`deleteObject`, the HelmRelease waited 3 m), and `deleteNamespace`: `kubectl delete namespace` waits by default — kept, bounded by 5 m.
- **observability.go** — `prometheusAvailableReplicas` (`.items[0].status.availableReplicas`, "" before the operator reports), the edge route and the mcp-prometheus release applied from the render's bytes.
- **kagentcrd.go** — one `getObject` of the CRD, the v1alpha2 index and the `iconUrl` presence read with `unstructured.Nested*`, the JSON patch through `patchObject(..., types.JSONPatchType, ...)`.
- **adk.go** — one ConfigMap read for `IMAGE_REGISTRY`/`IMAGE_TAG`. **anthropic.go** — `objectExists` + a typed Secret apply (the key never leaves the process). **modelmanager.go** — the host-server probe is `runProbePod` (it removes a leftover of the same name itself); the combined-output semantics the reason detection reads are preserved (the container log carries wget's message).
- **logs.go** — `logTargets` is now `map[component]logTarget{namespace, target}` (`deploy/<name>` or a label selector) streamed by `streamLogs`; `LogComponents()` unchanged for cobra; Ctrl-C ends the follow cleanly (`signal.NotifyContext`).
- **kube.go (additive)** — a mapper miss resets the cached discovery once and retries, in `gvrFor` and in the apply's kind lookup (`restMapping`). Without it a fresh `up` fails: the Gateway CRD apply primes the discovery cache before Helm installs the Flux, muster and Prometheus CRDs, and `memory.NewMemCacheClient`'s `Fresh()` only allows the deferred mapper's own retry while the cache is *unpopulated* — so `helmreleases.helm.toolkit.fluxcd.io`, `mcpservers.muster.giantswarm.io`, `prometheuses.monitoring.coreos.com` and the demo `Workflow` never resolved. kubectl invalidates its disk cache on a miss the same way.
- **exec.go** — `run`, `output` and `outputAll` lost their last callers and are gone; `command()` still pins `KUBECONFIG` for the remaining kubectl call sites.
- Tests: fake-backed (`newFakeLab`) tests for the apply-then-restart decision, the platform secrets (create / leave alone / merge the missing key), `platformReleases`, `mcpServerState`, the CRD version patch (patched by index, second run a no-op, no v1alpha2 refused, missing CRD), `deleteNamespace`, the mcp-prometheus existence probe, `prometheusAvailableReplicas`, every `logTargets` entry resolving through `streamLogs`, and the mapper-miss retry. The fake lab's mapper and list kinds learned HelmRelease, MCPServer and Prometheus.

## Measured

- Stripped linux/amd64 (`CGO_ENABLED=0 go build -trimpath -ldflags '-s -w'`): 77,910,176 B → 77,971,616 B (+61 KB).
- Modules (`go list -m all | wc -l`): 559 → 559.
- Cold `go build .` (private `GOCACHE`, main then branch back to back, under lab load): 29.7 s → 29.7 s.

## Verified on an isolated lab

Cluster `agentlab-kube1` (dex 32004, gateway 8446, muster 8097, agents 8085, backstage 7011), binary built from this branch, `PATH` = a directory holding only `docker` and `kubectl` symlinks (`command -v kind helm kubectl docker` lists kubectl and docker — no kind, no helm):

| command | result |
|---|---|
| `configure --defaults` (twice, ports validated) | ok |
| `up` | 6:01, exit 0 — Gateway CRDs, secrets, CoreDNS, kps, `Prometheus is serving`, both host probes (`host Ollama answers from inside the cluster: "version":"0.33.3"`, Lemonade `11.9.0`) through the probe pod, 11 MCPServer states read, demo workflow applied after the install, `created secret kagent/kagent-anthropic`, the Agent CRD read (`already declares spec.iconUrl`) |
| `platform-test` | 6/6 PASS, 2 s |
| `test` | 10/10, 2 s |
| `backstage-test` | ok, 4 s |
| `agents-test` | 4/4 PASS, 12 s |
| `toolsets-test` | 11/11 PASS, 88 s |
| `/usr/bin/timeout 10 agentlab logs muster` | exit 124 (the timeout), 631 lines streamed |
| `platform` (second run) | 29 s, idempotent: `agent-platform-secrets already exists`, CoreDNS `restartedAt` still the first boot's stamp, Backstage never restarted |
| `platform-down` | 41 s: mcp-prometheus HelmRelease deleted first, the platform's ordered teardown, `namespace monitoring deleted`, `namespace agent-platform deleted`; `helm list -A` empty, the Flux CRDs gone |
| `platform` (reinstall) | 3:24, a fresh revision 1, `created agent-platform-secrets` |
| `platform-test` (after the reinstall) | 6/6 PASS, 2 s |
| `down` | 6 s, exit 0; `kind get clusters` no longer lists the cluster, no node container left |

`grep -c '"kubectl"'` over the eight files: 0 each.
