### PR TITLE
fix(substrate): pin the line's egress-while-resuming build and run the WorkerPool on the pinned worker image

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -237,14 +237,20 @@ What `agentlab up` (and `platform`) does, idempotently:
    so one waited install suffices (HACKS.md U22);
 3. installs `substrate-crds` and `substrate` at the line's pinned version
    (`substrateVersion` in `internal/lab/substrate.go`: today upstream 0.0.26
-   plus kagent-dev/substrate#33, as a `0.0.27-dev.giantswarm.…` build) from
+   plus kagent-dev/substrate#33 and the line's egress-while-resuming patch,
+   as a `0.0.27-dev.giantswarm.…` build) from
    `oci://ghcr.io/giantswarm/substrate/helm` into `ate-system` with the
    chart's own values (`state/substrate-values.yaml`), the images
    (`ghcr.io/giantswarm/substrate/*`) side-loaded like the platform's plus the
    gVisor worker image the `WorkerPool` names, and waits for ate-api-server,
    atelet and atenet;
 4. checks the `SandboxConfig gvisor-default` the chart ships is there. The
-   `WorkerPool` and the `Harness`es come with the dev channel's kagent.
+   `WorkerPool` and the `Harness`es come with the dev channel's kagent; the
+   pool's worker image follows the same pin — the lab's meta chart values
+   name `ghcr.io/giantswarm/substrate/ateom-gvisor:<substrateVersion>` as
+   `kagent.substrateWorkerPool.workerImage`, so workers (where an actor's
+   networking runs) and control plane are one Substrate, and a bump of the
+   pin rolls the pool on the next `agentlab platform`.
 
 `agentlab platform-down` uninstalls Substrate after the platform (whose
 teardown deletes kagent's `WorkerPool` through finalizers ate-controller has
@@ -299,36 +305,47 @@ WorkerPool replaces it). A negative outcome is a finding about the line,
 not about the lab: the proof stays red until the line carries a fix, and
 is that fix's acceptance test.
 
