### PR TITLE
fix(substrate): pin the build whose egress dataplane keeps the CONNECT-time check and admits a resuming actor

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -353,7 +353,7 @@ listener (with the old shape the gs.2 dataplane refused its config and the
 first roll never became ready). The lab's Substrate pin follows that build
 (`0.0.27-dev.giantswarm.2026-09-11.02-07-06.h213d76b`), and the WorkerPool's
 worker image with it. On it the proof passed on both halves with the check in
-place: RESULT_PENDING. Every skill-carrying agent of the fleet needs all three
+place: Ready after 15s on Harness kagent, the turn as admin@lab.local answered "klaus-gateway" from the skill, nothing left behind (revision a8949e0f2c79); platform-test 6/6 and agents-test 5/5 green on the same lab. Every skill-carrying agent of the fleet needs all three
 gates open; the upstream exits of the two patches are tracked on
 giantswarm/giantswarm#37742 (row 8).
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -333,19 +333,29 @@ the first container starts, `RESUMING` admitted next to `RUNNING`, both hops
 log a refusal). Under it the proof's evidence changed shape — the worker logs
 `atunnel failed to open egress tunnel … egress gateway rejected CONNECT with
 403 Forbidden: actor is not running` and ate-api logs the dataplane's
-`GetActor` — and the third gate remained: the dataplane's `RUNNING` check
-(upstream agentgateway `egress_actor_resolution.rs`; the fix is prepared on
-the agentgateway line as `upstream/substrate-egress-resuming`). With an egress
-dataplane that does not gate on `RUNNING` — upstream agentgateway `v1.5.0`,
-whose `substrateEgress` derives the actor from the SPIFFE id and does no
-UID or state check, swapped into `atenet-egress` for the run — the proof
-passed on both halves: `Ready after 20s`, the turn answered
-`Skills: agent-self-awareness … klaus-gateway`, nothing left behind
-(agent-platform `3.22.1-dev.poc-kagent-main.2026-09-10.22-15-11.h284980b`,
-kagent `0.11.0-dev.giantswarm.2026-09-10.22-06-46.h0ac5240`, Go ADK
-`golang-adk@sha256:1f016b65…`, Substrate `…h1817627`). Every skill-carrying
-agent of the fleet needs all three gates open; the third is the agentgateway
-line's, tracked with the rest on giantswarm/giantswarm#37742 (row 8).
+`GetActor` — and the third gate remained: the dataplane's `RUNNING` check.
+With an egress dataplane that does not gate on `RUNNING` — upstream
+agentgateway `v1.5.0`, whose `substrateEgress` derives the actor from the
+SPIFFE id and does no UID or state check, swapped into `atenet-egress` for
+the run — the proof passed on both halves on 2026-09-11 (`Ready after 20s`,
+the turn answered `Skills: agent-self-awareness … klaus-gateway`), which
+proved the Substrate half but gave the authorization up.
+
+The agentgateway line closes the third gate without giving it up: its release
+`v1.5.1-gs.2` (giantswarm/agentgateway-upstream#4) carries upstream
+agentgateway #3237 — every egress CONNECT authorized against ate-api, the
+actor's UID and then its state — and admits `RESUMING` next to `RUNNING`
+(SUSPENDED, PAUSED, CRASHED and DELETING stay refused). giantswarm/substrate#7
+pins it for `atenet-router` and `atenet-egress`, and giantswarm/substrate#9
+declares the actor authorization where that dataplane reads it — #3237 made
+it a frontend policy on the CONNECT, no longer a route policy on the inner
+listener (with the old shape the gs.2 dataplane refused its config and the
+first roll never became ready). The lab's Substrate pin follows that build
+(`0.0.27-dev.giantswarm.2026-09-11.02-07-06.h213d76b`), and the WorkerPool's
+worker image with it. On it the proof passed on both halves with the check in
+place: RESULT_PENDING. Every skill-carrying agent of the fleet needs all three
+gates open; the upstream exits of the two patches are tracked on
+giantswarm/giantswarm#37742 (row 8).
 
 ## The request path
 

--- a/internal/lab/substrate.go
+++ b/internal/lab/substrate.go
@@ -51,7 +51,7 @@ import (
 // fork's publish workflow names it in its run summary); it moves only
 // together with kagent's Substrate pin.
 const (
-	substrateVersion       = "0.0.27-dev.giantswarm.2026-09-10.22-37-39.h1817627"
+	substrateVersion       = "0.0.27-dev.giantswarm.2026-09-11.02-07-06.h213d76b"
 	substrateChartsRepo    = "oci://ghcr.io/giantswarm/substrate/helm"
 	substrateImageRegistry = "ghcr.io/giantswarm/substrate"
 )


### PR DESCRIPTION
## Problem

`agentlab skills-test` (#137) was green only with an egress dataplane that authorizes nothing at CONNECT time (upstream agentgateway v1.5.0, the pin of giantswarm/substrate#5): the chart's earlier dataplane (`c0f5597c7cb8`, a pre-merge build of agentgateway#3237) checked the actor's UID and `RUNNING` state against ate-api and refused the golden boot — the third gate after the two giantswarm/substrate#4 fixed.

## Change

- `substrateVersion` → `0.0.27-dev.giantswarm.2026-09-11.02-07-06.h213d76b` (giantswarm/substrate#7 + #9): `atenet-router` and `atenet-egress` run the agentgateway line's `v1.5.1-gs.2` (giantswarm/agentgateway-upstream#4) — #3237's CONNECT-time authorization kept, `RESUMING` admitted next to `RUNNING`. #9 declares that authorization as the frontend policy #3237 made it (no longer a route policy on the inner listener), so the dataplane accepts the config. The WorkerPool's worker image follows the same pin (as #147 arranged).
- Docs: the skills proof's outcome on the three gates — which line fixes which, and the run that passed with the check in place.

## Verification (`agentlab-dev2`, dev channel `poc/kagent-main`, binary built from this branch)

- `agentlab platform`: `ate-system` rolled to `…h213d76b`; `atenet-egress` and `atenet-router` on `agentgateway:v1.5.1-gs.2` (Ready), WorkerPool `kagent-default` and all four workers on `ateom-gvisor:…h213d76b`.
- `skills-test` **PASS both halves** with the CONNECT-time UID+state check in place: golden boot of the git-skill AgentTemplate Ready on Harness `kagent` in 15s; the turn as `admin@lab.local` answered `klaus-gateway` from the skill's text (`KAGENT_PROPAGATE_TOKEN=true`); nothing left behind.
- `platform-test` **6/6**, `agents-test` **5/5** green on the same lab.

Versions: agent-platform `3.22.1-dev.poc-kagent-main.2026-09-11.00-10-33.hf06a28b`, kagent `0.11.0-dev.giantswarm.2026-09-11.00-32-34.h3bdff38`, Substrate `0.0.27-dev.giantswarm.2026-09-11.02-07-06.h213d76b`, dataplane `agentgateway:v1.5.1-gs.2`.

Not lab-verified: Flux/GitOps delivery of the platform itself (the lab installs Substrate directly).
