### PR TITLE
fix(forms): drive the paced form test on huh's focus state instead of a 30 ms clock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/giantswarm/agentlab
 go 1.26.0
 
 require (
+	charm.land/bubbletea/v2 v2.0.2
 	charm.land/huh/v2 v2.0.3
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/creativeprojects/go-selfupdate v1.6.0
@@ -25,7 +26,6 @@ require (
 require (
 	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	charm.land/bubbles/v2 v2.0.0 // indirect
-	charm.land/bubbletea/v2 v2.0.2 // indirect
 	charm.land/lipgloss/v2 v2.0.1 // indirect
 	code.gitea.io/sdk/gitea v0.23.2 // indirect
 	dario.cat/mergo v1.0.1 // indirect

--- a/internal/forms/drive_test.go
+++ b/internal/forms/drive_test.go
@@ -1,0 +1,103 @@
+package forms
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/huh/v2"
+)
+
+// driveTimeout bounds how long the driver waits for the form to reach the
+// state its next key targets. A drive that stalls (an enter refused by a
+// validator, a key meant for a field the form never focuses) fails the form
+// run naming the stalled key instead of hanging the test.
+const driveTimeout = 10 * time.Second
+
+// driver feeds a huh form a scripted keystroke stream at the form's own pace.
+// huh moves between fields and groups through asynchronous bubbletea commands,
+// so a key that follows an enter too closely lands on the field the enter is
+// still leaving; a delay between keys only makes that race rarer. The driver
+// is the form's input reader and its view hook at once: bubbletea renders on
+// its event-loop goroutine after every update, so the hook sees the focused
+// field exactly when it changes, and Read hands over the next key only once
+// the form has moved on from the field the previous enter or tab left.
+type driver struct {
+	keys []string
+
+	mu      sync.Mutex
+	focused huh.Field // the field focused at the last render
+	target  huh.Field // the field the previous key was handed to
+	advance bool      // whether the previous key moves the focus
+	changed chan struct{}
+}
+
+func newDriver(keys ...string) *driver {
+	return &driver{keys: keys, changed: make(chan struct{}, 1)}
+}
+
+// attach makes the driver the form's input, silences its output and hooks its
+// renders. Its method value is the shape of testHook, so the real form is
+// driven the same way as a form built in a test.
+func (d *driver) attach(form *huh.Form) *huh.Form {
+	return form.WithInput(d).WithOutput(io.Discard).WithViewHook(func(v tea.View) tea.View {
+		d.mu.Lock()
+		d.focused = form.GetFocusedField()
+		d.mu.Unlock()
+		select {
+		case d.changed <- struct{}{}:
+		default:
+		}
+		return v
+	})
+}
+
+// Read hands over the next key once the form is ready for it, and io.EOF once
+// the script is exhausted.
+func (d *driver) Read(b []byte) (int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.keys) == 0 {
+		return 0, io.EOF
+	}
+	deadline := time.After(driveTimeout)
+	for !d.ready() {
+		d.mu.Unlock()
+		select {
+		case <-d.changed:
+		case <-deadline:
+			d.mu.Lock()
+			return 0, fmt.Errorf("form still on %T after %s, key %q not delivered", d.target, driveTimeout, d.keys[0])
+		}
+		d.mu.Lock()
+	}
+	key := d.keys[0]
+	n := copy(b, key)
+	d.target, d.advance = d.focused, false
+	if n < len(key) {
+		d.keys[0] = key[n:]
+	} else {
+		d.keys = d.keys[1:]
+		d.advance = movesFocus(key)
+	}
+	return n, nil
+}
+
+// ready reports whether the form is where the next key belongs: a field is
+// focused and, when the previous key moves the focus, it has moved.
+func (d *driver) ready() bool {
+	return d.focused != nil && (!d.advance || d.focused != d.target)
+}
+
+// movesFocus reports whether huh leaves the focused field on a key: enter and
+// tab go forward, shift+tab back. The drives answer confirms with enter, so
+// the y/n shortcuts, which advance as well, are not listed.
+func movesFocus(key string) bool {
+	switch key {
+	case "\r", "\t", "\x1b[Z":
+		return true
+	}
+	return false
+}

--- a/internal/forms/forms.go
+++ b/internal/forms/forms.go
@@ -4,7 +4,6 @@ package forms
 
 import (
 	"fmt"
-	"io"
 	"regexp"
 	"slices"
 	"strconv"
@@ -25,22 +24,17 @@ const (
 	actionRemove = "remove"
 )
 
-// testInput/testOutput let tests drive the real TUI form with a scripted
-// keystroke stream instead of a terminal. nil outside of tests.
-var (
-	testInput  io.Reader
-	testOutput io.Writer
-)
+// testHook lets tests take over every form this package builds (input,
+// output, view hook), so the real TUI form runs against a scripted keystroke
+// stream instead of a terminal. nil outside of tests.
+var testHook func(*huh.Form) *huh.Form
 
-// newForm wraps huh.NewForm so the test IO overrides apply to every form this
+// newForm wraps huh.NewForm so the test hook applies to every form this
 // package builds.
 func newForm(groups ...*huh.Group) *huh.Form {
 	form := huh.NewForm(groups...)
-	if testInput != nil {
-		form = form.WithInput(testInput)
-	}
-	if testOutput != nil {
-		form = form.WithOutput(testOutput)
+	if testHook != nil {
+		return testHook(form)
 	}
 	return form
 }

--- a/internal/forms/forms_test.go
+++ b/internal/forms/forms_test.go
@@ -1,21 +1,17 @@
 package forms
 
 import (
-	"io"
 	"testing"
-	"time"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
-
-const keyDelay = 30 * time.Millisecond
 
 // TestRunTUIDrive drives the real TUI form (not accessible mode) with a
 // scripted keystroke stream: accept the cluster defaults, keep the default
 // users, keep the preselected components (platform AND Backstage — the
 // canonical lab), and accept their defaults.
 func TestRunTUIDrive(t *testing.T) {
-	testInput = newPacedReader(keyDelay,
+	testHook = newDriver(
 		"\r", "\r", "\r", // group 1: cluster name, dex port, dex image
 		"\r", // group 2: customize users? -> keep as is
 		"\r", // group 3: platform + backstage preselected; submit as is
@@ -24,9 +20,8 @@ func TestRunTUIDrive(t *testing.T) {
 		// extra models confirm
 		"\r", "\r", "\r", "\r", "\r", "\r", "\r", "\r",
 		"\r", // backstage group: port
-	)
-	testOutput = io.Discard
-	defer func() { testInput, testOutput = nil, nil }()
+	).attach
+	defer func() { testHook = nil }()
 
 	cfg := config.Default()
 	if err := Run(cfg, false, Hints{ModelServers: "Ollama 0.33.2 (:11434)"}); err != nil {
@@ -61,7 +56,7 @@ func TestRunTUIDrive(t *testing.T) {
 // TestRunTUIDriveEdit changes the cluster name and dex port through the form:
 // ctrl+u clears an input's pre-filled value before typing a replacement.
 func TestRunTUIDriveEdit(t *testing.T) {
-	testInput = newPacedReader(keyDelay,
+	testHook = newDriver(
 		"\x15", "renamed", "\r", // clear + retype cluster name
 		"\x15", "31000", "\r", // clear + retype dex port
 		"\r", // dex image: keep
@@ -69,9 +64,8 @@ func TestRunTUIDriveEdit(t *testing.T) {
 		// components: deselect the preselected platform, arrow down,
 		// deselect the preselected backstage -> none
 		" ", "\x1b[B", " ", "\r",
-	)
-	testOutput = io.Discard
-	defer func() { testInput, testOutput = nil, nil }()
+	).attach
+	defer func() { testHook = nil }()
 
 	cfg := config.Default()
 	if err := Run(cfg, false, Hints{}); err != nil {

--- a/internal/forms/minimal_test.go
+++ b/internal/forms/minimal_test.go
@@ -4,36 +4,9 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"charm.land/huh/v2"
 )
-
-// pacedReader delivers one keystroke chunk per Read with a small delay,
-// mimicking human typing: huh group transitions run asynchronous commands and
-// can drop keys that arrive in the same read burst.
-type pacedReader struct {
-	chunks []string
-	delay  time.Duration
-}
-
-func newPacedReader(delay time.Duration, chunks ...string) *pacedReader {
-	return &pacedReader{chunks: chunks, delay: delay}
-}
-
-func (p *pacedReader) Read(b []byte) (int, error) {
-	if len(p.chunks) == 0 {
-		return 0, io.EOF
-	}
-	time.Sleep(p.delay)
-	n := copy(b, p.chunks[0])
-	if n < len(p.chunks[0]) {
-		p.chunks[0] = p.chunks[0][n:]
-	} else {
-		p.chunks = p.chunks[1:]
-	}
-	return n, nil
-}
 
 // Minimal probe: can a huh TUI form be driven by a plain reader at all?
 func TestMinimalFormDrive(t *testing.T) {
@@ -49,13 +22,14 @@ func TestMinimalFormDrive(t *testing.T) {
 	}
 }
 
-// Reduced copy of the real form with paced input: input -> confirm ->
-// multiselect across three groups.
+// Reduced copy of the real form driven at the form's pace: input -> confirm ->
+// multiselect across three groups. Both spaces must reach the multi-select,
+// none the confirm.
 func TestReducedFormDrivePaced(t *testing.T) {
 	name := "agentlab"
 	customize := false
 	var comps []string
-	form := huh.NewForm(
+	form := newDriver("\r", "\r", " ", "\x1b[B", " ", "\r").attach(huh.NewForm(
 		huh.NewGroup(
 			huh.NewInput().Title("Cluster name").Value(&name),
 		).Title("Cluster"),
@@ -67,8 +41,7 @@ func TestReducedFormDrivePaced(t *testing.T) {
 				Options(huh.NewOption("platform", "platform"), huh.NewOption("backstage", "backstage")).
 				Value(&comps),
 		).Title("Components"),
-	).WithInput(newPacedReader(30*time.Millisecond,
-		"\r", "\r", " ", "\x1b[B", " ", "\r")).WithOutput(io.Discard)
+	))
 	if err := form.Run(); err != nil {
 		t.Fatalf("run: %v", err)
 	}


### PR DESCRIPTION
## Problem

`TestReducedFormDrivePaced` failed the v0.25.5 tag pipeline (`minimal_test.go:79: comps = [backstage], want both`), leaving `upload-release-assets` `not_run`. The test drove a three-group huh form through a reader that hands over one key every 30 ms. huh leaves a field through asynchronous bubbletea commands — enter on the confirm → `NextField` cmd → `nextFieldMsg` → `nextGroup` cmd → `nextGroupMsg` → the multi-select is focused — so the pace was a bet that two command round-trips finish within 30 ms. Under a CPU quota they don't: the first space lands on the confirm (no binding there, dropped), the down arrow and the second space reach the multi-select, and only `backstage` is selected. The `forms_test.go` drives of the real form used the same 30 ms pace; when one of *their* keys is lost the form waits for input forever and the test hangs until `go test`'s 10-minute timeout.

## Fix

The driver is the form's input reader **and** its view hook. bubbletea calls `View()` on the event-loop goroutine after every `Update`, so the hook observes `form.GetFocusedField()` exactly when it changes, race-free. `Read` hands over the next key only once a field is focused and, when the previous key was enter/tab/shift+tab, the focus has moved off the field that key went to. A stalled drive (an enter refused by a validator, a key for a field the form never focuses) fails the run after 10 s naming the undelivered key instead of hanging. No sleeps, no retries. `testInput`/`testOutput` collapse into one `testHook` that attaches the driver to every form the package builds.

## Evidence

Load is a cgroup CPU quota (`systemd-run --user --scope -p CPUQuota=…` on a `go test -c -race` binary — the mechanism behind CI resource classes) or one core shared with three busy loops (`taskset`). Every run uses `-race`.

| tests | code | load | result |
|---|---|---|---|
| `TestReducedFormDrivePaced`+`TestMinimalFormDrive` ×200 | `main` | 25 % quota | **34 failures** (`comps = [backstage]`) |
| same ×200 | `main` | 10 % quota | **82 failures** (74× `[backstage]`, 8× `[platform]`) |
| same ×200 | `main` | 1 core, 3 busy loops | 0 failures (too gentle: the 30 ms sleeps dominate the test) |
| `TestRunTUIDrive*` ×50 | `main` | 1 core, 3 busy loops | **hung** in `TestRunTUIDriveEdit` after ~40 s until the 10 min `go test` timeout |
| `TestRunTUIDrive*` ×50 | `main` | 25 % quota | **hung** in `TestRunTUIDriveEdit` (SIGQUIT after 5.5 min: event loop waiting for input, keys exhausted) |
| `TestReducedFormDrivePaced`+`TestMinimalFormDrive` ×200 | this PR | none | 200/200 in 8 s (was 49 s: the test no longer sleeps) |
| whole package ×200 (1000 test runs) | this PR | 25 % quota | 1000/1000 |
| whole package ×200 (1000 test runs) | this PR | 1 core, 3 busy loops | 1000/1000 |
| whole package ×200 (1000 test runs) | this PR | 10 % quota | 1000/1000 (finished after the merge) |

Against a 17 % (25 % quota) to 41 % (10 % quota) per-run baseline, 0 failures in 3000 loaded runs makes luck implausible.

Fixes #116
