### PR TITLE
feat: dev channel — platform.chartBranch follows a branch's dev builds, Substrate on demand

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,8 +222,13 @@ Load-bearing invariants (details in docs/):
   lab's embedded Helm stays the one writer of the release, and the Helm CLI
   its day-2 tool). The chart is pinned to an exact
   release (`platform.chartVersion`, default `config.DefaultChartVersion`);
-  `platform.chartPath` installs a local checkout instead. Never emit
-  `gitops.namespace` with the engine on.
+  `platform.chartPath` installs a local checkout instead; `platform.chartBranch`
+  is the dev channel — the branch's newest dev build, resolved into
+  `chartVersion` on every `configure`/`up`/`platform` (`chartbranch.go`,
+  `platform --pin` freezes it) — and implies Substrate, kagent main's actor
+  runtime, installed ahead of the platform (`substrate.go`,
+  `platform.substrate.enabled`). Never emit `gitops.namespace` with the
+  engine on.
 - The lab's credentials are throwaway by design; plaintext passwords in
   `agentlab.yaml` are fine.
 

--- a/HACKS.md
+++ b/HACKS.md
@@ -514,6 +514,28 @@ Unblocks when kind's `load docker-image` logic (the re-tag of an image ID the
 node already has, the per-image save) survives the containerd image store and
 is worth reusing over the plain archive import.
 
+### U22. `substratepools.go`: Substrate's CA/JWT pool bootstrap is a Go port of `kubectl-ate` — BLOCKED UPSTREAM
+The substrate chart (0.0.26) mounts four pool Secrets, a trust-anchor Secret
+and an authentication ConfigMap it does not render. Upstream's install is
+`helm install`, then `kubectl-ate admin make-ca-pool` / `make-jwt-pool` plus a
+shell step (jq + openssl for the trust anchor, a heredoc for the
+authentication config), then a second `helm upgrade --wait` — the first
+install's pods restart on missing volumes until then. The lab downloads no
+binaries (kind, Helm and client-go are embedded; `kubectl-ate` is unsigned)
+and upstream publishes no image with the bootstrap in it (`ate-setup` is not
+published), so `substratepools.go` copies the generate + serialise subset of
+substrate's internal `localca` and `localjwtauthority` packages (Apache-2.0
+header kept, pinned to 0.0.26 in the comment) and `substrate.go` creates every
+bootstrap object BEFORE one waited install; the pre-created
+`podcertificate-controller-system` namespace the chart also renders is adopted
+with Helm's `--take-ownership`. Drift risk: a Substrate bump that changes the
+pool wire format shows up as ate-api-server never Ready. The issuer too:
+upstream's default authentication config names `https://kubernetes.default.svc`,
+which ate-api-server rejects against kind's tokens (their `iss` is
+`…svc.cluster.local`); the lab reads the issuer off the apiserver's discovery
+document, as upstream's own `ate-setup` does. Unblocks when the substrate
+chart renders the bootstrap (a hook Job) or the packages become importable.
+
 ## Accepted lab trade-offs (not hacks to fix)
 
 - **Checksum stamping via the `REPLACED_AT_APPLY` placeholder** — the standard

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ machine, is in [Getting started](docs/getting-started.md).
 | [Getting started](docs/getting-started.md) | Requirements, docker CPU and memory, install, what `configure` discovers, the first `up`, connecting Claude Code |
 | [Command reference](docs/cli.md) | Every `agentlab` command and flag, the environment variables, keeping the binary current |
 | [TLS](docs/tls.md) | The lab CA, `trust` and `untrust`, Node and browsers, bringing your own certificate |
-| [The agent platform](docs/platform.md) | muster + mcp-kubernetes: the request path, per-server sign-in, the fake fleet, toolsets, deviations from a real management cluster |
+| [The agent platform](docs/platform.md) | muster + mcp-kubernetes: the request path, per-server sign-in, the fake fleet, toolsets, deviations from a real management cluster, the dev channel (a branch's dev builds, Substrate) |
 | [Agents](docs/agents.md) | The kagent runtime, the default ModelConfig and the API key Secret |
 | [Models](docs/models.md) | Extra model configs, model servers on the host, managed models through model-manager |
 | [Observability](docs/observability.md) | Prometheus + mcp-prometheus, and Backstage's metrics views |

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -57,3 +57,8 @@ gateway in kind). The chart also renders the shared `RemoteMCPServer`
 pointing agents at muster; note that kagent forwards the *caller's* token to
 muster, so agent tool calls through muster need a real Dex token on the way
 in — headless pokes at the unsecured controller API won't have one.