-**Outcome (2026-09-10): negative.** Measured on agent-platform
-`3.22.1-dev.poc-kagent-main.2026-09-10.21-02-36.h2739fe3` (kagent chart
-`0.11.0-dev.poc-agent-platform.2026-09-10.21-15-57.hcc77fbb`,
-kagent-controller `0.11.0-dev.poc-agent-platform.2026-09-10.20-29-02.hc231bd6`,
-Go ADK `ghcr.io/giantswarm/kagent/golang-adk@sha256:99b7b816f0d0…` — Alpine
-with git 2.49.1, so the image is not the problem) and Substrate
-`0.0.27-dev.giantswarm.2026-09-10.19-33-37.h734ec53`: the template stays
-`Ready=False ActorTemplatePending: waiting for the ActorTemplate golden
-snapshot` (Accepted, ResolvedRefs and Compatible `True`, no warnings) for
-the whole timeout while Substrate re-runs the golden actor about once a
-minute (atelet's `AteomHerder/Run`, the same actor id, one worker of
-`kagent-default` pinned to it throughout). The worker pod's log of the
-actor reads `Initialized empty Git repository in
-/plugins/standalone-0/.git/`, then `fatal: unable to access
-'https://github.com/giantswarm/agent-skills/': Send failure: Broken pipe`,
-then `failed to materialize Agent Plugins: materialize agent plugins:
-materialize skill "agent-self-awareness": exit status 128` — the ADK exits
-before readyz. atenet-egress logs nothing about the refused connection
-(its `ext-proc` logs health checks only), so the actor's `Broken pipe` is
-the only trace of the gate. The control without the skill reaches Ready in
-10 s. Deleting the template does not free the worker either: two minutes
-later Substrate still reported the golden actor as `ACTOR_STATE_DELETING`,
-pinned to the same worker pod, kagent's revision garbage collector kept
-failing to delete the ActorTemplate (`delete unreferenced ActorTemplate …:
-Aborted … another operation is in progress`, then `Internal … failed to
-terminate`), and the proof's cleanup had to delete that pod (the WorkerPool
-replaced it; Substrate let go right after). It is the gate the Claude harness hit in
-the laptop POC; the finding is on the line's upstream ledger
-(giantswarm/giantswarm#37742, row 8: boot-phase egress in Substrate, or
-kagent materialising skills after readiness).
+**Outcome (2026-09-11): positive — once every gate on the actor's egress
+admits a resuming actor.** Three gates stood between a booting actor and
+the network, found by reading the line's code and by the proof's evidence:
+
+1. **ateom** (the worker runtime, `cmd/ateom-gvisor`): the actor
+   certificate was minted before the workload started, but atunnel's
+   egress was armed only after readyz, together with ingress — until then
+   an intercepted connection was closed without a word, which is the
+   `Send failure: Broken pipe` of the first runs (measured 2026-09-10 on
+   Substrate `0.0.27-dev.giantswarm.2026-09-10.19-33-37.h734ec53`: the
+   template stayed `Ready=False ActorTemplatePending` for the whole
+   timeout, one worker pinned, nothing logged at any hop; the control
+   without the skill Ready in 10 s).
+2. **atenet's egress `ext_proc` handler** refused any actor that is not
+   `RUNNING`, a state Substrate commits only after readyz.
+3. **the egress dataplane itself**: the agentgateway build the Substrate
+   chart deploys (`ghcr.io/kagent-dev/substrate/agentgateway:c0f5597c7cb8`,
+   a pre-merge build of upstream agentgateway #3237) authorizes every
+   CONNECT against ate-api by itself — actor UID, then `RUNNING` — and is
+   the check in the request path (the chart's egress config carries the
+   `substrateEgress` policy and no `ext_proc`).
+
+The Substrate line carries the fix for the first two (giantswarm/substrate#4,
+in `0.0.27-dev.giantswarm.2026-09-10.22-37-39.h1817627`: egress armed before
+the first container starts, `RESUMING` admitted next to `RUNNING`, both hops
+log a refusal). Under it the proof's evidence changed shape — the worker logs
+`atunnel failed to open egress tunnel … egress gateway rejected CONNECT with
+403 Forbidden: actor is not running` and ate-api logs the dataplane's
+`GetActor` — and the third gate remained: the dataplane's `RUNNING` check
+(upstream agentgateway `egress_actor_resolution.rs`; the fix is prepared on
+the agentgateway line as `upstream/substrate-egress-resuming`). With an egress
+dataplane that does not gate on `RUNNING` — upstream agentgateway `v1.5.0`,
+whose `substrateEgress` derives the actor from the SPIFFE id and does no
+UID or state check, swapped into `atenet-egress` for the run — the proof
+passed on both halves: `Ready after 20s`, the turn answered
+`Skills: agent-self-awareness … klaus-gateway`, nothing left behind
+(agent-platform `3.22.1-dev.poc-kagent-main.2026-09-10.22-15-11.h284980b`,
+kagent `0.11.0-dev.giantswarm.2026-09-10.22-06-46.h0ac5240`, Go ADK
+`golang-adk@sha256:1f016b65…`, Substrate `…h1817627`). Every skill-carrying
+agent of the fleet needs all three gates open; the third is the agentgateway
+line's, tracked with the rest on giantswarm/giantswarm#37742 (row 8).
 
 ## The request path
 

--- a/internal/lab/chartbranch_test.go
+++ b/internal/lab/chartbranch_test.go
@@ -4,12 +4,16 @@ import (
 	"testing"
 )
 
+// devChannelBranch is the dev channel the tests follow: the agent-platform
+// branch whose meta chart builds carry kagent API v2.
+const devChannelBranch = "poc/kagent-main"
+
 // The dev-channel filter reads gitsemver's dev tags: a branch's own builds,
 // spelled with its sanitized name, in either the full or the `--`-shortened
 // form; never a release, never a sibling branch whose sanitized name shares
 // a prefix, never a renovate branch.
 func TestDevTagFilter(t *testing.T) {
-	matches := devTagFilter("poc/kagent-main")
+	matches := devTagFilter(devChannelBranch)
 	for _, ok := range []string{
 		"dev.poc-kagent-main.2026-09-09.20-23-54.h28f7f50",
 		"dev.poc-kagent-main.2026-09-10.08-12-33",
@@ -64,14 +68,14 @@ func TestPickDevTag(t *testing.T) {
 		"3.22.1-rc.1",
 		"not-a-version",
 	}
-	got, ok := pickDevTag(tags, "poc/kagent-main")
+	got, ok := pickDevTag(tags, devChannelBranch)
 	if !ok || got != "3.22.1-dev.poc-kagent-main.2026-09-10.08-12-33.h7f841be" {
 		t.Errorf("pickDevTag = %q, %v; want the 2026-09-10 build", got, ok)
 	}
 	// A newer base version (the branch rebased over a release) beats an
 	// older base with a later timestamp: that is the semver order Flux and
 	// Helm resolve by too, and the branch's next build carries it forward.
-	got, _ = pickDevTag(append(tags, "3.23.1-dev.poc-kagent-main.2026-09-01.00-00-00.h0000000"), "poc/kagent-main")
+	got, _ = pickDevTag(append(tags, "3.23.1-dev.poc-kagent-main.2026-09-01.00-00-00.h0000000"), devChannelBranch)
 	if got != "3.23.1-dev.poc-kagent-main.2026-09-01.00-00-00.h0000000" {
 		t.Errorf("a higher base must win: %q", got)
 	}
@@ -81,7 +85,7 @@ func TestPickDevTag(t *testing.T) {
 	if _, ok := pickDevTag(tags, "main"); ok {
 		t.Error("a branch without builds must not resolve")
 	}
-	if _, ok := pickDevTag(nil, "poc/kagent-main"); ok {
+	if _, ok := pickDevTag(nil, devChannelBranch); ok {
 		t.Error("no tags must not resolve")
 	}
 }

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -83,6 +83,11 @@ type tmplData struct {
 	PostRenderers              map[string]string
 	MCPPrometheusPostRenderers string
 	MCPPrometheusChartVersion  string
+	// SubstrateWorkerImage is the gVisor worker image of the Substrate the
+	// lab installs (substrate.go, ateomGVisorImage): on the dev channel the
+	// meta chart values name it as the WorkerPool's workerImage, so the
+	// workers run the same Substrate as the control plane.
+	SubstrateWorkerImage string
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -110,6 +115,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		PostRenderers:              postRenderers,
 		MCPPrometheusPostRenderers: strings.TrimRight(string(mcpPrometheus), "\n"),
 		MCPPrometheusChartVersion:  mcpPrometheusChartVersion,
+		SubstrateWorkerImage:       ateomGVisorImage,
 		ModelManagerEnabled:        cfg.ModelManagerEnabled(),
 		ModelManagerBackends:       cfg.Platform.ModelManager.Backends,
 		ModelManagerEndpoints:      endpoints,

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -291,6 +291,39 @@ func TestKagentServiceMonitorFollowsChannel(t *testing.T) {
 	}
 }
 
+// On the dev channel the WorkerPool's worker image follows the lab's
+// Substrate pin — control plane and workers at one version; the stable
+// channel, whose kagent creates no WorkerPool, renders no such key (the
+// released chart's schema does not know it).
+func TestKagentWorkerImageFollowsSubstratePin(t *testing.T) {
+	cfg := config.Default()
+	render := func() map[string]any {
+		out, err := renderTemplate(cfg, "agent-platform-values.yaml.tmpl", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var values map[string]any
+		if err := yaml.Unmarshal(out, &values); err != nil {
+			t.Fatalf("%v\n%s", err, out)
+		}
+		return values
+	}
+	if _, ok := render()["kagent"].(map[string]any)["substrateWorkerPool"]; ok {
+		t.Error("stable channel: kagent.substrateWorkerPool rendered, but the released chart has no WorkerPool")
+	}
+	cfg.Platform.ChartBranch = "poc/kagent-main"
+	pool, ok := render()["kagent"].(map[string]any)["substrateWorkerPool"].(map[string]any)
+	if !ok {
+		t.Fatal("dev channel: kagent.substrateWorkerPool not rendered")
+	}
+	if got := pool["workerImage"]; got != ateomGVisorImage {
+		t.Errorf("dev channel: kagent.substrateWorkerPool.workerImage = %v, want %s", got, ateomGVisorImage)
+	}
+	if !strings.HasSuffix(ateomGVisorImage, ":"+substrateVersion) {
+		t.Errorf("the worker image %s must carry the Substrate pin %s", ateomGVisorImage, substrateVersion)
+	}
+}
+
 // The Substrate values are the chart's defaults with the lab's two
 // deviations spelled out: no Namespace rendered (the lab creates it ahead of
 // the chart) and no atelet extra args (no local registry).

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -276,7 +276,7 @@ func TestKagentServiceMonitorFollowsChannel(t *testing.T) {
 	if got := kagentMonitor(render()); got != true {
 		t.Errorf("stable channel with observability: kagent.serviceMonitor.enabled = %v, want true", got)
 	}
-	cfg.Platform.ChartBranch = "poc/kagent-main"
+	cfg.Platform.ChartBranch = devChannelBranch
 	v := render()
 	if got := kagentMonitor(v); got != false {
 		t.Errorf("dev channel: kagent.serviceMonitor.enabled = %v, want false", got)
@@ -311,7 +311,7 @@ func TestKagentWorkerImageFollowsSubstratePin(t *testing.T) {
 	if _, ok := render()["kagent"].(map[string]any)["substrateWorkerPool"]; ok {
 		t.Error("stable channel: kagent.substrateWorkerPool rendered, but the released chart has no WorkerPool")
 	}
-	cfg.Platform.ChartBranch = "poc/kagent-main"
+	cfg.Platform.ChartBranch = devChannelBranch
 	pool, ok := render()["kagent"].(map[string]any)["substrateWorkerPool"].(map[string]any)
 	if !ok {
 		t.Fatal("dev channel: kagent.substrateWorkerPool not rendered")

--- a/internal/lab/resources_test.go
+++ b/internal/lab/resources_test.go
@@ -67,7 +67,7 @@ func labConfig(platform, agents, observability, backstage, modelManager bool) *c
 
 // devChannel puts a configuration on the dev channel (platform.chartBranch).
 func devChannel(cfg *config.Config) *config.Config {
-	cfg.Platform.ChartBranch = "poc/kagent-main"
+	cfg.Platform.ChartBranch = devChannelBranch
 	return cfg
 }
 

--- a/internal/lab/substrate.go
+++ b/internal/lab/substrate.go
@@ -51,7 +51,7 @@ import (
 // fork's publish workflow names it in its run summary); it moves only
 // together with kagent's Substrate pin.
 const (
-	substrateVersion       = "0.0.27-dev.giantswarm.2026-09-10.19-33-37.h734ec53"
+	substrateVersion       = "0.0.27-dev.giantswarm.2026-09-10.22-37-39.h1817627"
 	substrateChartsRepo    = "oci://ghcr.io/giantswarm/substrate/helm"
 	substrateImageRegistry = "ghcr.io/giantswarm/substrate"
 )
@@ -107,11 +107,14 @@ var substratePools = []substratePool{
 // PodCertificateRequest API behind the certificates.k8s.io/v1beta1 gate.
 const podCertificateAPIPath = "/apis/certificates.k8s.io/v1beta1"
 
-// ateomGVisorImage is the worker image the WorkerPool the dev channel's
-// kagent creates names (`workerImage:`, no `image:` line in any render), so
-// the preload lists it explicitly — pulled once here instead of at the first
-// actor's boot. The line tags its images with the bare version (upstream's
-// carry a `v`).
+// ateomGVisorImage is the worker image of the WorkerPool the dev channel's
+// kagent creates: the lab names it in the meta chart values
+// (kagent.substrateWorkerPool.workerImage, agent-platform-values.yaml.tmpl),
+// so workers and control plane run one Substrate — the worker image carries
+// the actor's networking (atunnel) and moves with the pin — and lists it in
+// the preload explicitly (`workerImage:` is no `image:` line in any render),
+// pulled once here instead of at the first actor's boot. The line tags its
+// images with the bare version (upstream's carry a `v`).
 const ateomGVisorImage = substrateImageRegistry + "/ateom-gvisor:" + substrateVersion
 
 // The SandboxConfig the chart ships, which every gVisor WorkerPool names.

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -293,6 +293,16 @@ kagent:
   # the edge only listens on the host's loopback.
   controllerRoute:
     enabled: true
+{{- if .SubstrateEnabled }}
+  # DEV CHANNEL: the WorkerPool the kagent chart creates runs the gVisor
+  # worker image of the Substrate the lab installs — one pin (substrate.go),
+  # control plane and workers at the same version. The worker image is where
+  # an actor's networking lives (atunnel, the egress tunnel), so the chart's
+  # own default — the image the platform ships — would run the lab's actors
+  # on a Substrate other than the one the lab just installed.
+  substrateWorkerPool:
+    workerImage: {{ .SubstrateWorkerImage }}
+{{- end }}
   # The default ModelConfig every agent starts from (the kagent chart renders
   # it from providers.<default>). The chart would only create the referenced
   # Secret if the raw key were inlined in these values — which would put a


### PR DESCRIPTION
## Problem

`agentlab skills-test` (#137, #145) was red: a Go ADK `AgentTemplate` with a git skill never got its golden snapshot because Substrate denied the actor's egress before readyz. The Substrate line now carries the fix (giantswarm/substrate#4, dev build `0.0.27-dev.giantswarm.2026-09-10.22-37-39.h1817627`: the worker arms an actor's tunneled egress before its first container starts; atenet admits a `RESUMING` actor; both hops log a refusal).

The fix lives in the worker image (`ateom-gvisor`), and the `WorkerPool` the dev channel's kagent creates named the meta chart's default worker image — a Substrate other than the one the lab installs, so bumping `substrateVersion` alone would have left the workers on the old runtime.

## Change

- `substrateVersion` → `0.0.27-dev.giantswarm.2026-09-10.22-37-39.h1817627`.
- The lab's meta chart values name `kagent.substrateWorkerPool.workerImage` from the same pin (`ateomGVisorImage`), dev channel only — the released chart has no WorkerPool and its schema no such key (`TestKagentWorkerImageFollowsSubstratePin`). Control plane and workers are one Substrate; a bump of the pin rolls the pool on the next `agentlab platform`.
- Docs: the dev-channel step, and the skills proof's outcome — the three gates on a booting actor's egress, which the line fixes, which remains (the egress dataplane's own `RUNNING` check, agentgateway's), and the run that passed.

## Verification (isolated lab `agentlab-dev2`, dev channel `poc/kagent-main`)

- `agentlab platform` with this binary: `ate-system` rolled to `…h1817627`, `WorkerPool kagent-default` `spec.workerImage` and all four workers on `ateom-gvisor:…h1817627`.
- `skills-test` on the chart's egress dataplane (`agentgateway:c0f5597c7cb8`): red at the third gate, with the new evidence (`atunnel failed to open egress tunnel … 403 Forbidden: actor is not running` in the worker's log; ate-api logs the dataplane's `GetActor`) — the first two gates are open.
- `skills-test` with upstream agentgateway `v1.5.0` swapped into `atenet-egress` (no `RUNNING` check): **PASS on both halves** — `Ready after 20s`, the turn answered `Skills: agent-self-awareness … klaus-gateway`, nothing left behind. `agents-test` green under the same dataplane.
- `platform-test` and `agents-test` after restoring the chart's dataplane: see the CI/comment below.