+
+On the [dev channel](platform.md#dev-channel) the runtime is kagent main
+(API v2: `Harness` + `AgentTemplate`, every agent an actor on Substrate,
+which the lab installs ahead of the platform); the Agent CRs and the heals
+above belong to the released line and are skipped there.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,7 @@ your shell's current-context.
 | `certs` | Generate the lab CA and Dex server cert, re-minting only what config or policy require. `--force` regenerates everything and breaks a running cluster's trust. |
 | `trust` | Install the lab CA into the system and browser trust stores (one sudo prompt; reversible). See [TLS](tls.md). |
 | `untrust` | Remove exactly the lab CA from those stores. |
-| `platform` | Install the agent platform on a running cluster: one idempotent upgrade-or-install of the agent-platform chart in its lab shape through the embedded Helm (the `helm upgrade --install --wait` of Helm 4, in-process), then wait for every component. `up` runs this when the platform is enabled. |
+| `platform` | Install the agent platform on a running cluster: one idempotent upgrade-or-install of the agent-platform chart in its lab shape through the embedded Helm (the `helm upgrade --install --wait` of Helm 4, in-process), then wait for every component. `up` runs this when the platform is enabled. On the [dev channel](platform.md#dev-channel) it first re-resolves the branch's newest build (and installs Substrate); `--pin` freezes the recorded build instead, `--pin=false` follows the branch again. |
 | `platform-down` | Remove the agent platform in the chart's ordered teardown, leaving Dex and the cluster alone. |
 | `logs <component>` | Tail a component's logs: `backstage`, `dex`, `mcp-prometheus`, `muster` or `prometheus`. |
 | `self-update` | Replace the binary with the latest GitHub release, once its cosign Sigstore bundle verifies (see below). `--check` only reports the running and the latest version, exit status 125 when a newer one exists. |
@@ -72,6 +72,8 @@ The flags pin a value regardless of the discovery, with or without
 | `--backstage[=false]` | Enable or disable Backstage (implies the platform). |
 | `--chart-version <x.y.z>` | The agent-platform chart release to install, an exact version (default: the release this agentlab was verified with, `config.DefaultChartVersion`). |
 | `--chart-path <dir>` | Install the agent-platform chart from a local checkout's `helm/agent-platform` directory instead of the pinned release; `--chart-path ""` clears it. See [Installing an unreleased chart](platform.md#installing-an-unreleased-chart). |
+| `--chart-branch <branch>` | The dev channel: follow this agent-platform branch's newest dev build — resolved now and on every `up`/`platform`, written to `chartVersion`; `--chart-branch ""` returns to the stable channel. Mutually exclusive with `--chart-path`; implies Substrate. See [Dev channel](platform.md#dev-channel). |
+| `--substrate[=false]` | Pin Substrate (kagent's actor runtime) on or off instead of following the chart channel (on with `--chart-branch`, off otherwise). |
 | `--model-manager[=false]` | Pin managed models on or off instead of following the host model servers the discovery finds (needs agents). |
 | `--model-manager-backends ollama,lemonade` | Pin the host model servers, in order; the first is model-manager's default backend. |
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,6 +59,7 @@ pinned versions, plus kind's own control plane on a live node):
 | the chart's Flux engine: the Flux Operator plus the `FluxInstance`'s source-controller and helm-controller (the lab shape brings it with the platform — it delivers every component and the agents) | 250m | 192 MiB |
 | observability: kube-state-metrics + mcp-prometheus | 300m | 328 MiB |
 | **total requests** | **≈ 2.6 CPU** | **≈ 2.5 GiB** |
+| the dev channel only (`--chart-branch`): Substrate's bundled PostgreSQL — its actor runtime, API server and data plane declare nothing | +1000m | +1 GiB |
 
 The memory column *understates* real use, and by a lot: the Prometheus server
 (its CR sets no `resources`), the prometheus-operator and node-exporter
@@ -73,6 +74,7 @@ Give docker at least:
 |---|---|---|
 | the full default lab (platform + agents + observability + Backstage) | **4** | **6 GiB** (the floor is 5.1 GiB; whole GiB) |
 | platform + agents only (`configure --backstage=false --observability=false`) | 3 | 4 GiB (3.9 GiB) |
+| the full lab on the [dev channel](platform.md#dev-channel) (`--chart-branch`, Substrate on) | 5 | 8 GiB (7.1 GiB) |
 
 Those are the floors `agentlab up` enforces, and they already include room for
 the pods the platform creates at run time: every kagent agent is another pod,

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -36,6 +36,9 @@ The lab installs it in its **lab shape**:
 - The chart is **pinned** to an exact release, `platform.chartVersion` in
   `agentlab.yaml` (the default is the release this agentlab was verified
   with). The lab never floats; bump the pin deliberately, with a lab run.
+  The one exception is deliberate too: the [dev channel](#dev-channel),
+  where `platform.chartBranch` follows a branch's newest dev build — and
+  still installs an exact version, written into `chartVersion`.
 
 The platform installs as part of `agentlab up` (it is enabled in the default
 configuration); on an already-running cluster the steps are also standalone:
@@ -107,6 +110,139 @@ rendered kind config publishes that onto the Mac (host port `platform.musterPort
 default 8090) — no port-forward. Port mappings are fixed at node-creation time,
 so changing the port means `agentlab down && agentlab up`; the stopgap on an old
 cluster is `kubectl -n agent-platform port-forward svc/muster 8090:8090`.
+
+## Dev channel
+
+The stable channel is the pin above: `platform.chartVersion`, an exact
+release. The **dev channel** follows a branch of agent-platform instead —
+the dev builds gitsemver publishes for every commit of a branch that has
+branch publishing on (`gen.ci.branchPublish` in giantswarm/github): charts
+tagged `X.Y.Z-dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>.h<sha>` next to the
+releases in `oci://gsoci.azurecr.io/charts/giantswarm/agent-platform`, each
+coupled to the images its commit built. That is how a team works on the
+next platform line together before anything is released: every lab installs
+the branch's newest build from published artifacts only — no checkout, no
+dev images, no local registry.
+
+```bash
+agentlab configure --defaults --chart-branch poc/kagent-main
+export ANTHROPIC_API_KEY=sk-ant-...
+agentlab up
+agentlab platform-test && agentlab test && agentlab backstage-test
+```
+
+`configure` resolves the branch right away and says what it picked:
+
+```
+  chart      agent-platform 3.22.1-dev.poc-kagent-main.2026-09-10.08-12-33.h7f841be (branch poc/kagent-main, dev channel)
+  substrate  true (the dev channel's kagent needs it; `configure --substrate=false` overrides)
+```
+
+and `agentlab.yaml` carries both:
+
+```yaml
+platform:
+  chartBranch: poc/kagent-main   # the dev channel: chartVersion follows this branch's newest dev build
+  chartVersion: 3.22.1-dev.poc-kagent-main.2026-09-10.08-12-33.h7f841be   # written by the resolver
+```
+
+How the resolution works: the branch is spelled the way gitsemver embeds it
+(lowercased, anything outside `[a-z0-9]` collapsed to one hyphen —
+`poc/kagent-main` is `poc-kagent-main`; a long name is shortened around a
+`--` marker, which the filter accepts too), the registry's tags are listed
+through the embedded Helm's registry client (anonymously, as pulls are), the
+tags whose prerelease is `dev.<that name>.…` are the branch's builds, and the
+highest semver among them is the newest — the pick a Flux `OCIRepository`
+with `semver: "*-*"` and a `semverFilter` on the branch makes. `up` and
+`platform` re-resolve on every run, so the lab follows the branch like Flux
+would: a newer build is a new revision of the release on the next
+`agentlab platform`. Everything downstream — `render`, the image preload,
+the install, `helm -n agent-platform history` — sees the exact version
+written to `chartVersion`, as on the stable channel; `render` and the
+proofs never resolve.
+
+- **Freezing a build**: `agentlab platform --pin` writes
+  `platform.chartPinned: true` and stops re-resolving, so the lab keeps the
+  build under test; `--pin=false` follows the branch again. A new
+  `--chart-branch` (or `""`, back to the stable channel) always starts
+  unpinned.
+- **No build yet**: a branch without dev builds is refused with the two ways
+  out — the branch's publish has not run (agent-platform needs
+  `gen.ci.branchPublish` and a commit on the branch), or pin a tag by hand.
+- **The fallback that needs no resolver**: `platform.chartVersion` accepts a
+  full dev tag as it is — `agentlab configure --chart-version
+  3.22.1-dev.poc-kagent-main.2026-09-10.08-12-33.h7f841be` validates and
+  Helm pulls that exact tag (look it up with `crane ls
+  gsoci.azurecr.io/charts/giantswarm/agent-platform | grep -- -dev.poc-kagent-main`).
+  The lab then does not follow the branch, and Substrate needs
+  `--substrate` explicitly.
+- `chartBranch` and `chartPath` are mutually exclusive: a local chart has no
+  builds to follow.
+- The dev-tag schema lives in one place, `devTagFilter` in
+  `internal/lab/chartbranch.go`. When gitsemver ships the RFC's successor
+  schema (`X.Y.Z-b<crc32 of the branch>t<timestamp>c<sha>`), that function
+  switches and nothing else changes.
+
+Component channels: agentlab sets nothing per component. The meta chart's
+dev builds carry their siblings' channels in their own values (the branch's
+`components.<name>.semverFilter`), so selecting the meta chart's dev channel
+selects the whole line.
+
+### Substrate
+
+The dev channel's kagent (kagent main, API v2) runs every agent as an actor
+on [Substrate](https://github.com/kagent-dev/substrate) — sandboxed (gVisor)
+worker pods of a `WorkerPool`, an API server, a per-node agent (`atelet`) and
+the actors' ingress/egress data plane (`atenet`) — and its controller does
+not start without it. The lab installs Substrate as cluster infrastructure
+ahead of the platform when `platform.substrate.enabled` says so; unset, the
+knob follows the channel — on with `chartBranch` while agents are on, off on
+the stable channel, whose released kagent ignores it — and `configure
+--substrate[=false]` pins it either way.
+
+What `agentlab up` (and `platform`) does, idempotently:
+
+1. checks the apiserver serves `certificates.k8s.io/v1beta1` — the
+   `PodCertificateRequest` and `ClusterTrustBundle` gates the lab's kind
+   config turns on for every cluster (inert for the released platform). A
+   cluster created by an earlier agentlab lacks them, and feature gates are
+   fixed at `kind create`: that is `agentlab down && agentlab up`, said
+   before anything installs;
+2. creates the bootstrap the chart mounts but does not render: the four
+   CA/JWT pool Secrets (`service-dns-ca-pool` and `pod-identity-ca-pool` in
+   `podcertificate-controller-system`, `actor-id-jwt-pool` and
+   `actor-id-ca-pool` in `ate-system`) — never regenerated once they exist,
+   a rotated root would orphan every certificate issued from it — the
+   `actor-id-ca-certs` trust anchor derived from the actor-id pool, and
+   `ate-api-authentication`, ate-api-server's authentication config
+   pointing at the cluster's own ServiceAccount issuer. Upstream does this
+   with `kubectl-ate admin make-ca-pool` / `make-jwt-pool` and a shell step
+   between two `helm install`s; the lab embeds a Go port of the two commands
+   (`substratepools.go`, from substrate 0.0.26) and creates everything first,
+   so one waited install suffices (HACKS.md U22);
+3. installs `substrate-crds` and `substrate` 0.0.26 from
+   `oci://ghcr.io/kagent-dev/substrate/helm` into `ate-system` with the
+   chart's own values (`state/substrate-values.yaml`), the images
+   side-loaded like the platform's plus the gVisor worker image the
+   `WorkerPool` names, and waits for ate-api-server, atelet and atenet;
+4. checks the `SandboxConfig gvisor-default` the chart ships is there. The
+   `WorkerPool` and the `Harness`es come with the dev channel's kagent.
+
+`agentlab platform-down` uninstalls Substrate after the platform (whose
+teardown deletes kagent's `WorkerPool` through finalizers ate-controller has
+to be running for). Substrate's bundled PostgreSQL requests 1 CPU / 1 GiB,
+so the dev channel's floor is one CPU and about 2 GiB above the stable lab's
+— see [Docker resources](getting-started.md#docker-resources).
+
+**Proofs on the dev channel.** `platform-test`, `test` and the sign-in half
+of `backstage-test` run unchanged (platform-test expects a kagent scrape
+target only while a controller ServiceMonitor exists — the dev channel's
+kagent serves no metrics listener, and the lab renders none for it). The
+agent proofs — `agents-test`, `toolsets-test`, `models-test`'s agent turn,
+`backstage-test`'s agents pages — drive the released kagent's API (Agent CRs
+delivered as HelmReleases); kagent API v2 has `AgentTemplate`s and
+`Harness`es instead, so on the dev channel they do not apply until the
+proofs dispatch on the API the cluster serves, the dev channel's next step.
 
 ## The request path
 
@@ -339,6 +475,7 @@ data the page reads — see [The muster plugin](backstage.md#the-muster-plugin).
 | `kagent.ui.service.type: NodePort`, nodePort 30880 pinned by the kagent `postRenderers` patch | On a real MC the UI sits behind the agentgateway edge; this lab publishes it through the kind port mapping instead (host side `platform.agentsPort`, default 8081). The chart's Service template renders no `nodePort` field, so the fixed node port is a patch (HACKS.md U9). |
 | `components.flux.enabled: true`, `gitops.self.enabled: false` | The lab shape (see [The agent platform](#the-agent-platform-muster--kubernetes-mcp)): a management cluster runs its own Flux and installs the chart through it; the lab has none, so the chart brings the engine — and must not adopt its own release, because the lab installs charts and images that are not released. |
 | The chart pinned to an exact release (`platform.chartVersion`) | Component versions are the chart's own ranges, resolved by its Flux at reconcile time (the fleet's dogfooding track). The chart itself never floats in the lab: two runs install the same thing, and a bump is a deliberate edit with a lab run behind it. |
+| Substrate 0.0.26 installed by the lab ahead of the platform, bootstrap included (`platform.substrate.enabled`, implied by the dev channel) | The dev channel's kagent runs its agents as Substrate actors and cannot start without it, and Substrate is not a meta-chart component yet: its CA/JWT bootstrap is imperative (`kubectl-ate admin make-ca-pool`). The lab ports the two bootstrap commands, creates every object before one waited install and needs the apiserver gates its kind config turns on. See [Dev channel](#dev-channel). |
 | `mcp-prometheus` as a lab-rendered Flux `HelmRelease` | The one release the lab installs outside the chart rides the same engine, as the same tenant identity, so its lab-only sidecar is a `postRenderers` patch like the others and there is exactly one Helm writer (the embedded Helm, for the chart) and one Flux engine on the cluster. |
 
 ## Platform gotchas

--- a/internal/config/chart_test.go
+++ b/internal/config/chart_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -110,4 +111,100 @@ func repeat(s string, n int) string {
 		out += s
 	}
 	return out
+}
+
+// The branches the dev-channel tests spell out.
+const (
+	pocBranch  = "poc/kagent-main"
+	mainBranch = "main"
+)
+
+// The branch spelling in a dev tag is gitsemver's: lowercase, runs of
+// anything outside [a-z0-9] collapsed to one hyphen, hyphens trimmed, a
+// numeric name without leading zeros, "unknown" for nothing at all.
+func TestSanitizeBranch(t *testing.T) {
+	for branch, want := range map[string]string{
+		pocBranch:                  "poc-kagent-main",
+		mainBranch:                 mainBranch,
+		"Feat/Agent_Workspaces.v2": "feat-agent-workspaces-v2",
+		"renovate/axios-1.x":       "renovate-axios-1-x",
+		"--weird//branch--":        "weird-branch",
+		"release/0042":             "release-0042",
+		"0042":                     "42",
+		"000":                      "0",
+		"":                         "unknown",
+		"///":                      "unknown",
+	} {
+		if got := SanitizeBranch(branch); got != want {
+			t.Errorf("SanitizeBranch(%q) = %q, want %q", branch, got, want)
+		}
+	}
+}
+
+// The dev channel: a branch must leave a name to match tags with, and it
+// excludes a local chart; the pin is meaningless without a branch; Substrate
+// follows the channel unless pinned.
+func TestChartBranchValidation(t *testing.T) {
+	for _, ok := range []string{"", pocBranch, mainBranch, "feat/x_1"} {
+		if err := ValidateChartBranch(ok); err != nil {
+			t.Errorf("%q: %v", ok, err)
+		}
+	}
+	for _, bad := range []string{" main", "main ", "///", "--"} {
+		if err := ValidateChartBranch(bad); err == nil {
+			t.Errorf("%q: want an error", bad)
+		}
+	}
+
+	cfg := Default()
+	cfg.Platform.ChartBranch = pocBranch
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("chartBranch alone: %v", err)
+	}
+	if !cfg.SubstrateEnabled() {
+		t.Error("chartBranch with agents on must imply Substrate")
+	}
+	cfg.Platform.Agents = false
+	if cfg.SubstrateEnabled() {
+		t.Error("chartBranch without agents must not imply Substrate")
+	}
+	cfg.Platform.Agents = true
+	off := false
+	cfg.Platform.Substrate.Enabled = &off
+	if cfg.SubstrateEnabled() {
+		t.Error("an explicit substrate.enabled: false must win over the channel")
+	}
+	cfg.Platform.Substrate.Enabled = nil
+
+	cfg.Platform.ChartPath = t.TempDir()
+	if err := os.WriteFile(filepath.Join(cfg.Platform.ChartPath, "Chart.yaml"), []byte("name: agent-platform\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("chartBranch with chartPath: want the mutual-exclusion error, got %v", err)
+	}
+	cfg.Platform.ChartPath = ""
+
+	cfg.Platform.ChartPinned = true
+	cfg.Normalize()
+	if !cfg.Platform.ChartPinned {
+		t.Error("Normalize must keep the pin while chartBranch is set")
+	}
+	cfg.Platform.ChartBranch = ""
+	cfg.Normalize()
+	if cfg.Platform.ChartPinned {
+		t.Error("Normalize must drop the pin without a chartBranch")
+	}
+	if cfg.SubstrateEnabled() {
+		t.Error("the stable channel must not imply Substrate")
+	}
+	on := true
+	cfg.Platform.Substrate.Enabled = &on
+	if !cfg.SubstrateEnabled() {
+		t.Error("an explicit substrate.enabled: true must install it on the stable channel too")
+	}
+	cfg.Platform.Enabled = false
+	if cfg.SubstrateEnabled() {
+		t.Error("Substrate is inert without the platform")
+	}
 }

--- a/internal/config/chart_test.go
+++ b/internal/config/chart_test.go
@@ -80,6 +80,28 @@ func TestChartSourceValidation(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("devImages for muster, backstage, kagent: %v", err)
 	}
+
+	cfg.Platform.ValuesFiles = []string{filepath.Join(t.TempDir(), "missing.yaml")}
+	if err := cfg.Validate(); err == nil {
+		t.Error("valuesFiles with a missing file: want an error")
+	}
+	cfg.Platform.ValuesFiles = []string{""}
+	if err := cfg.Validate(); err == nil {
+		t.Error("valuesFiles with an empty path: want an error")
+	}
+	overlay := filepath.Join(t.TempDir(), "overlay.yaml")
+	if err := os.WriteFile(overlay, []byte("components: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg.Platform.ValuesFiles = []string{overlay}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("valuesFiles with an existing file: %v", err)
+	}
+	cfg.Platform.ValuesFiles = []string{}
+	cfg.Normalize()
+	if cfg.Platform.ValuesFiles != nil {
+		t.Error("Normalize must drop an empty valuesFiles list")
+	}
 }
 
 func repeat(s string, n int) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,14 @@ type Platform struct {
 	// the entry restores the chart's image on the next run. Keys are the
 	// DevImageComponents.
 	DevImages map[string]string `yaml:"devImages,omitempty"`
+	// ValuesFiles are extra Helm values files merged over the lab's rendered
+	// values before the meta chart install, in order, with `helm -f`
+	// semantics (maps merge, lists replace, the later file wins): a lab that
+	// points a component at another chart source
+	// (components.<name>.repository / versionRange / insecure) or forwards
+	// values the lab template does not know. Paths are absolute or relative
+	// to the lab directory; each must exist.
+	ValuesFiles []string `yaml:"valuesFiles,omitempty"`
 	// Additional kagent ModelConfigs beyond the chart-rendered default
 	// (aiModel): self-hosted OpenAI-compatible endpoints (vLLM, Ollama),
 	// OpenRouter, Gemini, plain OpenAI. Rendered as lab-labeled ModelConfig
@@ -652,6 +660,9 @@ func (c *Config) Normalize() {
 	if len(c.Platform.DevImages) == 0 {
 		c.Platform.DevImages = nil
 	}
+	if len(c.Platform.ValuesFiles) == 0 {
+		c.Platform.ValuesFiles = nil
+	}
 	c.Platform.ModelManager.normalize()
 }
 
@@ -756,6 +767,14 @@ func (c *Config) Validate() error {
 		}
 		if err := ValidateImageRef(ref); err != nil {
 			return fmt.Errorf("platform.devImages.%s %q: %w", component, ref, err)
+		}
+	}
+	for _, path := range c.Platform.ValuesFiles {
+		if path == "" {
+			return fmt.Errorf("platform.valuesFiles: an empty path")
+		}
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("platform.valuesFiles: %w", err)
 		}
 	}
 	seenModels := map[string]bool{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,27 @@ type Platform struct {
 	// chart changes that have no release yet (the lab's chart loop). The
 	// directory is read, never written; chartVersion is ignored while set.
 	ChartPath string `yaml:"chartPath,omitempty"`
+	// ChartBranch selects the DEV CHANNEL: the lab follows the newest dev
+	// build of this agent-platform branch — the `X.Y.Z-dev.<branch>.<date>.
+	// <time>.h<sha>` prerelease tags gitsemver publishes for every commit of
+	// a branch with branch publishing on — instead of a release. `configure`,
+	// `up` and `platform` resolve it against the chart registry's tags and
+	// write the tag they picked into chartVersion, so `render`, the image
+	// preload and a re-run install exactly what was resolved, and the boot
+	// says which build it runs. Mutually exclusive with chartPath; "" is the
+	// stable channel. See docs/platform.md "Dev channel".
+	ChartBranch string `yaml:"chartBranch,omitempty"`
+	// ChartPinned freezes chartVersion at the recorded dev build while
+	// chartBranch is set: `up` and `platform` stop re-resolving, so the lab
+	// keeps running the build under test until `agentlab platform --pin=false`
+	// (or the key is dropped). Meaningless without chartBranch.
+	ChartPinned bool `yaml:"chartPinned,omitempty"`
+	// Substrate installs kagent's actor runtime (kagent-dev/substrate) on the
+	// cluster before the platform — the kagent of the dev channel (kagent
+	// main, API v2) runs its agents as Substrate actors and cannot start
+	// without it; the released kagent ignores it. Left unset, it follows the
+	// channel: on with chartBranch (while agents are on), off otherwise.
+	Substrate Substrate `yaml:"substrate,omitempty"`
 	// DevImages swaps a component's image for a build of your own (the lab's
 	// dev-image loop): component name -> image ref (`muster: muster:dev-1a2b`).
 	// `agentlab platform` side-loads the ref from the host docker cache and
@@ -202,6 +223,14 @@ type Platform struct {
 	// `agentlab configure` fills the backends from what answers on this
 	// machine, on every run.
 	ModelManager ModelManager `yaml:"modelManager"`
+}
+
+// Substrate configures kagent's actor runtime in the lab (docs/platform.md
+// "Dev channel"). Enabled is a tri-state on purpose: nil follows the chart
+// channel (SubstrateEnabled), an explicit value wins either way — `configure
+// --substrate[=false]` writes one.
+type Substrate struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // ModelManager configures the umbrella's model-manager component in the lab.
@@ -663,7 +692,90 @@ func (c *Config) Normalize() {
 	if len(c.Platform.ValuesFiles) == 0 {
 		c.Platform.ValuesFiles = nil
 	}
+	// A pin only means something on the dev channel; a stable lab has
+	// nothing to freeze.
+	if c.Platform.ChartBranch == "" {
+		c.Platform.ChartPinned = false
+	}
 	c.Platform.ModelManager.normalize()
+}
+
+// SubstrateEnabled reports whether the lab installs Substrate: the explicit
+// knob (platform.substrate.enabled) when set, else the chart channel — the
+// dev channel's kagent (kagent main, API v2) runs its agents as Substrate
+// actors and cannot start without it, so chartBranch with agents on implies
+// it; the stable channel's kagent ignores it. Inert without the platform.
+func (c *Config) SubstrateEnabled() bool {
+	if !c.Platform.Enabled {
+		return false
+	}
+	if c.Platform.Substrate.Enabled != nil {
+		return *c.Platform.Substrate.Enabled
+	}
+	return c.Platform.ChartBranch != "" && c.Platform.Agents
+}
+
+// SubstrateReason words why SubstrateEnabled reads the way it does, for the
+// configure summary.
+func (c *Config) SubstrateReason() string {
+	switch {
+	case c.Platform.Substrate.Enabled != nil:
+		return "pinned by platform.substrate.enabled"
+	case c.SubstrateEnabled():
+		return "the dev channel's kagent needs it; `configure --substrate=false` overrides"
+	default:
+		return "the released kagent does not need it; `configure --substrate` installs it anyway"
+	}
+}
+
+// branchSanitizeRe is gitsemver's: every run of characters outside [a-z0-9]
+// becomes one hyphen, so "--" never occurs in a sanitized name and stays
+// free as gitsemver's truncation marker.
+var branchSanitizeRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// SanitizeBranch spells a git branch the way gitsemver (v2.0.1,
+// sanitizeBranchName) embeds it in a dev version: lowercased, runs of
+// anything but [a-z0-9] collapsed to one hyphen, hyphens trimmed off both
+// ends — `poc/kagent-main` is `poc-kagent-main`. A purely numeric result
+// loses its leading zeros (a semver numeric identifier forbids them); an
+// empty result is gitsemver's "unknown". gitsemver may further shorten the
+// name to fit its 63-character version budget (head`--`tail), which the
+// dev-tag filter accounts for.
+func SanitizeBranch(branch string) string {
+	b := strings.Trim(branchSanitizeRe.ReplaceAllString(strings.ToLower(branch), "-"), "-")
+	if b == "" {
+		return "unknown"
+	}
+	if allDigits(b) {
+		if b = strings.TrimLeft(b, "0"); b == "" {
+			b = "0"
+		}
+	}
+	return b
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return s != ""
+}
+
+// ValidateChartBranch accepts a branch name that leaves something to match
+// a dev tag with; "" is the stable channel and always fine.
+func ValidateChartBranch(s string) error {
+	if s == "" {
+		return nil
+	}
+	if strings.TrimSpace(s) != s {
+		return fmt.Errorf("must not have surrounding whitespace")
+	}
+	if SanitizeBranch(s) == "unknown" {
+		return fmt.Errorf("must contain a letter or digit (the dev tags carry the branch as a lowercase [a-z0-9-] name)")
+	}
+	return nil
 }
 
 // exactVersionRe is a plain semver version (an optional leading v tolerated):
@@ -760,6 +872,12 @@ func (c *Config) Validate() error {
 		if _, err := os.Stat(filepath.Join(c.Platform.ChartPath, "Chart.yaml")); err != nil {
 			return fmt.Errorf("platform.chartPath: %w (an agent-platform checkout's helm/agent-platform directory)", err)
 		}
+	}
+	if err := ValidateChartBranch(c.Platform.ChartBranch); err != nil {
+		return fmt.Errorf("platform.chartBranch %q: %w", c.Platform.ChartBranch, err)
+	}
+	if c.Platform.ChartBranch != "" && c.Platform.ChartPath != "" {
+		return fmt.Errorf("platform.chartBranch and platform.chartPath are mutually exclusive: a local chart has no dev builds to follow (`configure --chart-path \"\"` clears the path)")
 	}
 	for component, ref := range c.Platform.DevImages {
 		if !slices.Contains(DevImageComponents, component) {

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -23,6 +23,14 @@ const agentsTestToolset = "preset:read-only"
 // Deployment runs with (fullnameOverride: agent-manager).
 const agentManagerServiceAccount = "system:serviceaccount:" + platformNamespace + ":" + agentManagerMCPServer
 
+// baselineServiceAccount is a ServiceAccount no binding names: what it may do
+// is what every ServiceAccount may — discovery, the self-subject reviews, and
+// whatever a cluster's bootstrap policy hands system:authenticated (the
+// trust-bundle discovery with the ClusterTrustBundle gate on, which the lab's
+// kind config turns on for every cluster). The agent-manager ServiceAccount's
+// permissions of its own are what it holds beyond that.
+const baselineServiceAccount = "system:serviceaccount:" + platformNamespace + ":agentlab-nobody"
+
 // AgentsTest is the headless proof that agent-manager acts as the signed-in
 // user, through the platform path only (Dex id_token -> muster -> call_tool
 // x_agent-manager_*): get_info reports identity caller; the admin's create ->
@@ -248,16 +256,20 @@ func AgentsTest(cfg *config.Config, email string) error {
 		}
 	}
 
-	step("The agent-manager ServiceAccount holds no RBAC (auth can-i --list --as=%s)", agentManagerServiceAccount)
+	step("The agent-manager ServiceAccount holds no RBAC of its own (auth can-i --list --as=%s, against a ServiceAccount no binding names)", agentManagerServiceAccount)
 	rules, err := serviceAccountRules(agentManagerServiceAccount, kagentNamespace)
 	if err != nil {
 		return err
 	}
-	granted := rulesBeyondDiscovery(rules)
-	if len(granted) > 0 {
-		return fmt.Errorf("the agent-manager ServiceAccount still holds permissions in %s:\n%s", kagentNamespace, strings.Join(granted, "\n"))
+	baseline, err := serviceAccountRules(baselineServiceAccount, kagentNamespace)
+	if err != nil {
+		return err
 	}
-	note("nothing beyond discovery and self-subject reviews")
+	granted := rulesBeyond(rules, baseline)
+	if len(granted) > 0 {
+		return fmt.Errorf("the agent-manager ServiceAccount still holds permissions in %s beyond every ServiceAccount's:\n%s", kagentNamespace, strings.Join(granted, "\n"))
+	}
+	note("nothing beyond what every ServiceAccount holds (%d rows: discovery, self-subject reviews%s)", len(baseline), bootstrapExtras(baseline))
 
 	step("%sdelete_agent %s as %s", toolPrefix, agentsTestAgent, user.Email)
 	var deleted struct {
@@ -304,22 +316,37 @@ func serviceAccountRules(principal, ns string) ([]string, error) {
 	return ruleRows(status), nil
 }
 
-// rulesBeyondDiscovery drops the rows every authenticated principal has — the
-// selfsubject* reviews and the non-resource discovery URLs — and returns the
-// rest: permissions of the principal's own.
-func rulesBeyondDiscovery(rows []string) []string {
+// rulesBeyond drops from rows every row of baseline — what a ServiceAccount no
+// binding names may do on this cluster — and the CLI's header row, and returns
+// the rest: permissions of the principal's own.
+func rulesBeyond(rows, baseline []string) []string {
 	var granted []string
 	for _, row := range rows {
 		fields := strings.Fields(row)
-		if len(fields) == 0 || fields[0] == "Resources" {
-			continue
-		}
-		if strings.HasPrefix(fields[0], "selfsubject") || strings.HasPrefix(fields[0], "[") {
+		if len(fields) == 0 || fields[0] == "Resources" || slices.Contains(baseline, row) {
 			continue
 		}
 		granted = append(granted, row)
 	}
 	return granted
+}
+
+// bootstrapExtras names the resource rows of the baseline beyond the
+// self-subject reviews — what the cluster's bootstrap policy hands every
+// principal (the ClusterTrustBundle discovery on a 1.36 cluster with the gate
+// on) — for the note.
+func bootstrapExtras(baseline []string) string {
+	var extras []string
+	for _, row := range baseline {
+		fields := strings.Fields(row)
+		if len(fields) > 0 && !strings.HasPrefix(fields[0], "selfsubject") && !strings.HasPrefix(fields[0], "[") {
+			extras = append(extras, fields[0])
+		}
+	}
+	if len(extras) == 0 {
+		return ""
+	}
+	return ", " + strings.Join(extras, ", ")
 }
 
 // agentHelmReleaseManagers lists the field managers on an agent's HelmRelease

--- a/internal/lab/agentstest_test.go
+++ b/internal/lab/agentstest_test.go
@@ -12,26 +12,34 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
-// TestRulesBeyondDiscovery: of what `can-i --list` grants, the selfsubject*
-// reviews and the non-resource URLs are everyone's; any other row is a
-// permission of the principal's own. The CLI's header row, were it there,
-// is skipped too.
-func TestRulesBeyondDiscovery(t *testing.T) {
-	rows := ruleRows(&authorizationv1.SubjectRulesReviewStatus{
+// TestRulesBeyond: of what `can-i --list` grants, every row a ServiceAccount no
+// binding names holds too — the selfsubject* reviews, the non-resource URLs,
+// the bootstrap trust-bundle discovery — is everyone's; any other row is a
+// permission of the principal's own. The CLI's header row, were it there, is
+// skipped too.
+func TestRulesBeyond(t *testing.T) {
+	baseline := ruleRows(&authorizationv1.SubjectRulesReviewStatus{
 		ResourceRules: []authorizationv1.ResourceRule{
 			{Verbs: []string{verbCreate}, APIGroups: []string{"authorization.k8s.io"}, Resources: []string{"selfsubjectaccessreviews", "selfsubjectrulesreviews"}},
 			{Verbs: []string{verbCreate}, APIGroups: []string{"authentication.k8s.io"}, Resources: []string{"selfsubjectreviews"}},
+			{Verbs: []string{verbGet, verbList, "watch"}, APIGroups: []string{"certificates.k8s.io"}, Resources: []string{"clustertrustbundles"}},
 		},
 		NonResourceRules: []authorizationv1.NonResourceRule{{Verbs: []string{verbGet}, NonResourceURLs: []string{"/healthz", "/api", "/api/*"}}},
 	})
-	if got := rulesBeyondDiscovery(append([]string{"Resources  Non-Resource URLs  Resource Names  Verbs", ""}, rows...)); len(got) != 0 {
-		t.Errorf("discovery-only rules judged as permissions: %v", got)
+	if got := rulesBeyond(append([]string{"Resources  Non-Resource URLs  Resource Names  Verbs", ""}, baseline...), baseline); len(got) != 0 {
+		t.Errorf("everyone's rules judged as permissions: %v", got)
 	}
 	extra := ruleRows(&authorizationv1.SubjectRulesReviewStatus{ResourceRules: []authorizationv1.ResourceRule{
 		{Verbs: []string{verbGet, verbList}, APIGroups: []string{fluxHelmReleaseGVK.Group}, Resources: []string{fluxHelmReleaseGVR.Resource}},
 	}})
-	if got := rulesBeyondDiscovery(append(rows, extra...)); !reflect.DeepEqual(got, extra) {
+	if got := rulesBeyond(append(baseline, extra...), baseline); !reflect.DeepEqual(got, extra) {
 		t.Errorf("granted = %v, want %v", got, extra)
+	}
+	if got := bootstrapExtras(baseline); got != ", clustertrustbundles.certificates.k8s.io" {
+		t.Errorf("bootstrapExtras = %q", got)
+	}
+	if got := bootstrapExtras(baseline[:3]); got != "" {
+		t.Errorf("bootstrapExtras without extras = %q", got)
 	}
 }
 

--- a/internal/lab/chartbranch.go
+++ b/internal/lab/chartbranch.go
@@ -1,0 +1,115 @@
+package lab
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The dev channel (docs/platform.md "Dev channel"): platform.chartBranch
+// names an agent-platform branch, and the lab follows that branch's newest
+// dev build — the chart gitsemver publishes for every commit of a branch
+// with branch publishing on (giantswarm/github `gen.ci.branchPublish`), the
+// way a Flux OCIRepository with `semver: "*-*"` and a `semverFilter` on the
+// branch would. Resolution happens where a version is chosen — `configure`,
+// `up`, `platform` — and writes the tag it picked into platform.chartVersion,
+// so everything downstream (the render, the image preload, the install, a
+// re-run, `helm history`) sees one exact version, as on the stable channel.
+
+// devTagRe is the shape of gitsemver's (v2.0.1) dev prerelease:
+// `dev.<branch>.<YYYY-MM-DD>.<HH-MM-SS>[.h<sha7>]`, the branch a lowercase
+// [a-z0-9-] name (config.SanitizeBranch), possibly shortened with a `--`
+// marker in its middle to fit gitsemver's 63-character version budget. The
+// date and time compare lexically per semver identifier, so within a branch
+// the highest version is the newest build.
+var devTagRe = regexp.MustCompile(`^dev\.([a-z0-9-]+)\.\d{4}-\d{2}-\d{2}\.\d{2}-\d{2}-\d{2}(?:\.h[0-9a-f]{7})?$`)
+
+// devTruncationMarker is what gitsemver puts in place of a long branch
+// name's dropped middle.
+const devTruncationMarker = "--"
+
+// devTagFilter is THE definition of "a dev build of this branch": the
+// predicate a chart version's prerelease must satisfy. Today it reads
+// gitsemver's `dev.<sanitized branch>.<date>.<time>.h<sha>` schema (the
+// one architect ships); the RFC's successor schema
+// `-b<crc32(branch) 8 hex>t<YYYYMMDDHHMMSS>c<sha7>` is switched here, in
+// this one function, when gitsemver ships it — nothing else in the lab
+// knows what a dev tag looks like.
+func devTagFilter(branch string) func(prerelease string) bool {
+	want := config.SanitizeBranch(branch)
+	return func(prerelease string) bool {
+		m := devTagRe.FindStringSubmatch(prerelease)
+		if m == nil {
+			return false
+		}
+		got := m[1]
+		if got == want {
+			return true
+		}
+		// gitsemver keeps a long branch's head and tail around the marker;
+		// a sanitized name never contains "--" itself, so the marker is
+		// unambiguous. Either side may be empty when the budget was tight.
+		head, tail, truncated := strings.Cut(got, devTruncationMarker)
+		return truncated && len(head)+len(tail) < len(want) &&
+			strings.HasPrefix(want, head) && strings.HasSuffix(want, tail)
+	}
+}
+
+// pickDevTag chooses the newest dev build of a branch among a chart
+// repository's tags: the highest semver version whose prerelease the branch's
+// devTagFilter accepts. Tags that are no version, releases and other
+// branches' builds are skipped; the order of the list does not matter.
+func pickDevTag(tags []string, branch string) (string, bool) {
+	matches := devTagFilter(branch)
+	var best *semver.Version
+	for _, tag := range tags {
+		v, err := semver.StrictNewVersion(tag)
+		if err != nil || !matches(v.Prerelease()) {
+			continue
+		}
+		if best == nil || v.GreaterThan(best) {
+			best = v
+		}
+	}
+	if best == nil {
+		return "", false
+	}
+	return best.Original(), true
+}
+
+// ResolveChartVersion follows platform.chartBranch: it lists the chart
+// repository's tags, picks the branch's newest dev build and writes it into
+// cfg.Platform.ChartVersion, reporting whether that changed the config (the
+// caller saves). A pinned lab (platform.chartPinned) keeps its recorded
+// version; the stable channel (no chartBranch) is left alone. No build of
+// the branch is a refusal with the two ways out: wait for the branch's
+// publish, or pin a tag by hand.
+func ResolveChartVersion(cfg *config.Config) (changed bool, err error) {
+	branch := cfg.Platform.ChartBranch
+	if branch == "" {
+		return false, nil
+	}
+	if cfg.Platform.ChartPinned {
+		note("chart agent-platform %s (branch %s, pinned — `agentlab platform --pin=false` follows the branch again)", cfg.Platform.ChartVersion, branch)
+		return false, nil
+	}
+	tags, err := helmChartTags(config.ChartRepository)
+	if err != nil {
+		return false, fmt.Errorf("resolving the dev channel of branch %s: %w", branch, err)
+	}
+	tag, ok := pickDevTag(tags, branch)
+	if !ok {
+		return false, fmt.Errorf("no dev build of branch %s in %s (no tag of the form X.Y.Z-dev.%s.<date>.<time>.h<sha> among %d);\n"+
+			"either the branch's publish has not run yet (agent-platform needs `gen.ci.branchPublish` in giantswarm/github and a commit on the branch),\n"+
+			"or pin a build by hand: `agentlab configure --chart-version <full dev tag>` after `--chart-branch \"\"`",
+			branch, config.ChartRepository, config.SanitizeBranch(branch), len(tags))
+	}
+	changed = tag != cfg.Platform.ChartVersion
+	cfg.Platform.ChartVersion = tag
+	note("chart agent-platform %s (branch %s)", tag, branch)
+	return changed, nil
+}

--- a/internal/lab/chartbranch_test.go
+++ b/internal/lab/chartbranch_test.go
@@ -1,0 +1,87 @@
+package lab
+
+import (
+	"testing"
+)
+
+// The dev-channel filter reads gitsemver's dev tags: a branch's own builds,
+// spelled with its sanitized name, in either the full or the `--`-shortened
+// form; never a release, never a sibling branch whose sanitized name shares
+// a prefix, never a renovate branch.
+func TestDevTagFilter(t *testing.T) {
+	matches := devTagFilter("poc/kagent-main")
+	for _, ok := range []string{
+		"dev.poc-kagent-main.2026-09-09.20-23-54.h28f7f50",
+		"dev.poc-kagent-main.2026-09-10.08-12-33",
+	} {
+		if !matches(ok) {
+			t.Errorf("%q must match poc/kagent-main", ok)
+		}
+	}
+	for _, bad := range []string{
+		"",
+		"rc.1",
+		"dev.poc-kagent-main-2.2026-09-09.20-23-54.h28f7f50",
+		"dev.poc-kagent.2026-09-09.20-23-54.h28f7f50",
+		"dev.renovate-axios-1-x.2026-09-09.19-47-39.h4fb8c37",
+		"dev.poc-kagent-main.2026-09-09.h28f7f50",
+		"dev.poc-kagent-main.2026-09-09.20-23-54.28f7f50",
+		"dev.POC-kagent-main.2026-09-09.20-23-54.h28f7f50",
+	} {
+		if matches(bad) {
+			t.Errorf("%q must not match poc/kagent-main", bad)
+		}
+	}
+
+	// gitsemver shortens a long branch to head--tail within its version
+	// budget; the head and tail are the sanitized name's own ends.
+	long := devTagFilter("feat/agent-workspaces-management-v2")
+	if !long("dev.feat-agent-w--management-v2.2026-09-10.08-12-33.h1234567") {
+		t.Error("the truncated form of the branch must match")
+	}
+	if long("dev.feat-agent-w--management-v3.2026-09-10.08-12-33.h1234567") {
+		t.Error("a truncated tail of another branch must not match")
+	}
+	if long("dev.feat-agent-workspaces-management-v2--x.2026-09-10.08-12-33.h1234567") {
+		t.Error("a marker that keeps more than the name must not match")
+	}
+	if devTagFilter("main")("dev.ma--in.2026-09-10.08-12-33.h1234567") {
+		t.Error("a name that fits is never truncated: head+tail must be shorter than the name")
+	}
+}
+
+// Among a repository's tags the newest dev build of the branch wins: a later
+// timestamp beats an earlier one whatever the list order, a higher base
+// version beats a lower one, releases and other branches never count.
+func TestPickDevTag(t *testing.T) {
+	tags := []string{
+		"3.22.0",
+		"3.21.2",
+		"3.22.1-dev.poc-kagent-main.2026-09-10.08-12-33.h7f841be",
+		"3.22.1-dev.poc-kagent-main.2026-09-09.20-23-54.h28f7f50",
+		"3.22.1-dev.renovate-axios-1-x.2026-09-11.19-47-39.h4fb8c37",
+		"3.22.1-dev.poc-kagent-main-2.2026-09-12.10-00-00.haaaaaaa",
+		"3.22.1-rc.1",
+		"not-a-version",
+	}
+	got, ok := pickDevTag(tags, "poc/kagent-main")
+	if !ok || got != "3.22.1-dev.poc-kagent-main.2026-09-10.08-12-33.h7f841be" {
+		t.Errorf("pickDevTag = %q, %v; want the 2026-09-10 build", got, ok)
+	}
+	// A newer base version (the branch rebased over a release) beats an
+	// older base with a later timestamp: that is the semver order Flux and
+	// Helm resolve by too, and the branch's next build carries it forward.
+	got, _ = pickDevTag(append(tags, "3.23.1-dev.poc-kagent-main.2026-09-01.00-00-00.h0000000"), "poc/kagent-main")
+	if got != "3.23.1-dev.poc-kagent-main.2026-09-01.00-00-00.h0000000" {
+		t.Errorf("a higher base must win: %q", got)
+	}
+	if got, ok := pickDevTag(tags, "renovate/axios-1.x"); !ok || got != "3.22.1-dev.renovate-axios-1-x.2026-09-11.19-47-39.h4fb8c37" {
+		t.Errorf("renovate branch: %q, %v", got, ok)
+	}
+	if _, ok := pickDevTag(tags, "main"); ok {
+		t.Error("a branch without builds must not resolve")
+	}
+	if _, ok := pickDevTag(nil, "poc/kagent-main"); ok {
+		t.Error("no tags must not resolve")
+	}
+}

--- a/internal/lab/down.go
+++ b/internal/lab/down.go
@@ -99,6 +99,11 @@ func PlatformDown(cfg *config.Config) error {
 	if err := deleteNamespace(ctx, platformNamespace); err != nil {
 		return err
 	}
+	// Substrate after the platform: the teardown above deleted kagent's
+	// WorkerPool and Harnesses, whose finalizers ate-controller processed.
+	if err := substrateDown(ctx); err != nil {
+		return err
+	}
 	// What an earlier agentlab installed next to the umbrella: its own Flux
 	// controllers for the agent create flow. The chart brings the engine now
 	// and refuses a second Flux (refuseOlderLabShape), so they go with the

--- a/internal/lab/helm.go
+++ b/internal/lab/helm.go
@@ -240,12 +240,18 @@ func (h *helmOp) loadChart(opts *action.ChartPathOptions, ref, version string) (
 }
 
 // helmValuesFile reads one values file the way `-f` does: Helm's values
-// loader, so a `null` deletes the key it overrides exactly as the CLI has it.
+// loader, so a `null` survives as the key's deletion marker.
 func helmValuesFile(path string) (map[string]any, error) {
-	opts := values.Options{ValueFiles: []string{path}}
+	return helmValuesFiles(path)
+}
+
+// helmValuesFiles reads values files the way repeated `-f` flags do: maps
+// merge, lists replace, the later file wins.
+func helmValuesFiles(paths ...string) (map[string]any, error) {
+	opts := values.Options{ValueFiles: paths}
 	vals, err := opts.MergeValues(getter.All(helmSettings()))
 	if err != nil {
-		return nil, fmt.Errorf("reading the values %s: %w", path, err)
+		return nil, fmt.Errorf("reading the values %s: %w", strings.Join(paths, ", "), err)
 	}
 	return vals, nil
 }

--- a/internal/lab/helm.go
+++ b/internal/lab/helm.go
@@ -187,6 +187,19 @@ func newHelmOp(namespace string) (*helmOp, error) {
 	if err := cfg.Init(labRESTClientGetter(namespace), namespace, helmDriver); err != nil {
 		return nil, fmt.Errorf("initialising the embedded Helm: %w", err)
 	}
+	rc, err := newHelmRegistryClient(settings, log)
+	if err != nil {
+		return nil, err
+	}
+	cfg.RegistryClient = rc
+	return &helmOp{cfg: cfg, settings: settings, log: log}, nil
+}
+
+// newHelmRegistryClient is the CLI's default OCI registry client: the
+// registry cache on, credentials from Helm's registry config file (anonymous
+// where there are none — gsoci and ghcr hand out pull and tag-list tokens
+// without any).
+func newHelmRegistryClient(settings *cli.EnvSettings, log *helmLog) (*registry.Client, error) {
 	rc, err := registry.NewClient(
 		registry.ClientOptDebug(settings.Debug),
 		registry.ClientOptEnableCache(true),
@@ -196,8 +209,27 @@ func newHelmOp(namespace string) (*helmOp, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating the OCI registry client: %w", err)
 	}
-	cfg.RegistryClient = rc
-	return &helmOp{cfg: cfg, settings: settings, log: log}, nil
+	return rc, nil
+}
+
+// helmChartTags lists an oci:// chart repository's tags the way Helm resolves
+// a version range against it (registry.Client.Tags, what source-controller
+// does for an OCIRepository too): every tag that parses as a semver version,
+// highest first — a `+` build metadata separator spelled `_` in the registry
+// comes back as `+`. Needs no cluster: only the registry is contacted.
+func helmChartTags(ref string) ([]string, error) {
+	log := newHelmLog()
+	settings := helmSettings()
+	rc, err := newHelmRegistryClient(settings, log)
+	if err != nil {
+		return nil, err
+	}
+	tags, err := rc.Tags(strings.TrimPrefix(ref, registry.OCIScheme+"://"))
+	if err != nil {
+		log.dump()
+		return nil, fmt.Errorf("listing the tags of %s: %w", ref, err)
+	}
+	return tags, nil
 }
 
 // fail wraps an operation's error the way a failed subprocess read — the
@@ -275,9 +307,21 @@ func helmChartLabel(ref, version string) string {
 	return ref + " --version " + version
 }
 
+// helmInstallOptions are the flags of helmUpgradeInstall beyond the chart
+// and its values.
+type helmInstallOptions struct {
+	// CreateNamespace is `--create-namespace`.
+	CreateNamespace bool
+	// TakeOwnership is `--take-ownership`: objects the chart renders that
+	// already exist without Helm's ownership metadata are adopted instead of
+	// refused — a namespace the lab had to create ahead of the chart to seed
+	// Secrets into (Substrate's podcertificate-controller-system).
+	TakeOwnership bool
+}
+
 // helmUpgradeInstall is `helm upgrade --install <release> <chart> -n <ns> -f
 // <values> --wait --timeout <timeout> --force-conflicts` (plus
-// --create-namespace when asked):
+// --create-namespace and --take-ownership when asked):
 // the release is installed when it does not exist or was uninstalled,
 // upgraded otherwise, with the CLI's defaults — server-side apply on install
 // and, on upgrade, the method the release was applied with; no
@@ -287,7 +331,7 @@ func helmChartLabel(ref, version string) string {
 // release, custom resources included, is Current. Ctrl-C cancels the
 // operation the way it cancels the CLI: the release is marked failed instead
 // of staying pending forever.
-func helmUpgradeInstall(namespace, releaseName, ref, version string, vals map[string]any, timeout time.Duration, createNamespace bool) error {
+func helmUpgradeInstall(namespace, releaseName, ref, version string, vals map[string]any, timeout time.Duration, opts helmInstallOptions) error {
 	h, err := newHelmOp(namespace)
 	if err != nil {
 		return err
@@ -312,7 +356,8 @@ func helmUpgradeInstall(namespace, releaseName, ref, version string, vals map[st
 		install := action.NewInstall(h.cfg)
 		install.ReleaseName = releaseName
 		install.Namespace = namespace
-		install.CreateNamespace = createNamespace
+		install.CreateNamespace = opts.CreateNamespace
+		install.TakeOwnership = opts.TakeOwnership
 		install.Timeout = timeout
 		install.WaitStrategy = kube.StatusWatcherStrategy
 		install.ForceConflicts = true
@@ -339,6 +384,7 @@ func helmUpgradeInstall(namespace, releaseName, ref, version string, vals map[st
 	// was pinned (owned by the binary's name then) upgrades instead of
 	// failing on every zero-valued field of the chart.
 	upgrade.ForceConflicts = true
+	upgrade.TakeOwnership = opts.TakeOwnership
 	upgrade.MaxHistory = h.settings.MaxHistory
 	ch, err := h.loadChart(&upgrade.ChartPathOptions, ref, version)
 	if err != nil {

--- a/internal/lab/helm_test.go
+++ b/internal/lab/helm_test.go
@@ -245,3 +245,32 @@ func TestHelmReleaseProbesWithoutCluster(t *testing.T) {
 		t.Errorf("error should name the missing lab kubeconfig: %v", err)
 	}
 }
+
+// TestHelmValuesFilesLaterWins: platform.valuesFiles are read as repeated
+// `-f` flags — maps merge, lists replace, the later file wins.
+func TestHelmValuesFilesLaterWins(t *testing.T) {
+	isolateHelm(t)
+	dir := t.TempDir()
+	base := filepath.Join(dir, "base.yaml")
+	overlay := filepath.Join(dir, "overlay.yaml")
+	if err := os.WriteFile(base, []byte("components:\n  kagent:\n    enabled: true\n    omitKeys: [a, b]\nkeep: base\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlay, []byte("components:\n  kagent:\n    repository: oci://kind-registry:5000/charts\n    omitKeys: [c]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	vals, err := helmValuesFiles(base, overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kagent, _ := vals["components"].(map[string]any)["kagent"].(map[string]any)
+	if kagent["enabled"] != true || kagent["repository"] != "oci://kind-registry:5000/charts" {
+		t.Errorf("maps not merged: %#v", kagent)
+	}
+	if keys, _ := kagent["omitKeys"].([]any); len(keys) != 1 || keys[0] != "c" {
+		t.Errorf("lists must be replaced by the later file, got %#v", kagent["omitKeys"])
+	}
+	if vals["keep"] != "base" {
+		t.Errorf("keys only the base file has must survive, got %#v", vals["keep"])
+	}
+}

--- a/internal/lab/kagentcrd.go
+++ b/internal/lab/kagentcrd.go
@@ -75,3 +75,11 @@ func agentCRDIconURL(crd *unstructured.Unstructured) (idx int, present bool, nam
 	}
 	return idx, present, names
 }
+
+// agentCRDServed reports whether kagent's Agent CRD exists: the 0.x line
+// serves it, kagent API v2 (Harness + AgentTemplate, kagent.dev/v1alpha3)
+// does not — the Agent-CR heals then have nothing to apply to.
+func agentCRDServed() bool {
+	_, err := getObject(context.Background(), gvrCRDs, "", agentCRD)
+	return err == nil
+}

--- a/internal/lab/kube.go
+++ b/internal/lab/kube.go
@@ -454,18 +454,58 @@ func (k *kubeClients) apply(ctx context.Context, obj *unstructured.Unstructured)
 // apiVersion/kind it carries, minus the empty creationTimestamp and status
 // the conversion emits, which are nobody's intent.
 func applyTyped(ctx context.Context, obj runtime.Object) (applyResult, error) {
-	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	u, err := toUnstructured(obj)
 	if err != nil {
 		return applyResult{}, err
 	}
-	u := &unstructured.Unstructured{Object: raw}
-	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
-	unstructured.RemoveNestedField(u.Object, "status")
 	k, err := labKube()
 	if err != nil {
 		return applyResult{}, err
 	}
 	return k.apply(ctx, u)
+}
+
+// createTyped creates a typed object the way `kubectl create` does — no
+// apply, no update: for an object that must not overwrite one another run
+// created a moment earlier, a Secret holding freshly generated key material
+// (substrate.go). The caller guards with an existence check; an AlreadyExists
+// comes back as the apiserver's error.
+func createTyped(ctx context.Context, obj runtime.Object) error {
+	u, err := toUnstructured(obj)
+	if err != nil {
+		return err
+	}
+	k, err := labKube()
+	if err != nil {
+		return err
+	}
+	gvk := u.GroupVersionKind()
+	mapping, err := k.restMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", gvk.Kind, u.GetName(), err)
+	}
+	ns := u.GetNamespace()
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace && ns == "" {
+		ns = defaultNamespace
+		u.SetNamespace(ns)
+	}
+	if _, err := k.resource(mapping.Resource, ns).Create(ctx, u, metav1.CreateOptions{FieldManager: applyFieldManager}); err != nil {
+		return fmt.Errorf("creating %s: %w", describe(mapping.Resource, ns, u.GetName()), err)
+	}
+	return nil
+}
+
+// toUnstructured is a typed object's wire form with the apiVersion/kind it
+// carries, minus the empty creationTimestamp and status the conversion emits.
+func toUnstructured(obj runtime.Object) (*unstructured.Unstructured, error) {
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{Object: raw}
+	unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(u.Object, "status")
+	return u, nil
 }
 
 // awaitCRDs waits until the apiserver serves every kind the given

--- a/internal/lab/kube_test.go
+++ b/internal/lab/kube_test.go
@@ -80,6 +80,8 @@ var (
 	musterMCPServerGVR = musterMCPServerGVK.GroupVersion().WithResource("mcpservers")
 	prometheusGVK      = schema.GroupVersionKind{Group: "monitoring.coreos.com", Version: "v1", Kind: "Prometheus"}
 	prometheusGVR      = prometheusGVK.GroupVersion().WithResource("prometheuses")
+	serviceMonitorGVK  = prometheusGVK.GroupVersion().WithKind("ServiceMonitor")
+	serviceMonitorGVR  = prometheusGVK.GroupVersion().WithResource("servicemonitors")
 )
 
 // fakeLab is a kubeClients bundle on fakes, installed as the lab's client for
@@ -159,6 +161,7 @@ func newFakeLab(t *testing.T, objects ...runtime.Object) *fakeLab {
 		fluxHelmReleaseGVR: "HelmReleaseList",
 		musterMCPServerGVR: "MCPServerList",
 		prometheusGVR:      "PrometheusList",
+		serviceMonitorGVR:  "ServiceMonitorList",
 		gvrModelConfigs:    "ModelConfigList",
 		gvrAgents:          "AgentList",
 	}, seeds...)
@@ -180,6 +183,7 @@ func newFakeLab(t *testing.T, objects ...runtime.Object) *fakeLab {
 		fluxHelmReleaseGVK,
 		musterMCPServerGVK,
 		prometheusGVK,
+		serviceMonitorGVK,
 		// kagent's ModelConfig and Agent, which the proofs read and write
 		// (crds_test.go).
 		gvkModelConfig,

--- a/internal/lab/models.go
+++ b/internal/lab/models.go
@@ -178,35 +178,62 @@ func extraModelsHint(models []config.ExtraModel) string {
 // waitModelConfigAccepted polls one ModelConfig until the controller accepts
 // it — the machine check that the provider/model/Secret combination is one
 // the runtime can mount, before anyone debugs it from a failing agent pod.
-// A read that fails is reported as such, with the apiserver's words, never as
+// kagent main splits the verdict in two: Accepted (the spec is coherent) and
+// ResolvedRefs (the Secret it names exists and holds the key); an Accepted
+// ModelConfig whose ResolvedRefs is False is not usable, so that is refused
+// too, while a status without the condition (the 0.x line) still passes. A
+// read that fails is reported as such, with the apiserver's words, never as
 // an empty status.
 func waitModelConfigAccepted(name string) error {
 	var status string
 	var readErr error
 	accepted := waitFor(10, modelConfigAcceptedPoll, func() bool {
-		status, readErr = modelConfigCondition(name, "Accepted")
+		status, _, readErr = modelConfigCondition(name, "Accepted")
 		return readErr == nil && status == "True"
 	})
 	if !accepted {
 		return notReached("ModelConfig "+name, "Accepted", status, readErr,
 			fmt.Sprintf("check `kubectl -n %s describe %s %s`", kagentNamespace, modelConfigResource, name))
 	}
-	note("ModelConfig %s: Accepted", name)
+	resolved, message, err := modelConfigCondition(name, conditionResolvedRefs)
+	if err != nil {
+		return err
+	}
+	if resolved == condFalseStatus {
+		return fmt.Errorf("ModelConfig %s is Accepted but %s=False: %s;\ncheck `kubectl -n %s describe %s %s`", name, conditionResolvedRefs, message, kagentNamespace, modelConfigResource, name)
+	}
+	note("ModelConfig %s: Accepted%s", name, resolvedNote(resolved))
 	return nil
 }
 
-// modelConfigCondition reads one condition's status off a ModelConfig ("" while
-// the controller has not written it).
-func modelConfigCondition(name, condType string) (string, error) {
+// resolvedNote words the ResolvedRefs condition for the note: nothing when the
+// controller writes none (the 0.x line), the status otherwise.
+func resolvedNote(resolved string) string {
+	if resolved == "" {
+		return ""
+	}
+	return ", " + conditionResolvedRefs + "=" + resolved
+}
+
+// conditionResolvedRefs is kagent main's second ModelConfig condition: the
+// referenced Secret exists and holds the key.
+const conditionResolvedRefs = "ResolvedRefs"
+
+// condFalseStatus is a condition's False status.
+const condFalseStatus = "False"
+
+// modelConfigCondition reads one condition's status and message off a
+// ModelConfig ("" while the controller has not written it).
+func modelConfigCondition(name, condType string) (status, message string, err error) {
 	gvr, err := gvrFor(modelConfigResource)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
 	defer cancel()
 	obj, err := getObject(ctx, gvr, kagentNamespace, name)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return conditionStatus(obj, condType), nil
+	return conditionStatus(obj, condType), conditionMessage(obj, condType), nil
 }

--- a/internal/lab/models_test.go
+++ b/internal/lab/models_test.go
@@ -90,12 +90,19 @@ func TestWaitModelConfigAccepted(t *testing.T) {
 	prev := modelConfigAcceptedPoll
 	modelConfigAcceptedPoll = time.Millisecond
 	t.Cleanup(func() { modelConfigAcceptedPoll = prev })
+	unresolved := withCondition(labelledModelConfig("unresolved"), "Accepted", "True", "")
+	conds, _, _ := unstructured.NestedSlice(unresolved.Object, fieldStatus, "conditions")
+	_ = unstructured.SetNestedSlice(unresolved.Object, append(conds, map[string]any{fieldType: conditionResolvedRefs, fieldStatus: condFalse, fieldMessage: "secret placeholder not found"}), fieldStatus, "conditions")
 	newFakeLab(t,
 		withCondition(labelledModelConfig("ok"), "Accepted", "True", ""),
 		withCondition(labelledModelConfig("nope"), "Accepted", condFalse, "no such provider"),
+		unresolved,
 	)
 	if err := waitModelConfigAccepted("ok"); err != nil {
-		t.Errorf("accepted: %v", err)
+		t.Errorf("accepted without a ResolvedRefs condition (the 0.x line): %v", err)
+	}
+	if err := waitModelConfigAccepted("unresolved"); err == nil || !strings.Contains(err.Error(), "ResolvedRefs=False: secret placeholder not found") {
+		t.Errorf("accepted but unresolved: %v", err)
 	}
 	err := waitModelConfigAccepted("nope")
 	if err == nil || !strings.Contains(err.Error(), `ModelConfig nope never reached Accepted (last status: "False")`) {

--- a/internal/lab/observability.go
+++ b/internal/lab/observability.go
@@ -71,7 +71,7 @@ func observabilityUp(cfg *config.Config) error {
 		return err
 	}
 	if err := ensureSecretFromFiles(observabilityNamespace, "dex-ca", map[string]string{
-		"ca.crt": caCertPath,
+		caCertKey: caCertPath,
 	}); err != nil {
 		return err
 	}
@@ -212,5 +212,5 @@ func installOCIChart(cfg *config.Config, release, chartRef, version, valuesTmpl 
 			}
 		}
 	}
-	return helmUpgradeInstall(observabilityNamespace, release, chartRef, version, values, ociChartInstallTimeout, true)
+	return helmUpgradeInstall(observabilityNamespace, release, chartRef, version, values, ociChartInstallTimeout, helmInstallOptions{CreateNamespace: true})
 }

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -45,6 +45,11 @@ const (
 	conditionTrue  = "True"
 )
 
+// caCertKey is the data key a CA-bundle Secret carries its PEM under — the
+// convention the chart's global.identity.ca, muster's extraCaFile and
+// Substrate's actor-id trust anchor share.
+const caCertKey = "ca.crt"
+
 // The platform's generated secrets (platformSecretsName): created once and
 // then left alone — regenerating the encryption key on every run would
 // invalidate every issued token. dex-client-secret must match the
@@ -129,22 +134,30 @@ type platformChart struct {
 	ref string
 	// version is the version of a registry chart; empty for a directory.
 	version string
+	// branch is the dev channel's branch when the version is one of its
+	// builds (platform.chartBranch); empty on the stable channel.
+	branch string
 }
 
 func (c platformChart) String() string {
-	if c.version == "" {
+	switch {
+	case c.version == "":
 		return "the local chart at " + c.ref
+	case c.branch != "":
+		return fmt.Sprintf("agent-platform %s (branch %s)", c.version, c.branch)
+	default:
+		return fmt.Sprintf("agent-platform %s", c.version)
 	}
-	return fmt.Sprintf("agent-platform %s", c.version)
 }
 
 // platformChartFor reads the chart source from the config: platform.chartPath
-// wins over the pinned release.
+// wins over the pinned release; on the dev channel the version is the
+// branch's build ResolveChartVersion recorded.
 func platformChartFor(cfg *config.Config) platformChart {
 	if cfg.Platform.ChartPath != "" {
 		return platformChart{ref: cfg.Platform.ChartPath}
 	}
-	return platformChart{ref: config.ChartRepository, version: cfg.Platform.ChartVersion}
+	return platformChart{ref: config.ChartRepository, version: cfg.Platform.ChartVersion, branch: cfg.Platform.ChartBranch}
 }
 
 // platformUp installs and verifies the platform, then prints the boot's one
@@ -157,6 +170,17 @@ func platformUp(cfg *config.Config, header string) error {
 	removeLegacyArtifacts()
 	if err := refuseOlderLabShape(); err != nil {
 		return err
+	}
+	// The dev channel follows its branch on every run, like Flux would: a
+	// newer build is a new revision of the release below. The pick lands in
+	// agentlab.yaml so the next command — or a colleague reading the file —
+	// sees the exact version this lab runs.
+	if changed, err := ResolveChartVersion(cfg); err != nil {
+		return err
+	} else if changed {
+		if err := cfg.Save(); err != nil {
+			return err
+		}
 	}
 	chart := platformChartFor(cfg)
 	step("Installing %s in the lab shape (bundled Flux engine on, self-management off)", chart)
@@ -183,7 +207,7 @@ func platformUp(cfg *config.Config, header string) error {
 	// self-signed Dex over TLS (values: muster.muster.extraCaFile); Backstage
 	// mounts the same Secret through global.identity.ca (NODE_EXTRA_CA_CERTS).
 	if err := ensureSecretFromFiles(platformNamespace, "dex-ca", map[string]string{
-		"ca.crt": caCertPath,
+		caCertKey: caCertPath,
 	}); err != nil {
 		return err
 	}
@@ -242,6 +266,14 @@ func platformUp(cfg *config.Config, header string) error {
 	// exist before the ServiceMonitors the components render.
 	if cfg.Platform.Observability {
 		if err := observabilityUp(cfg); err != nil {
+			return err
+		}
+	}
+	// Substrate before the platform too: the dev channel's kagent creates
+	// its WorkerPool and Harnesses against Substrate's API at startup, and
+	// its controller does not come up without them (substrate.go).
+	if cfg.SubstrateEnabled() {
+		if err := substrateUp(cfg); err != nil {
 			return err
 		}
 	}
@@ -327,7 +359,7 @@ func platformUp(cfg *config.Config, header string) error {
 	// HelmRelease among them — so the install returns once the components
 	// are Ready; waitPlatformReleases below then reads the outcome per
 	// release.
-	if err := helmUpgradeInstall(platformNamespace, platformRelease, chart.ref, chart.version, values, helmInstallTimeout, false); err != nil {
+	if err := helmUpgradeInstall(platformNamespace, platformRelease, chart.ref, chart.version, values, helmInstallTimeout, helmInstallOptions{}); err != nil {
 		reportPlatformReleases()
 		return err
 	}
@@ -503,6 +535,9 @@ func platformUp(cfg *config.Config, header string) error {
 	if cfg.Platform.Observability {
 		obsHint = "  Observability: Prometheus scrapes the cluster; muster serves it as x_mcp-prometheus_* tools\n" +
 			"  (try asking Claude Code for a pod's CPU or memory)."
+	}
+	if cfg.SubstrateEnabled() {
+		agentsHint += fmt.Sprintf("\n  Substrate %s (kagent's actor runtime) runs in %s: kubectl get workerpools,sandboxconfigs -A", substrateVersion, substrateNamespace)
 	}
 	fmt.Printf(`
 %s

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -270,8 +270,11 @@ func platformUp(cfg *config.Config, header string) error {
 	if err != nil {
 		return err
 	}
-	// Read the way `helm -f` reads it, once for the renders and the install.
-	values, err := helmValuesFile(valuesPath)
+	// Read the way `helm -f` reads it, once for the renders and the install:
+	// the lab's render first, then platform.valuesFiles in order (the overlays
+	// win) — a lab that points a component at another chart source or forwards
+	// values the template does not know.
+	values, err := helmValuesFiles(append([]string{valuesPath}, cfg.Platform.ValuesFiles...)...)
 	if err != nil {
 		return err
 	}
@@ -409,15 +412,23 @@ func platformUp(cfg *config.Config, header string) error {
 		if err := ensureExtraModels(cfg); err != nil {
 			return err
 		}
-		// Agent pods need the golang-adk runtime image at kagent's own tag,
-		// which upstream has been observed not to publish (HACKS.md U8).
-		step("Ensuring the agents' ADK runtime images are on the node")
-		healADKImages(cfg)
-		// The 0.9.x Agent CRD rejects the spec.iconUrl the create flow always
-		// composes, failing every created agent's HelmRelease (HACKS.md U11).
-		step("Ensuring the Agent CRD accepts spec.iconUrl")
-		if err := patchAgentCRDIconURL(); err != nil {
-			return err
+		// Both heals below are shaped for the 0.x line's Agent CR. kagent API
+		// v2 (Harness + AgentTemplate, kagent.dev/v1alpha3) serves no
+		// agents.kagent.dev, composes no runtime image from its release tag
+		// (Harnesses pin their images by digest) and has no iconUrl to accept.
+		if !agentCRDServed() {
+			note("kagent serves no %s (API v2: Harness + AgentTemplate); skipping the Agent-CR heals", agentCRD)
+		} else {
+			// Agent pods need the golang-adk runtime image at kagent's own tag,
+			// which upstream has been observed not to publish (HACKS.md U8).
+			step("Ensuring the agents' ADK runtime images are on the node")
+			healADKImages(cfg)
+			// The 0.9.x Agent CRD rejects the spec.iconUrl the create flow always
+			// composes, failing every created agent's HelmRelease (HACKS.md U11).
+			step("Ensuring the Agent CRD accepts spec.iconUrl")
+			if err := patchAgentCRDIconURL(); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/lab/platform_test.go
+++ b/internal/lab/platform_test.go
@@ -188,3 +188,22 @@ func TestMCPServerState(t *testing.T) {
 		t.Errorf("mcpServerState(absent) = %v, want the apiserver's NotFound", err)
 	}
 }
+
+// TestKagentControllerMonitored: the kagent scrape target is expected only
+// while a ServiceMonitor for the kagent controller exists in the kagent
+// namespace — the connectivity chart's or the kagent chart's own; monitors of
+// other components or namespaces do not count.
+func TestKagentControllerMonitored(t *testing.T) {
+	newFakeLab(t, customObject(serviceMonitorGVK, platformNamespace, "agent-platform-connectivity-kagent-controller", nil))
+	if kagentControllerMonitored() {
+		t.Error("a monitor in another namespace counted")
+	}
+	newFakeLab(t, customObject(serviceMonitorGVK, kagentNamespace, "kagent-ui", nil))
+	if kagentControllerMonitored() {
+		t.Error("a monitor of another component counted")
+	}
+	newFakeLab(t, customObject(serviceMonitorGVK, kagentNamespace, "agent-platform-connectivity-kagent-controller", nil))
+	if !kagentControllerMonitored() {
+		t.Error("the connectivity chart's controller monitor not seen")
+	}
+}

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -2,6 +2,7 @@ package lab
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -241,7 +242,11 @@ func PlatformTest(cfg *config.Config, email string) error {
 		// scrape interval, hence the generous retry.
 		expected := []string{componentMuster, "valkey", mcpPrometheusRelease}
 		if cfg.Platform.Agents {
-			expected = append(expected, "kagent")
+			if kagentControllerMonitored() {
+				expected = append(expected, "kagent")
+			} else {
+				note("no ServiceMonitor for the kagent controller in %s (kagent main serves no metrics listener): not expecting a kagent target", kagentNamespace)
+			}
 		}
 		step("Verifying Prometheus scrapes the platform itself (%s)", strings.Join(expected, ", "))
 		var missing []string
@@ -438,4 +443,33 @@ func proveDownstreamIdentity(cfg *config.Config, toolPrefix string) error {
 		}
 	}
 	return nil
+}
+
+// serviceMonitorResource is the Prometheus operator's ServiceMonitor as a
+// resource argument.
+const serviceMonitorResource = "servicemonitors.monitoring.coreos.com"
+
+// kagentControllerMonitored reports whether a ServiceMonitor for the kagent
+// controller exists in the kagent namespace — the connectivity chart's
+// (agent-platform-connectivity-kagent-controller) or the kagent chart's own.
+// kagent main's controller serves no Prometheus listener; a lab that renders
+// no monitor for it has no kagent target to expect, one that does expects it
+// scraped. A read that fails counts as no monitor.
+func kagentControllerMonitored() bool {
+	gvr, err := gvrFor(serviceMonitorResource)
+	if err != nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	monitors, err := listObjects(ctx, gvr, kagentNamespace, "")
+	if err != nil {
+		return false
+	}
+	for _, m := range monitors {
+		if strings.Contains(m.GetName(), "kagent-controller") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -201,6 +201,7 @@ var manifests = map[string]struct {
 	"rbac.yaml.tmpl":                         {out: "rbac.yaml"},
 	"agent-platform-values.yaml.tmpl":        {out: "agent-platform-values.yaml"},
 	"kube-prometheus-stack-values.yaml.tmpl": {out: "kube-prometheus-stack-values.yaml"},
+	substrateValuesTemplate:                  {out: "substrate-values.yaml"},
 	mcpPrometheusTemplate:                    {out: "mcp-prometheus.yaml"},
 	"observability-route.yaml.tmpl":          {out: "observability-route.yaml"},
 	"demo-workflow.yaml.tmpl":                {out: "demo-workflow.yaml"},

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -236,3 +236,65 @@ func TestKindConfigSubstrateGates(t *testing.T) {
 		t.Errorf("containerdConfigPatches = %q, want the one certs.d config_path patch", kindCfg.ContainerdConfigPatches)
 	}
 }
+
+// The kagent controller ServiceMonitor follows observability on the stable
+// channel and is off on the dev channel, whose kagent serves no metrics
+// listener; the chart-level gate stays with observability either way.
+func TestKagentServiceMonitorFollowsChannel(t *testing.T) {
+	cfg := config.Default()
+	render := func() map[string]any {
+		out, err := renderTemplate(cfg, "agent-platform-values.yaml.tmpl", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var values map[string]any
+		if err := yaml.Unmarshal(out, &values); err != nil {
+			t.Fatalf("%v\n%s", err, out)
+		}
+		return values
+	}
+	kagentMonitor := func(v map[string]any) any {
+		return v["kagent"].(map[string]any)["serviceMonitor"].(map[string]any)["enabled"]
+	}
+	if got := kagentMonitor(render()); got != true {
+		t.Errorf("stable channel with observability: kagent.serviceMonitor.enabled = %v, want true", got)
+	}
+	cfg.Platform.ChartBranch = "poc/kagent-main"
+	v := render()
+	if got := kagentMonitor(v); got != false {
+		t.Errorf("dev channel: kagent.serviceMonitor.enabled = %v, want false", got)
+	}
+	if got := v["global"].(map[string]any)["observability"].(map[string]any)["metrics"].(map[string]any)["serviceMonitor"].(map[string]any)["enabled"]; got != true {
+		t.Errorf("dev channel: the chart-level monitor gate must still follow observability, got %v", got)
+	}
+	cfg.Platform.Observability = false
+	cfg.Platform.ChartBranch = ""
+	if got := kagentMonitor(render()); got != false {
+		t.Errorf("without observability: kagent.serviceMonitor.enabled = %v, want false", got)
+	}
+}
+
+// The Substrate values are the chart's defaults with the lab's two
+// deviations spelled out: no Namespace rendered (the lab creates it ahead of
+// the chart) and no atelet extra args (no local registry).
+func TestSubstrateValuesRender(t *testing.T) {
+	out, err := renderTemplate(config.Default(), substrateValuesTemplate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var values map[string]any
+	if err := yaml.Unmarshal(out, &values); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	if values["createNamespace"] != false {
+		t.Errorf("createNamespace = %v, want false", values["createNamespace"])
+	}
+	if args, _ := values["atelet"].(map[string]any)["extraArgs"].([]any); len(args) != 0 {
+		t.Errorf("atelet.extraArgs = %v, want none", args)
+	}
+	for _, store := range []string{"postgres", "rustfs"} {
+		if size := values[store].(map[string]any)["storageSize"]; size != "1Gi" {
+			t.Errorf("%s.storageSize = %v, want 1Gi", store, size)
+		}
+	}
+}

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -204,5 +205,34 @@ func TestMCPPrometheusRelease(t *testing.T) {
 		if !strings.Contains(s, want) {
 			t.Errorf("mcp-prometheus.yaml lacks %q", want)
 		}
+	}
+}
+
+// The kind config carries what Substrate's WorkerPools need from the
+// apiserver — the PodCertificateRequest API and ClusterTrustBundle projection,
+// pod identities and trust bundles projected into the ateom workers — and
+// points containerd at /etc/containerd/certs.d, where a node learns about the
+// local registry. All of it is fixed at `kind create`, so it renders always.
+// Decoded into kind's own config type, so the field names are the ones the
+// embedded kind reads.
+func TestKindConfigSubstrateGates(t *testing.T) {
+	out, err := renderTemplate(config.Default(), "kind-config.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kindCfg v1alpha4.Cluster
+	if err := yaml.Unmarshal(out, &kindCfg); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	for _, gate := range []string{"ClusterTrustBundle", "ClusterTrustBundleProjection", "PodCertificateRequest"} {
+		if !kindCfg.FeatureGates[gate] {
+			t.Errorf("featureGates.%s = %v, want true", gate, kindCfg.FeatureGates[gate])
+		}
+	}
+	if got := kindCfg.RuntimeConfig["certificates.k8s.io/v1beta1"]; got != "true" {
+		t.Errorf("runtimeConfig[certificates.k8s.io/v1beta1] = %q, want \"true\"", got)
+	}
+	if len(kindCfg.ContainerdConfigPatches) != 1 || !strings.Contains(kindCfg.ContainerdConfigPatches[0], `config_path = "/etc/containerd/certs.d"`) {
+		t.Errorf("containerdConfigPatches = %q, want the one certs.d config_path patch", kindCfg.ContainerdConfigPatches)
 	}
 }

--- a/internal/lab/resources.go
+++ b/internal/lab/resources.go
@@ -70,6 +70,14 @@ const (
 	// model-manager in front of the host model servers.
 	reqModelManagerCPU = 55
 	reqModelManagerMem = 80
+	// Substrate (kagent's actor runtime, the dev channel): its bundled
+	// PostgreSQL requests 1 CPU / 1 GiB, the chart's default; ate-api-server,
+	// ate-controller, atelet, atenet and rustfs declare nothing. Measured in
+	// the POC lab 2026-09-09 (substrate 0.0.26): its control plane sat at
+	// 274 MiB real, the node's RSS grew from 2.26 to 3.53 GiB with Substrate
+	// and the dev channel's kagent together; worker pods are BestEffort.
+	reqSubstrateCPU = 1000
+	reqSubstrateMem = 1024
 	// Backstage requests almost nothing and uses several times its 250Mi;
 	// the memory floor below accounts for that with a factor, not here.
 	reqBackstageCPU = 20
@@ -116,6 +124,8 @@ var labResourceGroups = []resourceGroup{
 		func(c *config.Config) bool { return c.Platform.Enabled && c.Platform.Agents }},
 	{"model-manager", resourceRequests{reqModelManagerCPU, reqModelManagerMem},
 		func(c *config.Config) bool { return c.ModelManagerEnabled() }},
+	{"Substrate", resourceRequests{reqSubstrateCPU, reqSubstrateMem},
+		func(c *config.Config) bool { return c.SubstrateEnabled() }},
 	{"Backstage", resourceRequests{reqBackstageCPU, reqBackstageMem},
 		func(c *config.Config) bool { return c.Platform.Enabled && c.Backstage.Enabled }},
 	{"Flux engine", resourceRequests{reqFluxCPU, reqFluxMem},

--- a/internal/lab/resources_test.go
+++ b/internal/lab/resources_test.go
@@ -65,6 +65,12 @@ func labConfig(platform, agents, observability, backstage, modelManager bool) *c
 	return cfg
 }
 
+// devChannel puts a configuration on the dev channel (platform.chartBranch).
+func devChannel(cfg *config.Config) *config.Config {
+	cfg.Platform.ChartBranch = "poc/kagent-main"
+	return cfg
+}
+
 // The floor follows the enabled components. The full default lab reproduces
 // the live measurement the constants come from (2590m / 2596Mi allocated on
 // 2026-09-08) and lands on the Docker resources table's rows: 4 CPUs for the full lab, 3 for
@@ -84,6 +90,16 @@ func TestLabResourceNeeds(t *testing.T) {
 			cfg: labConfig(true, true, true, true, true),
 			cpu: 2590, mem: 2596, minCPUs: 4, minMem: 5192,
 			groups: "kind control plane,Dex,agent platform,agents runtime,model-manager,Backstage,Flux engine,observability",
+		},
+		"the dev channel: the full lab plus Substrate, implied by chartBranch": {
+			cfg: devChannel(labConfig(true, true, true, true, true)),
+			cpu: 3590, mem: 3620, minCPUs: 5, minMem: 7240,
+			groups: "kind control plane,Dex,agent platform,agents runtime,model-manager,Substrate,Backstage,Flux engine,observability",
+		},
+		"the dev channel without agents: no kagent, nothing for Substrate to serve": {
+			cfg: devChannel(labConfig(true, false, true, true, false)),
+			cpu: 2085, mem: 1876, minCPUs: 3, minMem: 3752,
+			groups: "kind control plane,Dex,agent platform,Backstage,Flux engine,observability",
 		},
 		"full default lab without model-manager": {
 			cfg: labConfig(true, true, true, true, false),

--- a/internal/lab/substrate.go
+++ b/internal/lab/substrate.go
@@ -1,0 +1,355 @@
+package lab
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// Substrate (kagent-dev/substrate) is kagent's actor runtime: WorkerPools of
+// sandboxed (gVisor) worker pods that ate-controller schedules actors onto,
+// ate-api-server as their control plane, atelet as the per-node agent and
+// atenet as the actors' ingress/egress data plane. The dev channel's kagent
+// (kagent main, API v2) runs every agent as a Substrate actor and cannot
+// start without it, so the lab installs Substrate as cluster infrastructure
+// ahead of the platform when platform.substrate.enabled says so
+// (config.SubstrateEnabled — implied by the dev channel); the released
+// kagent ignores it. docs/platform.md "Dev channel".
+//
+// Not a meta-chart component (yet): Substrate needs an imperative bootstrap
+// the chart does not render — the CA and JWT pools its signers and
+// ate-api-server mount, the trust anchor atenet reads and ate-api-server's
+// authentication config (upstream: `kubectl-ate admin make-ca-pool` /
+// `make-jwt-pool` plus a shell step). The lab performs that bootstrap itself
+// (substratepools.go is the Go port of the two commands) and creates every
+// bootstrap object BEFORE the chart, so the install is one waited
+// upgrade-or-install instead of upstream's install / bootstrap / re-install
+// dance. The gates it needs from the apiserver (PodCertificateRequest,
+// ClusterTrustBundle, certificates.k8s.io/v1beta1) are in the lab's kind
+// config for every cluster (kind-config.yaml.tmpl).
+//
+// Pinned like the observability charts: Go consts, bumped deliberately, with
+// a lab run.
+const (
+	substrateVersion       = "0.0.26"
+	substrateChartsRepo    = "oci://ghcr.io/kagent-dev/substrate/helm"
+	substrateImageRegistry = "ghcr.io/kagent-dev/substrate"
+)
+
+// The namespaces and releases. ate-system is hardcoded in the chart
+// (ate-controller's Role names it), so the release must land there;
+// podcertificate-controller-system is rendered by the chart — pre-created
+// here for the two pools its signer mounts, then adopted by Helm
+// (helmInstallOptions.TakeOwnership).
+const (
+	substrateNamespace         = "ate-system"
+	podCertControllerNamespace = "podcertificate-controller-system"
+	substrateCRDsRelease       = "substrate-crds"
+	substrateRelease           = "substrate"
+	substrateValuesTemplate    = "substrate-values.yaml.tmpl"
+)
+
+// The bootstrap objects the chart mounts but does not render.
+const (
+	// actorIDCACertsSecret carries the actor-identity CA's root as PEM
+	// (caCertKey); atenet-egress trusts actor certificates against it.
+	actorIDCACertsSecret = "actor-id-ca-certs" // #nosec G101 -- a Secret's name, not a credential
+	// ateAPIAuthConfigMap is ate-api-server's authentication.yaml.
+	ateAPIAuthConfigMap = "ate-api-authentication"
+	// ateAPIAudience is the audience of the ServiceAccount tokens actors and
+	// kagent present to ate-api-server (the chart's Service name).
+	ateAPIAudience = "api.ate-system.svc"
+	// substratePoolID is the id of the initial CA / signing key of every
+	// pool, as upstream's bootstrap passes it (--ca-id=1, --key-id=1).
+	substratePoolID = "1"
+	// actorIDCAPool is the pool whose root becomes actorIDCACertsSecret.
+	actorIDCAPool = "actor-id-ca-pool"
+)
+
+// substratePool is one of the four pool Secrets: two CA pools for the
+// podcertificate-controller's signers (service DNS and pod identity), the
+// JWT authority pool ate-api-server mints actor identity tokens from and the
+// CA pool it signs actor certificates with.
+type substratePool struct {
+	namespace, name string
+	// jwt marks the JWT authority pool; the others are CA pools.
+	jwt bool
+}
+
+var substratePools = []substratePool{
+	{namespace: podCertControllerNamespace, name: "service-dns-ca-pool"},
+	{namespace: podCertControllerNamespace, name: "pod-identity-ca-pool"},
+	{namespace: substrateNamespace, name: "actor-id-jwt-pool", jwt: true},
+	{namespace: substrateNamespace, name: actorIDCAPool},
+}
+
+// podCertificateAPIPath is the API Substrate cannot start a pod without: the
+// PodCertificateRequest API behind the certificates.k8s.io/v1beta1 gate.
+const podCertificateAPIPath = "/apis/certificates.k8s.io/v1beta1"
+
+// ateomGVisorImage is the worker image the WorkerPool the dev channel's
+// kagent creates names (`workerImage:`, no `image:` line in any render), so
+// the preload lists it explicitly — pulled once here instead of at the first
+// actor's boot.
+const ateomGVisorImage = substrateImageRegistry + "/ateom-gvisor:v" + substrateVersion
+
+// The SandboxConfig the chart ships, which every gVisor WorkerPool names.
+const (
+	sandboxConfigResource = "sandboxconfigs.ate.dev"
+	defaultSandboxConfig  = "gvisor-default"
+)
+
+// substrateInstallTimeout bounds each of the two upgrade-or-installs and
+// their kstatus wait (the POC lab took under two minutes for the whole
+// bootstrap, images warm).
+const substrateInstallTimeout = 5 * time.Minute
+
+// substrateUninstallTimeout bounds the waited uninstall on platform-down.
+const substrateUninstallTimeout = 5 * time.Minute
+
+// substrateUp installs Substrate: the preflight on the apiserver gates, the
+// namespaces, the bootstrap objects (idempotent — an existing pool is never
+// regenerated), the images, then substrate-crds and substrate in one waited
+// upgrade-or-install each, and the SandboxConfig check. Idempotent: a re-run
+// on a live cluster is a no-op revision.
+func substrateUp(cfg *config.Config) error {
+	step("Installing Substrate %s (kagent's actor runtime)", substrateVersion)
+	ctx := context.Background()
+	if err := preflightPodCertificateAPI(ctx); err != nil {
+		return err
+	}
+	for _, ns := range []string{substrateNamespace, podCertControllerNamespace} {
+		if err := ensureNamespace(ns); err != nil {
+			return err
+		}
+	}
+	created, err := ensureSubstratePools(ctx)
+	if err != nil {
+		return err
+	}
+	note("CA/JWT pools: %d created, %d kept (a regenerated root would orphan every certificate issued from it)", created, len(substratePools)-created)
+	if err := ensureActorIDCACerts(ctx); err != nil {
+		return err
+	}
+	if err := ensureATEAPIAuthentication(ctx); err != nil {
+		return err
+	}
+
+	_, valuesPath, err := renderManifest(cfg, substrateValuesTemplate)
+	if err != nil {
+		return err
+	}
+	values, err := helmValuesFile(valuesPath)
+	if err != nil {
+		return err
+	}
+	chartRef := substrateChartsRepo + "/" + substrateRelease
+	crdsRef := substrateChartsRepo + "/" + substrateCRDsRelease
+	// The same host-cache -> node rule as the platform (preload.go);
+	// best-effort, the node pulls anything missed under the install's wait.
+	if rendered, err := helmTemplate(substrateNamespace, substrateRelease, chartRef, substrateVersion, values, nil); err == nil {
+		images := append(scrapeImages(rendered), ateomGVisorImage)
+		if res := sideloadImages(cfg, hostPullImages(images)); res.n > 0 {
+			note("side-loaded %d Substrate images (%s)", res.n, res.d)
+		}
+	} else {
+		note("cannot render substrate %s (%v); the node pulls its images itself", substrateVersion, excerpt(err.Error(), 300))
+	}
+
+	step("Installing %s and %s %s into %s (this waits for ate-api-server, atelet and atenet)", substrateCRDsRelease, substrateRelease, substrateVersion, substrateNamespace)
+	if err := helmUpgradeInstall(substrateNamespace, substrateCRDsRelease, crdsRef, substrateVersion, map[string]any{}, substrateInstallTimeout, helmInstallOptions{}); err != nil {
+		return err
+	}
+	// TakeOwnership: the chart renders the podcertificate-controller-system
+	// Namespace the pools above needed in place first.
+	if err := helmUpgradeInstall(substrateNamespace, substrateRelease, chartRef, substrateVersion, values, substrateInstallTimeout, helmInstallOptions{TakeOwnership: true}); err != nil {
+		return err
+	}
+	// The kstatus wait returned with every workload Ready; the SandboxConfig
+	// is the one object a WorkerPool cannot do without.
+	gvr, err := gvrFor(sandboxConfigResource)
+	if err != nil {
+		return err
+	}
+	if exists, err := objectExists(ctx, gvr, "", defaultSandboxConfig); err != nil {
+		return err
+	} else if !exists {
+		return fmt.Errorf("substrate %s installed, but SandboxConfig %s is missing: WorkerPools name it (check `kubectl get sandboxconfigs`)", substrateVersion, defaultSandboxConfig)
+	}
+	note("Substrate is up: SandboxConfig %s present; WorkerPools and Harnesses come with kagent", defaultSandboxConfig)
+	return nil
+}
+
+// preflightPodCertificateAPI refuses a cluster whose apiserver does not
+// serve certificates.k8s.io/v1beta1 — one created before the lab's kind
+// config turned the gates on. Feature gates are fixed at `kind create`, so
+// the only fix is a new cluster; said here, before anything is installed.
+func preflightPodCertificateAPI(ctx context.Context) error {
+	if _, err := rawGet(ctx, podCertificateAPIPath); err != nil {
+		return fmt.Errorf("the apiserver does not serve certificates.k8s.io/v1beta1 (%v):\n"+
+			"Substrate needs the PodCertificateRequest and ClusterTrustBundle gates the lab's kind config turns on, and this\n"+
+			"cluster predates them — feature gates are fixed at kind create, so run `agentlab down && agentlab up`", err)
+	}
+	return nil
+}
+
+// ensureSubstratePools creates the pool Secrets that do not exist yet and
+// leaves existing ones alone: rotating a root would orphan every certificate
+// and token issued from it while the pods holding them keep running. Create,
+// not apply, for the same reason (kube.go createTyped). Returns how many
+// were created.
+func ensureSubstratePools(ctx context.Context) (created int, err error) {
+	for _, pool := range substratePools {
+		exists, err := objectExists(ctx, gvrSecrets, pool.namespace, pool.name)
+		if err != nil {
+			return created, err
+		}
+		if exists {
+			continue
+		}
+		var data map[string][]byte
+		secretType := corev1.SecretTypeOpaque
+		if pool.jwt {
+			data, err = generateJWTPoolSecretData(substratePoolID)
+		} else {
+			data, err = generateCAPoolSecretData(substratePoolID)
+			secretType = corev1.SecretTypeTLS
+		}
+		if err != nil {
+			return created, fmt.Errorf("generating pool %s/%s: %w", pool.namespace, pool.name, err)
+		}
+		if err := createTyped(ctx, &corev1.Secret{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+			ObjectMeta: metav1.ObjectMeta{Name: pool.name, Namespace: pool.namespace},
+			Type:       secretType,
+			Data:       data,
+		}); err != nil {
+			return created, fmt.Errorf("creating pool %s/%s: %w", pool.namespace, pool.name, err)
+		}
+		created++
+	}
+	return created, nil
+}
+
+// ensureActorIDCACerts derives the trust anchor Secret from the actor-id CA
+// pool: its signing root as PEM under `ca.crt`. Applied, not created — it is
+// a pure function of the pool, so re-deriving it is always right.
+func ensureActorIDCACerts(ctx context.Context) error {
+	pool, err := secretDataKey(ctx, substrateNamespace, actorIDCAPool, "pool")
+	if err != nil {
+		return err
+	}
+	root, err := caPoolRootPEM(pool)
+	if err != nil {
+		return fmt.Errorf("pool %s/%s: %w", substrateNamespace, actorIDCAPool, err)
+	}
+	return ensureSecret(substrateNamespace, actorIDCACertsSecret, corev1.SecretTypeOpaque, map[string][]byte{caCertKey: root})
+}
+
+// secretDataKey reads one data key of a Secret, decoded.
+func secretDataKey(ctx context.Context, ns, name, key string) ([]byte, error) {
+	secret, err := getObject(ctx, gvrSecrets, ns, name)
+	if err != nil {
+		return nil, err
+	}
+	encoded, found, _ := unstructured.NestedString(secret.Object, "data", key)
+	if !found {
+		return nil, fmt.Errorf("secret %s/%s has no data key %s", ns, name, key)
+	}
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("secret %s/%s key %s: %w", ns, name, key, err)
+	}
+	return raw, nil
+}
+
+// ensureATEAPIAuthentication writes ate-api-server's authentication config:
+// actor identities are Kubernetes ServiceAccount tokens for the audience
+// api.ate-system.svc, verified against the cluster's own issuer.
+func ensureATEAPIAuthentication(ctx context.Context) error {
+	issuer, err := serviceAccountIssuer(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = applyTyped(ctx, &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: ateAPIAuthConfigMap, Namespace: substrateNamespace},
+		Data:       map[string]string{"authentication.yaml": ateAPIAuthentication(issuer)},
+	})
+	return err
+}
+
+// serviceAccountIssuer is the `iss` of the apiserver's ServiceAccount tokens,
+// read off its OpenID discovery document (`/.well-known/openid-configuration`)
+// — kind's is https://kubernetes.default.svc.cluster.local. It has to be the
+// apiserver's own spelling: ate-api-server matches the token's iss claim
+// against it verbatim, and upstream's shorter in-cluster default fails on
+// kind for exactly that reason.
+func serviceAccountIssuer(ctx context.Context) (string, error) {
+	raw, err := rawGet(ctx, "/.well-known/openid-configuration")
+	if err != nil {
+		return "", fmt.Errorf("reading the apiserver's OpenID discovery document: %w", err)
+	}
+	var doc struct {
+		Issuer string `json:"issuer"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil || doc.Issuer == "" {
+		return "", fmt.Errorf("the apiserver's OpenID discovery document names no issuer (%v): %s", err, excerpt(string(raw), 200))
+	}
+	return doc.Issuer, nil
+}
+
+// inClusterIssuer is the ServiceAccount issuer of a cluster that publishes
+// no other; kind spells it with the cluster domain.
+const inClusterIssuer = "https://kubernetes.default.svc"
+
+// ateAPIAuthentication renders ate-api-server's authentication.yaml the way
+// substrate's ate-setup does (buildAuthenticationConfig): one JWT provider,
+// the cluster's ServiceAccount issuer, the ate-api audience. An in-cluster
+// issuer's discovery document is not on the public internet, so the server
+// is pointed at its own projected ServiceAccount CA and token to fetch it.
+func ateAPIAuthentication(issuer string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "actorIdentityJWTProvider: kubernetes\njwtProviders:\n- name: kubernetes\n  issuer: %s\n  audiences: [%s]\n", issuer, ateAPIAudience)
+	if issuer == inClusterIssuer || issuer == inClusterIssuer+".cluster.local" {
+		b.WriteString("  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n" +
+			"  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n")
+	}
+	return b.String()
+}
+
+// substrateDown removes Substrate from the cluster — after the platform,
+// whose teardown deletes kagent's WorkerPool and Harnesses through finalizers
+// ate-controller has to be running for. The releases go first (substrate
+// waited, so its own objects' finalizers run while its controllers exist),
+// then the namespaces with the pools in them: a next `up` generates fresh
+// ones, and nothing issued from the old ones survives the teardown either.
+// Presence-driven, not config-driven, so a knob flipped off still cleans up.
+func substrateDown(ctx context.Context) error {
+	if helmReleaseExists(substrateNamespace, substrateRelease) {
+		step("Uninstalling Substrate (its controllers, then the CRDs)")
+		if err := helmUninstall(substrateNamespace, substrateRelease, true, substrateUninstallTimeout); err != nil {
+			return err
+		}
+	}
+	if helmReleaseExists(substrateNamespace, substrateCRDsRelease) {
+		if err := helmUninstall(substrateNamespace, substrateCRDsRelease, false, substrateUninstallTimeout); err != nil {
+			return err
+		}
+	}
+	for _, ns := range []string{substrateNamespace, podCertControllerNamespace} {
+		if err := deleteNamespace(ctx, ns); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/lab/substrate_test.go
+++ b/internal/lab/substrate_test.go
@@ -1,0 +1,130 @@
+package lab
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// The four pool Secrets are created once — CA pools as kubernetes.io/tls
+// with the pool, chain and key, the JWT pool Opaque with the pool — and an
+// existing pool is never regenerated: a second run keeps every byte.
+func TestEnsureSubstratePools(t *testing.T) {
+	newFakeLab(t)
+	ctx := context.Background()
+	created, err := ensureSubstratePools(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created != len(substratePools) {
+		t.Errorf("created %d pools, want %d", created, len(substratePools))
+	}
+	first := map[string]*unstructured.Unstructured{}
+	for _, pool := range substratePools {
+		secret, err := getObject(ctx, gvrSecrets, pool.namespace, pool.name)
+		if err != nil {
+			t.Fatalf("pool %s/%s: %v", pool.namespace, pool.name, err)
+		}
+		first[pool.name] = secret
+		typ, _, _ := unstructured.NestedString(secret.Object, "type")
+		data, _, _ := unstructured.NestedMap(secret.Object, "data")
+		switch {
+		case pool.jwt && (typ != string(corev1.SecretTypeOpaque) || len(data) != 1 || data["pool"] == nil):
+			t.Errorf("JWT pool %s: type %q, keys %v; want Opaque with pool", pool.name, typ, data)
+		case !pool.jwt && (typ != string(corev1.SecretTypeTLS) || len(data) != 3 || data["pool"] == nil || data[corev1.TLSCertKey] == nil || data[corev1.TLSPrivateKeyKey] == nil):
+			t.Errorf("CA pool %s: type %q, keys %v; want kubernetes.io/tls with pool, tls.crt, tls.key", pool.name, typ, data)
+		}
+	}
+	created, err = ensureSubstratePools(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created != 0 {
+		t.Errorf("second run created %d pools, want 0", created)
+	}
+	for _, pool := range substratePools {
+		secret, err := getObject(ctx, gvrSecrets, pool.namespace, pool.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before, _, _ := unstructured.NestedMap(first[pool.name].Object, "data")
+		after, _, _ := unstructured.NestedMap(secret.Object, "data")
+		if before["pool"] != after["pool"] {
+			t.Errorf("pool %s was regenerated on the second run", pool.name)
+		}
+	}
+}
+
+// actor-id-ca-certs is derived from the actor-id CA pool: its root as PEM
+// under ca.crt, identical to the pool Secret's tls.crt.
+func TestEnsureActorIDCACerts(t *testing.T) {
+	data, err := generateCAPoolSecretData(substratePoolID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newFakeLab(t, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: actorIDCAPool, Namespace: substrateNamespace},
+		Type:       corev1.SecretTypeTLS,
+		Data:       data,
+	})
+	ctx := context.Background()
+	if err := ensureActorIDCACerts(ctx); err != nil {
+		t.Fatal(err)
+	}
+	got, err := secretDataKey(ctx, substrateNamespace, actorIDCACertsSecret, caCertKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data[corev1.TLSCertKey]) {
+		t.Errorf("ca.crt is not the pool's root:\n%s", got)
+	}
+	// Idempotent: a second derivation applies the same bytes.
+	if err := ensureActorIDCACerts(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := secretDataKey(ctx, substrateNamespace, actorIDCACertsSecret, "missing"); err == nil || !strings.Contains(err.Error(), "no data key missing") {
+		t.Errorf("a missing key must be named: %v", err)
+	}
+}
+
+// ate-api-server's authentication.yaml: the in-cluster issuer in kind's own
+// spelling with the projected ServiceAccount CA and token to discover it by
+// (the exact document the POC bootstrap wrote); an external issuer without.
+func TestATEAPIAuthentication(t *testing.T) {
+	want := "actorIdentityJWTProvider: kubernetes\n" +
+		"jwtProviders:\n" +
+		"- name: kubernetes\n" +
+		"  issuer: https://kubernetes.default.svc.cluster.local\n" +
+		"  audiences: [api.ate-system.svc]\n" +
+		"  certificateAuthorityFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt\n" +
+		"  discoveryTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token\n"
+	if got := ateAPIAuthentication("https://kubernetes.default.svc.cluster.local"); got != want {
+		t.Errorf("in-cluster issuer:\n%s\nwant\n%s", got, want)
+	}
+	if got := ateAPIAuthentication(inClusterIssuer); !strings.Contains(got, "discoveryTokenFile") {
+		t.Errorf("the short in-cluster issuer needs the token file too:\n%s", got)
+	}
+	got := ateAPIAuthentication("https://accounts.google.com")
+	if strings.Contains(got, "certificateAuthorityFile") || !strings.Contains(got, "issuer: https://accounts.google.com\n") {
+		t.Errorf("external issuer:\n%s", got)
+	}
+}
+
+// A cluster without the certificates.k8s.io/v1beta1 API is refused before
+// anything installs, with the only fix — a new cluster — spelled out; the
+// issuer read fails the same way on an apiserver that publishes none.
+func TestSubstratePreflightWithoutTheAPI(t *testing.T) {
+	newFakeLab(t)
+	ctx := context.Background()
+	err := preflightPodCertificateAPI(ctx)
+	if err == nil || !strings.Contains(err.Error(), "agentlab down && agentlab up") {
+		t.Errorf("want the recreate hint, got %v", err)
+	}
+	if _, err := serviceAccountIssuer(ctx); err == nil {
+		t.Error("an apiserver without a discovery document must be an error, not an empty issuer")
+	}
+}

--- a/internal/lab/substratepools.go
+++ b/internal/lab/substratepools.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Ported from kagent-dev/substrate v0.0.26: internal/localca/localca.go
+// (GenerateCA, Marshal, TLSCertificateChainPEM, TLSPrivateKeyPEM) and
+// internal/localjwtauthority/localjwtauthority.go (GenerateECDSAP256Authority,
+// Marshal) — the generate + serialise subset behind `kubectl-ate admin
+// make-ca-pool` and `make-jwt-pool` (cmd/kubectl-ate/internal/cmd/
+// admin_make_ca_pool.go, admin_make_jwt_pool.go). Both packages are
+// substrate-internal and cannot be imported. The wire format below is what
+// ate-api-server, podcertificate-controller and atenet read off the pool
+// Secrets (localca.Unmarshal, localjwtauthority.Unmarshal), so the JSON field
+// names are theirs and must not change; a Substrate bump that changes the
+// format shows up as ate-api-server never becoming Ready (substrate.go).
+
+package lab
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// caPoolWire is a CA pool as its Secret's `pool` key holds it: the CAs and
+// which of them signs. A CA is one root certificate with its signing key.
+type caPoolWire struct {
+	CAs              []*caWire
+	ActiveForSigning string
+}
+
+type caWire struct {
+	ID                 string
+	SigningKeyPKCS8    []byte
+	RootCertificateDER []byte
+}
+
+// jwtPoolWire is a JWT authority pool as its Secret's `pool` key holds it.
+type jwtPoolWire struct {
+	Authorities      []*jwtAuthorityWire
+	ActiveForSigning string
+}
+
+type jwtAuthorityWire struct {
+	ID              string
+	Algorithm       string
+	SigningKeyPKCS8 []byte
+}
+
+// caPoolValidity is the root certificate's lifetime make-ca-pool mints.
+const caPoolValidity = 365 * 24 * time.Hour
+
+// The PEM block types of a TLS certificate and a PKCS#8 key.
+const (
+	pemCertificate = "CERTIFICATE"
+	pemPrivateKey  = "PRIVATE KEY"
+)
+
+// generateCAPoolSecretData is `kubectl-ate admin make-ca-pool --ca-id <id>`
+// as Secret data: a pool of one freshly minted ED25519 CA, active for
+// signing, under `pool`, and the same root as a TLS pair (`tls.crt` the
+// chain, `tls.key` the PKCS#8 key) — the Secret is of type kubernetes.io/tls.
+func generateCAPoolSecretData(caID string) (map[string][]byte, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating the root key: %w", err)
+	}
+	notBefore := time.Now()
+	template := &x509.Certificate{
+		// Random subject content: some certificate handling assumes equal
+		// parent and template subjects mean a self-signing operation
+		// (localca.GenerateCA keeps it random for defense in depth).
+		Subject:               pkix.Name{CommonName: rand.Text()},
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(caPoolValidity),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	if err != nil {
+		return nil, fmt.Errorf("generating the root certificate: %w", err)
+	}
+	keyPKCS8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("serialising the signing key: %w", err)
+	}
+	pool, err := json.Marshal(&caPoolWire{
+		CAs:              []*caWire{{ID: caID, SigningKeyPKCS8: keyPKCS8, RootCertificateDER: der}},
+		ActiveForSigning: caID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("serialising the pool: %w", err)
+	}
+	return map[string][]byte{
+		"pool":                  pool,
+		corev1.TLSCertKey:       pem.EncodeToMemory(&pem.Block{Type: pemCertificate, Bytes: der}),
+		corev1.TLSPrivateKeyKey: pem.EncodeToMemory(&pem.Block{Type: pemPrivateKey, Bytes: keyPKCS8}),
+	}, nil
+}
+
+// generateJWTPoolSecretData is `kubectl-ate admin make-jwt-pool --key-id
+// <id>` as Secret data: a pool of one ECDSA P-256 authority signing ES256,
+// active, under `pool` (an Opaque Secret).
+func generateJWTPoolSecretData(keyID string) (map[string][]byte, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating the signing key: %w", err)
+	}
+	keyPKCS8, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return nil, fmt.Errorf("serialising the signing key: %w", err)
+	}
+	pool, err := json.Marshal(&jwtPoolWire{
+		Authorities:      []*jwtAuthorityWire{{ID: keyID, Algorithm: "ES256", SigningKeyPKCS8: keyPKCS8}},
+		ActiveForSigning: keyID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("serialising the pool: %w", err)
+	}
+	return map[string][]byte{"pool": pool}, nil
+}
+
+// caPoolRootPEM is the signing CA's root certificate out of a CA pool's
+// `pool` JSON, as PEM — what the shell bootstrap produced with jq and
+// openssl for the actor-id-ca-certs Secret atenet trusts. The active CA, or
+// the first when none is designated (localca's own fallback).
+func caPoolRootPEM(pool []byte) ([]byte, error) {
+	var wire caPoolWire
+	if err := json.Unmarshal(pool, &wire); err != nil {
+		return nil, fmt.Errorf("parsing the pool: %w", err)
+	}
+	if len(wire.CAs) == 0 {
+		return nil, fmt.Errorf("the pool has no CAs")
+	}
+	root := wire.CAs[0]
+	for _, ca := range wire.CAs {
+		if ca.ID == wire.ActiveForSigning {
+			root = ca
+		}
+	}
+	if _, err := x509.ParseCertificate(root.RootCertificateDER); err != nil {
+		return nil, fmt.Errorf("parsing the root certificate of CA %q: %w", root.ID, err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: pemCertificate, Bytes: root.RootCertificateDER}), nil
+}

--- a/internal/lab/substratepools_test.go
+++ b/internal/lab/substratepools_test.go
@@ -1,0 +1,152 @@
+package lab
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// A CA pool Secret round-trips through the shape substrate reads: the `pool`
+// JSON names the CA under CAs[0] with its root DER and PKCS#8 key and marks
+// it ActiveForSigning; tls.crt is that root as PEM, tls.key its key — the
+// three keys kubectl-ate admin make-ca-pool writes.
+func TestGenerateCAPoolSecretData(t *testing.T) {
+	data, err := generateCAPoolSecretData("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"pool", corev1.TLSCertKey, corev1.TLSPrivateKeyKey} {
+		if len(data[key]) == 0 {
+			t.Errorf("Secret key %s missing", key)
+		}
+	}
+	// Read the JSON the way a jq consumer (and localca.Unmarshal) does: the
+	// field names are substrate's, the byte slices base64 strings.
+	var generic struct {
+		CAs []struct {
+			ID                 string
+			SigningKeyPKCS8    string
+			RootCertificateDER string
+		}
+		ActiveForSigning string
+	}
+	if err := json.Unmarshal(data["pool"], &generic); err != nil {
+		t.Fatalf("pool JSON: %v\n%s", err, data["pool"])
+	}
+	if generic.ActiveForSigning != "1" || len(generic.CAs) != 1 || generic.CAs[0].ID != "1" {
+		t.Fatalf("pool = %+v, want one CA \"1\" active for signing", generic)
+	}
+	der, err := base64.StdEncoding.DecodeString(generic.CAs[0].RootCertificateDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("RootCertificateDER: %v", err)
+	}
+	if !cert.IsCA || !cert.BasicConstraintsValid || cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+		t.Errorf("root is not a signing CA: IsCA=%v KeyUsage=%v", cert.IsCA, cert.KeyUsage)
+	}
+	if cert.NotAfter.Sub(cert.NotBefore) != caPoolValidity {
+		t.Errorf("validity %s, want %s", cert.NotAfter.Sub(cert.NotBefore), caPoolValidity)
+	}
+	keyDER, err := base64.StdEncoding.DecodeString(generic.CAs[0].SigningKeyPKCS8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := x509.ParsePKCS8PrivateKey(keyDER)
+	if err != nil {
+		t.Fatalf("SigningKeyPKCS8: %v", err)
+	}
+	priv, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		t.Fatalf("signing key is %T, want ed25519", key)
+	}
+	if !priv.Public().(ed25519.PublicKey).Equal(cert.PublicKey) {
+		t.Error("the root certificate's public key is not the signing key's")
+	}
+	// The TLS pair is the same root and key, PEM-encoded.
+	block, _ := pem.Decode(data[corev1.TLSCertKey])
+	if block == nil || block.Type != pemCertificate || !bytes.Equal(block.Bytes, der) {
+		t.Error("tls.crt is not the root certificate as PEM")
+	}
+	block, _ = pem.Decode(data[corev1.TLSPrivateKeyKey])
+	if block == nil || block.Type != pemPrivateKey || !bytes.Equal(block.Bytes, keyDER) {
+		t.Error("tls.key is not the signing key as PKCS#8 PEM")
+	}
+	// The wire struct itself decodes what it encoded.
+	var wire caPoolWire
+	if err := json.Unmarshal(data["pool"], &wire); err != nil || len(wire.CAs) != 1 || !bytes.Equal(wire.CAs[0].RootCertificateDER, der) {
+		t.Errorf("caPoolWire round trip: %v %+v", err, wire)
+	}
+	// actor-id-ca-certs is the root PEM out of the pool.
+	root, err := caPoolRootPEM(data["pool"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(root, data[corev1.TLSCertKey]) {
+		t.Error("caPoolRootPEM must be the tls.crt of a one-CA pool")
+	}
+	if _, err := caPoolRootPEM([]byte(`{"CAs":[],"ActiveForSigning":""}`)); err == nil {
+		t.Error("an empty pool must be refused")
+	}
+	// Two pools never share a root.
+	other, err := generateCAPoolSecretData("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(other[corev1.TLSCertKey], data[corev1.TLSCertKey]) {
+		t.Error("two generated pools carry the same root")
+	}
+}
+
+// A JWT pool Secret holds one ES256 authority under Authorities[0], active
+// for signing — what kubectl-ate admin make-jwt-pool writes and ate-api-server
+// signs actor identity tokens with.
+func TestGenerateJWTPoolSecretData(t *testing.T) {
+	data, err := generateJWTPoolSecretData("1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 1 || len(data["pool"]) == 0 {
+		t.Fatalf("Secret data keys %v, want exactly pool", data)
+	}
+	var generic struct {
+		Authorities []struct {
+			ID              string
+			Algorithm       string
+			SigningKeyPKCS8 string
+		}
+		ActiveForSigning string
+	}
+	if err := json.Unmarshal(data["pool"], &generic); err != nil {
+		t.Fatalf("pool JSON: %v\n%s", err, data["pool"])
+	}
+	if generic.ActiveForSigning != "1" || len(generic.Authorities) != 1 || generic.Authorities[0].ID != "1" || generic.Authorities[0].Algorithm != "ES256" {
+		t.Fatalf("pool = %+v, want one ES256 authority \"1\" active for signing", generic)
+	}
+	keyDER, err := base64.StdEncoding.DecodeString(generic.Authorities[0].SigningKeyPKCS8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := x509.ParsePKCS8PrivateKey(keyDER)
+	if err != nil {
+		t.Fatalf("SigningKeyPKCS8: %v", err)
+	}
+	ec, ok := key.(*ecdsa.PrivateKey)
+	if !ok || ec.Curve != elliptic.P256() {
+		t.Errorf("signing key is %T on %v, want ECDSA P-256 (ES256)", key, ec)
+	}
+	var wire jwtPoolWire
+	if err := json.Unmarshal(data["pool"], &wire); err != nil || len(wire.Authorities) != 1 || !bytes.Equal(wire.Authorities[0].SigningKeyPKCS8, keyDER) {
+		t.Errorf("jwtPoolWire round trip: %v %+v", err, wire)
+	}
+}

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -325,9 +325,11 @@ kagent:
   # ServiceMonitor it renders (the kagent chart itself ships none); the
   # chart-level gate is global.observability.metrics.serviceMonitor.enabled
   # above, and the controller already serves plain-HTTP /metrics on :8080 via
-  # the chart's default METRICS_BIND_ADDRESS/METRICS_SECURE env.
+  # the chart's default METRICS_BIND_ADDRESS/METRICS_SECURE env. Off on the
+  # dev channel: kagent main's controller opens no metrics listener, and a
+  # monitor of a port nobody serves is a target platform-test would wait for.
   serviceMonitor:
-    enabled: {{ .Platform.Observability }}
+    enabled: {{ and .Platform.Observability (not .Platform.ChartBranch) }}
   # No OTLP gateway in kind; the exporters would only log dial errors.
   otel:
     tracing:

--- a/internal/lab/templates/kind-config.yaml.tmpl
+++ b/internal/lab/templates/kind-config.yaml.tmpl
@@ -1,6 +1,26 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 name: {{ .ClusterName }}
+# Substrate (kagent's actor runtime) projects pod identities and trust
+# bundles into its ateom workers: the PodCertificateRequest API behind
+# certificates.k8s.io/v1beta1 plus ClusterTrustBundle projection. Without
+# these its WorkerPools cannot start a single pod. Feature gates are fixed
+# at `kind create`, so they are always on — turning them on later means
+# `agentlab down && agentlab up`.
+featureGates:
+  ClusterTrustBundle: true
+  ClusterTrustBundleProjection: true
+  PodCertificateRequest: true
+runtimeConfig:
+  "certificates.k8s.io/v1beta1": "true"
+# The node image's containerd leaves the CRI registry config_path empty, so a
+# hosts.toml under /etc/containerd/certs.d would be ignored — and that
+# directory is how a node learns that localhost:5001 is the kind-registry
+# container, the registry Substrate resolves actor images through.
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
 nodes:
   - role: control-plane
     # Every mapping binds 127.0.0.1 explicitly. kind defaults listenAddress to

--- a/internal/lab/templates/substrate-values.yaml.tmpl
+++ b/internal/lab/templates/substrate-values.yaml.tmpl
@@ -1,0 +1,31 @@
+# ---------------------------------------------------------------------------
+# kagent-dev/substrate — kagent's actor runtime — in this kind lab.
+#
+# The chart's own defaults, on purpose: the dev channel's kagent creates its
+# WorkerPool against this Substrate exactly as a management cluster's would,
+# and the lab has nothing to deviate on. What the lab does differently sits
+# outside the values: the CA/JWT pool Secrets, the actor-id trust anchor and
+# ate-api-server's authentication config are created by `agentlab` before the
+# chart installs (substrate.go), so one waited upgrade-or-install suffices.
+# ---------------------------------------------------------------------------
+
+# The lab creates ate-system itself (the pools have to exist before the
+# chart), so the chart renders no Namespace for its release.
+createNamespace: false
+
+postgres:
+  enabled: true
+  # kind's local-path provisioner backs the claim.
+  storageSize: 1Gi
+
+rustfs:
+  enabled: true
+  # The actor snapshot store (s3://ate-snapshots): enough for the proofs'
+  # throwaway actors; raise it before real workspace use.
+  storageSize: 1Gi
+
+atelet:
+  # No --localhost-registry-replacement: the lab runs no local registry, the
+  # actor images come from registries the node pulls from (the dev channel
+  # pins them by digest).
+  extraArgs: []

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ Then:        claude mcp add --transport http muster https://muster.127.0.0.1.nip
 		certsCmd(),
 		labCmd("trust", "Install the lab CA into the system and browser trust stores (one sudo prompt; reversible)", lab.Trust),
 		labCmd("untrust", "Remove the lab CA from the system and browser trust stores", lab.Untrust),
-		labCmd("platform", "Install the Giant Swarm agent platform (the agent-platform chart in the lab shape)", lab.PlatformUp),
+		platformCmd(),
 		platformTestCmd(),
 		modelsTestCmd(),
 		agentsTestCmd(),
@@ -266,9 +266,9 @@ func accessibleMode() bool {
 
 func configureCmd() *cobra.Command {
 	var defaults, accessible bool
-	var platform, agents, observability, backstage, modelManager bool
+	var platform, agents, observability, backstage, modelManager, substrate bool
 	var modelManagerBackends []string
-	var chartVersion, chartPath string
+	var chartVersion, chartPath, chartBranch string
 	cmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Discover this machine, then ask for the lab configuration (or keep it with --defaults) and save agentlab.yaml",
@@ -309,6 +309,16 @@ func configureCmd() *cobra.Command {
 			if cmd.Flags().Changed("chart-path") {
 				cfg.Platform.ChartPath = chartPath
 			}
+			if cmd.Flags().Changed("chart-branch") {
+				// A new branch (or none) starts unpinned: the pin froze a
+				// build of the previous one.
+				cfg.Platform.ChartBranch = chartBranch
+				cfg.Platform.ChartPinned = false
+			}
+			if cmd.Flags().Changed("substrate") {
+				cfg.Platform.Substrate.Enabled = &substrate
+			}
+			cfg.Normalize()
 			var pinEnabled *bool
 			if cmd.Flags().Changed("model-manager") {
 				pinEnabled = &modelManager
@@ -336,6 +346,12 @@ func configureCmd() *cobra.Command {
 					return err
 				}
 			}
+			// The dev channel: the branch's newest build becomes the pinned
+			// chartVersion now, so the file says what `up` will install and
+			// a branch without builds is refused here, not after a boot.
+			if _, err := lab.ResolveChartVersion(cfg); err != nil {
+				return err
+			}
 			if err := cfg.Save(); err != nil {
 				return err
 			}
@@ -343,10 +359,16 @@ func configureCmd() *cobra.Command {
 			fmt.Printf("  cluster    %s (Dex on %s)\n", cfg.ClusterName, cfg.Issuer())
 			fmt.Printf("  users      %d\n", len(cfg.Users))
 			fmt.Printf("  platform   %v (agents %v, observability %v)\n", cfg.Platform.Enabled, cfg.Platform.Agents, cfg.Platform.Observability)
-			if cfg.Platform.ChartPath != "" {
+			switch {
+			case cfg.Platform.ChartPath != "":
 				fmt.Printf("  chart      local checkout %s (chartVersion %s ignored while set)\n", cfg.Platform.ChartPath, cfg.Platform.ChartVersion)
-			} else {
+			case cfg.Platform.ChartBranch != "":
+				fmt.Printf("  chart      agent-platform %s (branch %s, dev channel%s)\n", cfg.Platform.ChartVersion, cfg.Platform.ChartBranch, pinnedNote(cfg))
+			default:
 				fmt.Printf("  chart      agent-platform %s\n", cfg.Platform.ChartVersion)
+			}
+			if cfg.Platform.Enabled {
+				fmt.Printf("  substrate  %v (%s)\n", cfg.SubstrateEnabled(), cfg.SubstrateReason())
 			}
 			for _, name := range slices.Sorted(maps.Keys(cfg.Platform.DevImages)) {
 				fmt.Printf("  dev image  %s -> %s\n", name, cfg.Platform.DevImages[name])
@@ -375,8 +397,47 @@ func configureCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&modelManager, "model-manager", false, "pin managed models on/off instead of following the host model servers the discovery finds (needs agents)")
 	cmd.Flags().StringVar(&chartVersion, "chart-version", "", "the agent-platform chart release to install (an exact version; default "+config.DefaultChartVersion+")")
 	cmd.Flags().StringVar(&chartPath, "chart-path", "", "install the agent-platform chart from this local directory (an agent-platform checkout's helm/agent-platform) instead of the pinned release; \"\" clears it")
+	cmd.Flags().StringVar(&chartBranch, "chart-branch", "", "the dev channel: follow this agent-platform branch's newest dev build (resolved now and on every up/platform, written to chartVersion); \"\" returns to the stable channel")
+	cmd.Flags().BoolVar(&substrate, "substrate", false, "pin Substrate (kagent's actor runtime) on/off instead of following the chart channel (on with --chart-branch)")
 	cmd.Flags().StringSliceVar(&modelManagerBackends, "model-manager-backends", nil, "pin the host model servers, in order (ollama, lemonade; the first is model-manager's default backend) instead of the ones the discovery finds")
 	cmd.Flags().BoolVar(&accessible, "accessible", false, "prompt-per-question form mode (for screen readers and plain terminals)")
+	return cmd
+}
+
+// pinnedNote marks a pinned dev-channel lab in the configure summary.
+func pinnedNote(cfg *config.Config) string {
+	if cfg.Platform.ChartPinned {
+		return ", pinned"
+	}
+	return ""
+}
+
+// platformCmd installs the platform on a running cluster; --pin freezes (or
+// --pin=false releases) the dev channel's recorded build first.
+func platformCmd() *cobra.Command {
+	var pin bool
+	cmd := &cobra.Command{
+		Use:   "platform",
+		Short: "Install the Giant Swarm agent platform (the agent-platform chart in the lab shape)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			if cmd.Flags().Changed("pin") {
+				if cfg.Platform.ChartBranch == "" {
+					return fmt.Errorf("--pin only applies to the dev channel (platform.chartBranch is not set; the stable channel is always pinned)")
+				}
+				cfg.Platform.ChartPinned = pin
+				if err := cfg.Save(); err != nil {
+					return err
+				}
+			}
+			return lab.PlatformUp(cfg)
+		},
+	}
+	cmd.Flags().BoolVar(&pin, "pin", false, "dev channel: freeze platform.chartVersion at the recorded build instead of following platform.chartBranch (--pin=false follows it again)")
 	return cmd
 }
 


### PR DESCRIPTION
## What

Additive; the stable channel is unchanged.

- **The dev channel.** `platform.chartBranch` (`agentlab configure --chart-branch poc/kagent-main`) makes the lab follow an agent-platform branch's newest dev build — the `X.Y.Z-dev.<branch>.<date>.<time>.h<sha>` charts gitsemver publishes with branch publishing on. `configure`, `up` and `platform` list the registry's tags through the embedded Helm's registry client, pick the branch's highest semver (the pick a Flux `OCIRepository` with `semver: "*-*"` + `semverFilter` makes) and write it into `chartVersion`, so render/preload/install/`helm history` see one exact version as on the stable channel. `platform --pin` freezes it. The tag schema lives in ONE function, `devTagFilter` (switchable to the RFC's `-b…t…c…` schema; gitsemver's `--`-shortened branch names are accepted). No build → refused with the ways out; `chartBranch` ⟂ `chartPath`.
- **Substrate on demand.** kagent-dev/substrate 0.0.26 — the actor runtime the dev channel's kagent cannot start without — installs ahead of the platform behind `platform.substrate.enabled` (implied by `chartBranch` with agents on; `configure --substrate[=false]` pins it). The lab does the imperative bootstrap itself: a Go port of `kubectl-ate admin make-ca-pool`/`make-jwt-pool` (`substratepools.go`, Apache-2.0, from 0.0.26) creates the four pool Secrets (never regenerated), the actor-id trust anchor and ate-api-server's authentication config with the apiserver's own issuer BEFORE one waited upgrade-or-install each of `substrate-crds` and `substrate` (`--take-ownership` for the namespace the chart also renders), then checks the `SandboxConfig`. A cluster without `certificates.k8s.io/v1beta1` is refused with `agentlab down && agentlab up`; `platform-down` uninstalls it after the platform; a `Substrate` resource group raises the docker floor (+1 CPU / +1 GiB requests).
- **Ported from #129** (the POC record, which stays open): the kind feature gates + `runtimeConfig` + containerd `config_path` (`TestKindConfigSubstrateGates`), `platform.valuesFiles`, the `agentCRDServed()` heal skip, the conditional kagent scrape expectation in platform-test and the ModelConfig `ResolvedRefs` check. NOT the v1alpha3 proofs — they follow in a second PR behind an `agentCRDServed()` dispatch.
- **agents-test's ServiceAccount check** compares against a ServiceAccount no binding names (`agentlab-nobody`, impersonated) instead of a fixed row list: with the ClusterTrustBundle gate on, 1.36 hands every principal the trust-bundle discovery, which the old check flagged.
- The kagent controller ServiceMonitor renders off on the dev channel (kagent main serves no metrics listener).
- Docs: `docs/platform.md` "Dev channel" (colleague happy path, the no-resolver fallback `configure --chart-version <full dev tag>`), docker floors, `docs/cli.md`, HACKS.md U22. No CHANGELOG file in this repo — release notes come from the commits (cliff).

## Why

bumblebee-plans#51 / giantswarm/giantswarm#37705: the kagent API v2 line is built as RFC dev artifacts and consumed as a dev release, so every Bumblebee colleague can run it from published artifacts only — no checkout, no dev images, no local registry.

## How verified

- `go build ./... && go vet ./... && go test ./...` green; `golangci-lint run -E gosec -E goconst -E govet` 0 issues; `pre-commit run --all-files` all hooks pass. New unit tests: `TestSanitizeBranch`, `TestChartBranchValidation`, `TestDevTagFilter`, `TestPickDevTag` (fake tag list: a renovate branch tag must not match, two builds of one branch → the newer wins, a higher base wins, the `--`-shortened form), `TestGenerateCAPoolSecretData`/`TestGenerateJWTPoolSecretData` (round trip of the Secret JSON in the shape ate-api reads: `pool.CAs[0].RootCertificateDER`, `ActiveForSigning`, `tls.crt`/`tls.key`; the JWT pool's ES256 authority), `TestEnsureSubstratePools` (idempotent, never regenerated), `TestEnsureActorIDCACerts`, `TestATEAPIAuthentication` (the exact document), `TestSubstratePreflightWithoutTheAPI`, `TestKagentServiceMonitorFollowsChannel`, `TestSubstrateValuesRender`, the dev-channel rows of `TestLabResourceNeeds`, `TestRulesBeyond`.
- **A fresh isolated lab `agentlab-dev2`** (kind v0.32.0 / kindest/node v1.36.1; dex 32003, edge 8445, muster 8096, agents 8084, backstage 7010) built from this branch, on the **stable channel** (agent-platform 3.20.2, full lab: agents, observability, Backstage, model-manager fronting ollama + lemonade) with **`platform.substrate.enabled: true`**:
  - `agentlab up`: **7 min 13 s** wall (2026-09-09 21:22:54Z → 21:30:07Z), exit 0. Substrate step 96 s: 4 pools created, 12 images side-loaded (15 s), `substrate-crds` + `substrate` installed and Ready in 42 s. `ate-system`: 10 pods Running (ate-api-server ×2, ate-controller, atelet, atenet-egress 2/2, atenet-router 2/2, dns 2/2, postgres-0 2/2, rustfs; rustfs-bucket-init Completed), `SandboxConfig gvisor-default` present.
  - Node after the boot: 4.05 GiB RSS (`docker stats`), requests 3600m CPU / 3652 Mi, 39 pods Running.
  - Proofs, all exit 0: `platform-test` 2 s (6 PASS, the kagent scrape target included), `test` 1 s, `backstage-test` 3 s, `agents-test` 12 s (4 PASS; the SA baseline names `clustertrustbundles.certificates.k8s.io` as the bootstrap extra), `toolsets-test` 53 s (11 PASS).
- **Resolver e2e**: no `-dev.poc-kagent-main.` tag of agent-platform exists on gsoci at merge time (branch publish for agent-platform is being enabled in parallel; a bounded poller ran during this PR). The resolver is unit-tested against a fake tag list and the filter is one documented function; `configure --chart-version <full dev tag>` is the documented no-resolver fallback.
- The dev-channel half (kagent main on Substrate) is exercised by the orchestrator's next wave on a dev-channel lab once the dev tags exist; the proofs dispatch for kagent API v2 is the follow-up PR.
