### PR TITLE
feat(proofs): skills-test takes a fixture of the caller's — another repository, and a private one through credentialRef

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -284,7 +284,9 @@ materialises the template's skills when it starts (a git skill is
 `git fetch --depth 1 origin <commit>` of a full commit into `/plugins`,
 copied to `/skills`), before it serves readyz; and atenet refuses outbound
 connections from an actor that is not `RUNNING`. The proof creates an
-`AgentTemplate` on the platform's Go ADK Harness (`kagent`) with one skill
+`AgentTemplate` on the platform's Go ADK Harness (`kagent`) — labelled as
+that Harness's `allowedAgentTemplates` selector admits, read from the
+Harness itself — with one skill
 pinned to a full commit of a public repository — `agent-self-awareness` of
 giantswarm/agent-skills, the repository most of the fleet's skills come
 from — and the shared muster server as its tools, waits for `Ready` on the

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -305,6 +305,21 @@ WorkerPool replaces it). A negative outcome is a finding about the line,
 not about the lab: the proof stays red until the line carries a fix, and
 is that fix's acceptance test.
 
+Another fixture takes the public one's place: `--skill-repo`,
+`--skill-commit`, `--skill-path` (the skill's directory within the
+repository, its last element the skill's name), `--skill-question` and
+`--skill-expect` (the answer only the skill's text has, matched
+case-insensitively in the reply together with the skill's name). A private
+repository adds `--skill-secret`: a Secret in the kagent namespace whose
+`token` key holds a read token for the repository's host, rendered as the
+source's `skills[].source.git.credentialRef` (`{name, key: token}`) — the
+proof refuses to run it against a kagent whose served `AgentTemplate` CRD
+lacks the field, since that kagent would prune it and fetch anonymously. The
+Secret is yours to create; the proof never reads its value. A Secret that
+does not exist shows as `ResolvedRefs=False` on the Harness before any
+actor boots; a wrong token as a failed golden boot whose worker log carries
+git's authentication error.
+
 **Outcome (2026-09-11): positive — once every gate on the actor's egress
 admits a resuming actor.** Three gates stood between a booting actor and
 the network, found by reading the line's code and by the proof's evidence:

--- a/internal/lab/kagentapi.go
+++ b/internal/lab/kagentapi.go
@@ -43,9 +43,14 @@ import (
 // and the A2A v1 package the controller itself is built with.
 
 const (
-	// kagentRoutePrefix is the path prefix the connectivity chart mounts the
-	// kagent API at on the agentgateway hostname (kagent.controllerRoute.pathPrefix).
+	// kagentRoutePrefix is the path prefix the 3.x connectivity chart mounts the
+	// kagent API at on the agentgateway hostname (an HTTPRoute whose URLRewrite
+	// strips it). The 4.x chart routes the API by gRPC service and method on a
+	// GRPCRoute instead, under no prefix — kagentRoutePrefixServed tells which.
 	kagentRoutePrefix = "/kagent"
+	// kagentGRPCRouteName is the 4.x connectivity chart's GRPCRoute for the
+	// controller, in the platform namespace.
+	kagentGRPCRouteName = "kagent-controller"
 	// kagentHarness is the platform's Go ADK Harness: every AgentTemplate the
 	// proofs create is labelled for it (harnessLabel) and every turn runs on it.
 	kagentHarness = "kagent"
@@ -79,7 +84,8 @@ const (
 // kagentAPI is one person's view of the kagent controller through the edge.
 type kagentAPI struct {
 	client *http.Client
-	// base is <AgentgatewayBaseURL>/kagent.
+	// base is the kagent API's root on the edge: <AgentgatewayBaseURL> plus
+	// the route's prefix (kagentRoutePrefixServed).
 	base string
 	// user is the x-user-id: the person the controller attributes instances to.
 	user string
@@ -95,7 +101,25 @@ func newKagentAPI(cfg *config.Config, user, token string) (*kagentAPI, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &kagentAPI{client: client, base: cfg.AgentgatewayBaseURL() + kagentRoutePrefix, user: user, token: token}, nil
+	return &kagentAPI{client: client, base: cfg.AgentgatewayBaseURL() + kagentRoutePrefixServed(), user: user, token: token}, nil
+}
+
+// kagentRoutePrefixServed is the prefix the lab's edge puts the kagent API
+// under: none when the connectivity chart routes it by gRPC service and
+// method (a GRPCRoute in the platform namespace, the 4.x shape — a request
+// under /kagent would fall through to the MCP catch-all route there),
+// /kagent when it is the prefixed HTTPRoute of the 3.x shape.
+func kagentRoutePrefixServed() string {
+	gvr, err := gvrFor("grpcroutes.gateway.networking.k8s.io")
+	if err != nil {
+		return kagentRoutePrefix
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	if _, err := getObject(ctx, gvr, platformNamespace, kagentGRPCRouteName); err == nil {
+		return ""
+	}
+	return kagentRoutePrefix
 }
 
 // grpcStatus is a non-OK gRPC status the controller answered with.

--- a/internal/lab/skillstest.go
+++ b/internal/lab/skillstest.go
@@ -3,6 +3,8 @@ package lab
 import (
 	"context"
 	"fmt"
+	"path"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -44,19 +46,117 @@ const (
 	skillsTestControlAgent = skillsTestAgent + "-control"
 )
 
-// The fixture: giantswarm/agent-skills, the public repository most of the
-// fleet's skills come from, at a full commit; the skill whose SKILL.md names
-// a fact the model cannot know otherwise (skillsTestFact), which the turn
-// asks for without saying it.
+// The default fixture: giantswarm/agent-skills, the public repository most of
+// the fleet's skills come from, at a full commit; the skill whose SKILL.md
+// names a fact the model cannot know otherwise (skillsTestFact), which the
+// turn asks for without saying it. A SkillsFixture of the caller's puts
+// another repository in its place — a private one, with the Secret whose
+// token its host takes.
 const (
-	skillsTestRepo   = "https://github.com/giantswarm/agent-skills"
-	skillsTestCommit = "cb1fb768bbbbcaa035b884a99ad308b14f846468"
-	skillsTestSkill  = "agent-self-awareness"
-	skillsTestFact   = "klaus-gateway"
-	skillsTestPrompt = "First list the names of every skill available to you. Then load the skill named " + skillsTestSkill +
-		" and answer from its text only: which application bridges kagent with Slack? Reply in one line: the skill names, then the application's name."
+	skillsTestRepo         = "https://github.com/giantswarm/agent-skills"
+	skillsTestCommit       = "cb1fb768bbbbcaa035b884a99ad308b14f846468"
+	skillsTestSkill        = "agent-self-awareness"
+	skillsTestFact         = "klaus-gateway"
+	skillsTestQuestion     = "which application bridges kagent with Slack?"
 	skillsTestSystemPrompt = "You are a terse assistant of the agentlab skills proof. Use your skills when asked about them. Answer in one short line."
+	// skillsCredentialKey is the Secret key the runtime reads a source's token
+	// from (skills[].source.git.credentialRef.key).
+	skillsCredentialKey = "token"
 )
+
+// SkillsFixture is the skill the proof boots and asks about: a git repository
+// at a full commit, the skill's directory within it (its last element is the
+// skill's name), the question the turn asks and the answer only the skill's
+// text has — and, for a private repository, the Secret in the kagent
+// namespace whose token key the runtime presents to the repository's host
+// (skills[].source.git.credentialRef). The zero value is the public fixture.
+type SkillsFixture struct {
+	Repo, Commit, Skill, Question, Expect string
+	// CredentialSecret names the Secret (key skillsCredentialKey); "" fetches
+	// anonymously. The proof never reads the Secret.
+	CredentialSecret string
+}
+
+var fullCommitID = regexp.MustCompile(`^([0-9a-fA-F]{40}|[0-9a-fA-F]{64})$`)
+
+// resolve returns the public fixture for the zero value and checks a fixture
+// of the caller's: every field but the Secret, an http(s) URL, a full commit.
+func (f SkillsFixture) resolve() (SkillsFixture, error) {
+	if f.Repo == "" && f.Commit == "" && f.Skill == "" && f.Question == "" && f.Expect == "" {
+		f.Repo, f.Commit, f.Skill, f.Question, f.Expect = skillsTestRepo, skillsTestCommit, skillsTestSkill, skillsTestQuestion, skillsTestFact
+		return f, nil
+	}
+	var missing []string
+	for _, field := range []struct{ flag, value string }{
+		{"--skill-repo", f.Repo}, {"--skill-commit", f.Commit}, {"--skill-path", f.Skill}, {"--skill-question", f.Question}, {"--skill-expect", f.Expect},
+	} {
+		if field.value == "" {
+			missing = append(missing, field.flag)
+		}
+	}
+	if len(missing) > 0 {
+		return f, fmt.Errorf("a fixture of your own takes every one of --skill-repo, --skill-commit, --skill-path, --skill-question and --skill-expect; missing: %s", strings.Join(missing, ", "))
+	}
+	if !strings.HasPrefix(f.Repo, "https://") && !strings.HasPrefix(f.Repo, "http://") {
+		return f, fmt.Errorf("--skill-repo %q: an http(s) git URL", f.Repo)
+	}
+	if !fullCommitID.MatchString(f.Commit) {
+		return f, fmt.Errorf("--skill-commit %q: a full 40- or 64-hex commit id (the CRD refuses anything else)", f.Commit)
+	}
+	f.Skill = strings.Trim(f.Skill, "/")
+	if f.Skill == "" || f.Skill == "." || strings.Contains(f.Skill, "..") {
+		return f, fmt.Errorf("--skill-path %q: the skill's directory within the repository", f.Skill)
+	}
+	if f.CredentialSecret != "" && !strings.HasPrefix(f.Repo, "https://") {
+		return f, fmt.Errorf("--skill-secret needs an https:// repository (the CRD refuses a credentialRef on an http URL)")
+	}
+	return f, nil
+}
+
+// skillsAgentTemplateCRD is the CRD the fixture's credentialRef must be served by.
+const skillsAgentTemplateCRD = "agenttemplates.kagent.dev"
+
+// requireCredentialRefServed checks the served AgentTemplate CRD carries
+// skills[].source.git.credentialRef: a kagent line without it prunes the
+// field at admission and fetches anonymously, which a private fixture would
+// report as a boot failure for the wrong reason.
+func requireCredentialRefServed() error {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+	defer cancel()
+	crd, err := getObject(ctx, gvrCRDs, "", skillsAgentTemplateCRD)
+	if err != nil {
+		return fmt.Errorf("read the AgentTemplate CRD: %w", err)
+	}
+	versions, _, _ := unstructured.NestedSlice(crd.Object, "spec", "versions")
+	for _, v := range versions {
+		version, _ := v.(map[string]any)
+		if name, _, _ := unstructured.NestedString(version, nameKey); name != path.Base(agentTemplateAPIVersion) {
+			continue
+		}
+		if _, found, _ := unstructured.NestedMap(version, "schema", "openAPIV3Schema", "properties", "spec", "properties", "skills", "items", "properties", "source", "properties", "git", "properties", "credentialRef"); found {
+			return nil
+		}
+	}
+	return fmt.Errorf("the served AgentTemplate CRD (%s) has no skills[].source.git.credentialRef: the kagent line under test predates the per-source credential, a private fixture cannot be fetched", skillsAgentTemplateCRD)
+}
+
+// name is the skill's name: the last element of its directory.
+func (f SkillsFixture) name() string { return path.Base(f.Skill) }
+
+// prompt is the turn: list the skills, load the fixture's, answer its
+// question from the text only.
+func (f SkillsFixture) prompt() string {
+	return "First list the names of every skill available to you. Then load the skill named " + f.name() +
+		" and answer from its text only: " + f.Question + " Reply in one line: the skill names, then the answer."
+}
+
+// credentialNote words the fixture's credential for the steps, "" when none.
+func (f SkillsFixture) credentialNote() string {
+	if f.CredentialSecret == "" {
+		return ""
+	}
+	return fmt.Sprintf(" with credentialRef {name: %s, key: %s}", f.CredentialSecret, skillsCredentialKey)
+}
 
 // SkillsTestReadyTimeout bounds the golden boot by default: the runtime image
 // into Substrate's layer cache, the actor's start, the skill fetch, the
@@ -81,7 +181,7 @@ const (
 // actor's own about its skill fetch and its exit.
 var (
 	egressGateWords = []string{"denied", "not running", "RUNNING", "reject", "forbid", "CONNECT"}
-	actorBootWords  = []string{"fatal", "materializ", "readyz", "unable to", "exit", "level\":\"error", "\"error\":"}
+	actorBootWords  = []string{"fatal", "materializ", "readyz", "unable to", "exit", "level\":\"error", "\"error\":", "authentication", "401", "credential"}
 )
 
 // Resources of kagent API v2 the proof reads beyond the AgentTemplate, and
@@ -102,6 +202,9 @@ type SkillsTestOptions struct {
 	ModelConfig string
 	// ReadyTimeout bounds the golden boot (default SkillsTestReadyTimeout).
 	ReadyTimeout time.Duration
+	// Fixture is the skill to boot and ask about; the zero value is the
+	// public fixture, a private repository's names its Secret.
+	Fixture SkillsFixture
 }
 
 // SkillsTest is the headless proof that a Go ADK AgentTemplate with a git skill
@@ -129,6 +232,11 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	if opts.ReadyTimeout <= 0 {
 		opts.ReadyTimeout = SkillsTestReadyTimeout
 	}
+	fixture, err := opts.Fixture.resolve()
+	if err != nil {
+		return err
+	}
+	opts.Fixture = fixture
 
 	step("Logging in to Dex as %s", user.Email)
 	token, err := passwordGrant(cfg, config.AgentPlatformClientID, config.AgentPlatformClientSecret,
@@ -160,8 +268,13 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	cleanup()
 	defer cleanup()
 
-	step("Applying AgentTemplate %s on Harness %s: skill %s from %s @ %.12s, tools from %s", skillsTestAgent, kagentHarness, skillsTestSkill, skillsTestRepo, skillsTestCommit, componentMuster)
-	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestAgent, opts.ModelConfig, true))); err != nil {
+	step("Applying AgentTemplate %s on Harness %s: skill %s from %s @ %.12s%s, tools from %s", skillsTestAgent, kagentHarness, fixture.name(), fixture.Repo, fixture.Commit, fixture.credentialNote(), componentMuster)
+	if fixture.CredentialSecret != "" {
+		if err := requireCredentialRefServed(); err != nil {
+			return err
+		}
+	}
+	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestAgent, opts.ModelConfig, &fixture))); err != nil {
 		return err
 	}
 	note("accepted by the apiserver (the CRD validates the full commit and the relative path)")
@@ -182,11 +295,11 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	}
 
 	step("One A2A turn through the edge as %s: the agent names its skills and answers from the skill's text", user.Email)
-	reply, err := agentTurnAs(cfg, skillsTestAgent, token, skillsTestPrompt)
+	reply, err := agentTurnAs(cfg, skillsTestAgent, token, fixture.prompt())
 	if err != nil {
 		return err
 	}
-	if err := skillReplyProves(reply, skillsTestSkill, skillsTestFact); err != nil {
+	if err := skillReplyProves(reply, fixture.name(), fixture.Expect); err != nil {
 		return fmt.Errorf("the skill was not in effect on the turn: %w", err)
 	}
 	note("answered: %s", excerpt(reply, 200))
@@ -199,32 +312,40 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	note("nothing left in the kagent namespace or in Substrate")
 
 	fmt.Println()
-	fmt.Printf("PASS: AgentTemplate %s with the git skill %s (%s @ %.12s) reached Ready on Harness %s in %s — the Go ADK fetched the skill during the golden boot under Substrate's egress gate (%s)\n",
-		skillsTestAgent, skillsTestSkill, skillsTestRepo, skillsTestCommit, kagentHarness, boot.elapsed.Round(time.Second), facts.summary())
+	fmt.Printf("PASS: AgentTemplate %s with the git skill %s (%s @ %.12s%s) reached Ready on Harness %s in %s — the Go ADK fetched the skill during the golden boot under Substrate's egress gate (%s)\n",
+		skillsTestAgent, fixture.name(), fixture.Repo, fixture.Commit, fixture.credentialNote(), kagentHarness, boot.elapsed.Round(time.Second), facts.summary())
 	fmt.Printf("PASS: one turn through the edge as %s named the skill and answered %q from its text; the Harness re-emits the person's bearer on tool calls (%s=true), so muster attributes any tool call of the turn to %s\n",
-		user.Email, skillsTestFact, propagateIdentityEnv, user.Email)
+		user.Email, fixture.Expect, propagateIdentityEnv, user.Email)
 	fmt.Printf("PASS: nothing left behind — the AgentTemplate, its AgentInstance, Substrate's ActorTemplate and actor are gone\n")
 	return nil
 }
 
 // skillsAgentTemplate is the proof's AgentTemplate: the Go ADK Harness, the
 // ModelConfig, the terse prompt, the shared muster server as its tools (the
-// fleet's shape: skills and tools), labelled as agentlab's — and, unless
-// control, one git skill pinned to the fixture's full commit, selected by
-// the directory of the same name within the repository.
-func skillsAgentTemplate(name, modelConfig string, withSkill bool) string {
+// fleet's shape: skills and tools), labelled as agentlab's — and, given a
+// fixture (nil is the control), one git skill pinned to its full commit,
+// selected by its directory within the repository, with the fixture's
+// credentialRef when it names a Secret.
+func skillsAgentTemplate(name, modelConfig string, fixture *SkillsFixture) string {
 	skills := ""
 	description := "Throwaway agent of `agentlab skills-test` (the control: the same template without the skill); deleted by the same run."
-	if withSkill {
+	if fixture != nil {
 		description = "Throwaway agent of `agentlab skills-test`: one git skill pinned to a full commit; deleted by the same run."
+		credential := ""
+		if fixture.CredentialSecret != "" {
+			credential = fmt.Sprintf(`          credentialRef:
+            name: %s
+            key: %s
+`, fixture.CredentialSecret, skillsCredentialKey)
+		}
 		skills = fmt.Sprintf(`  skills:
     - name: %s
       source:
         git:
           url: %s
           commit: %s
-        path: %s
-`, skillsTestSkill, skillsTestRepo, skillsTestCommit, skillsTestSkill)
+%s        path: %s
+`, fixture.name(), fixture.Repo, fixture.Commit, credential, fixture.Skill)
 	}
 	return fmt.Sprintf(`apiVersion: %s
 kind: AgentTemplate
@@ -331,7 +452,7 @@ func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestO
 
 	step("The control: the same template without the skill, up to %s", skillsControlTimeout)
 	control := "not booted"
-	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestControlAgent, opts.ModelConfig, false))); err != nil {
+	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestControlAgent, opts.ModelConfig, nil))); err != nil {
 		control = "could not be applied: " + err.Error()
 	} else if boot, err := waitGoldenBoot(skillsTestControlAgent, kagentHarness, skillsControlTimeout); err != nil {
 		control = "could not be read: " + err.Error()
@@ -344,8 +465,8 @@ func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestO
 	note("%s", control)
 
 	fmt.Println()
-	fmt.Printf("FAIL: AgentTemplate %s with the git skill %s (%s @ %.12s) %s on Harness %s (%s)\n",
-		skillsTestAgent, skillsTestSkill, skillsTestRepo, skillsTestCommit, verdict, kagentHarness, facts.summary())
+	fmt.Printf("FAIL: AgentTemplate %s with the git skill %s (%s @ %.12s%s) %s on Harness %s (%s)\n",
+		skillsTestAgent, opts.Fixture.name(), opts.Fixture.Repo, opts.Fixture.Commit, opts.Fixture.credentialNote(), verdict, kagentHarness, facts.summary())
 	fmt.Printf("FAIL: the control without the skill: %s\n", control)
 	return fmt.Errorf("the golden boot of a template with a git skill %s on Harness %s; the evidence above is the finding (docs/platform.md \"The skills proof (the golden boot)\")", verdict, kagentHarness)
 }

--- a/internal/lab/skillstest.go
+++ b/internal/lab/skillstest.go
@@ -269,17 +269,17 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	cleanup()
 	defer cleanup()
 
-	admission := harnessAdmissionLabels()
-	step("Applying AgentTemplate %s on Harness %s: skill %s from %s @ %.12s%s, tools from %s", skillsTestAgent, kagentHarness, fixture.name(), fixture.Repo, fixture.Commit, fixture.credentialNote(), componentMuster)
+	shape := readSkillsTemplateShape()
+	step("Applying AgentTemplate %s on Harness %s: skill %s from %s @ %.12s%s, %s", skillsTestAgent, kagentHarness, fixture.name(), fixture.Repo, fixture.Commit, fixture.credentialNote(), shape.toolsNote())
 	if fixture.CredentialSecret != "" {
 		if err := requireCredentialRefServed(); err != nil {
 			return err
 		}
 	}
-	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestAgent, opts.ModelConfig, &fixture, admission))); err != nil {
+	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestAgent, opts.ModelConfig, &fixture, shape))); err != nil {
 		return err
 	}
-	note("accepted by the apiserver (the CRD validates the full commit and the relative path); labelled %v as the Harness admits", admission)
+	note("accepted by the apiserver (the CRD validates the full commit and the relative path); labelled %v as the Harness admits", shape.admission)
 
 	step("Waiting up to %s for Ready on Harness %s — the golden boot: the actor starts, fetches the skill, serves readyz, is snapshotted", opts.ReadyTimeout, kagentHarness)
 	boot, err := waitGoldenBoot(skillsTestAgent, kagentHarness, opts.ReadyTimeout)
@@ -287,7 +287,7 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 		return err
 	}
 	if !boot.ready {
-		return skillsGoldenBootFailed(cfg, api, opts, boot, facts, admission)
+		return skillsGoldenBootFailed(cfg, api, opts, boot, facts, shape)
 	}
 	harness := boot.template.harness(kagentHarness)
 	note("Ready after %s: revision %.12s%s", boot.elapsed.Round(time.Second), harness.LatestSuccessfulRevision, warningsNote(harness.Warnings))
@@ -322,6 +322,34 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	return nil
 }
 
+// skillsTemplateShape is what the lab's platform dictates about the proof's
+// templates: the labels the Harness admits, and whether the shared muster
+// RemoteMCPServer exists to bind as the template's tools (the 3.x
+// connectivity chart renders one; the 4.x chart renders one per agent
+// instead, so there the proof's template carries no tools — the skill is
+// what it proves).
+type skillsTemplateShape struct {
+	admission   map[string]string
+	musterTools bool
+}
+
+// readSkillsTemplateShape reads the shape off the lab.
+func readSkillsTemplateShape() skillsTemplateShape {
+	shape := skillsTemplateShape{admission: harnessAdmissionLabels()}
+	if _, err := readKagentObject(remoteMCPServerResource, componentMuster); err == nil {
+		shape.musterTools = true
+	}
+	return shape
+}
+
+// toolsNote words the template's tools for the steps.
+func (s skillsTemplateShape) toolsNote() string {
+	if s.musterTools {
+		return "tools from " + componentMuster
+	}
+	return "no tools (the platform renders no shared " + componentMuster + " RemoteMCPServer; the skill is what the template carries)"
+}
+
 // harnessAdmissionLabels are the labels the platform Harness admits
 // (spec.allowedAgentTemplates.selector.matchLabels): the proof's templates
 // carry them, so the Harness picks them up whichever label the platform
@@ -341,15 +369,25 @@ func harnessAdmissionLabels() map[string]string {
 }
 
 // skillsAgentTemplate is the proof's AgentTemplate: the Go ADK Harness, the
-// ModelConfig, the terse prompt, the shared muster server as its tools (the
-// fleet's shape: skills and tools), labelled as agentlab's and as the
-// Harness admits — and, given a fixture (nil is the control), one git skill
-// pinned to its full commit, selected by its directory within the
-// repository, with the fixture's credentialRef when it names a Secret.
-func skillsAgentTemplate(name, modelConfig string, fixture *SkillsFixture, admission map[string]string) string {
+// ModelConfig, the terse prompt, the shared muster server as its tools where
+// the platform renders one (the fleet's shape: skills and tools), labelled
+// as agentlab's and as the Harness admits — and, given a fixture (nil is the
+// control), one git skill pinned to its full commit, selected by its
+// directory within the repository, with the fixture's credentialRef when it
+// names a Secret.
+func skillsAgentTemplate(name, modelConfig string, fixture *SkillsFixture, shape skillsTemplateShape) string {
 	labels := []string{managedByLabel + ": " + managedByAgentlabValue}
-	for _, key := range slices.Sorted(maps.Keys(admission)) {
-		labels = append(labels, key+": "+admission[key])
+	for _, key := range slices.Sorted(maps.Keys(shape.admission)) {
+		labels = append(labels, key+": "+shape.admission[key])
+	}
+	tools := ""
+	if shape.musterTools {
+		tools = fmt.Sprintf(`  tools:
+    - mcp:
+        server:
+          kind: %s
+          name: %s
+`, remoteMCPServerKind, componentMuster)
 	}
 	skills := ""
 	description := "Throwaway agent of `agentlab skills-test` (the control: the same template without the skill); deleted by the same run."
@@ -383,12 +421,7 @@ spec:
   modelConfig:
     name: %s
   systemPrompt: %q
-  tools:
-    - mcp:
-        server:
-          kind: %s
-          name: %s
-%s`, agentTemplateAPIVersion, name, kagentNamespace, strings.Join(labels, "\n    "), description, modelConfig, skillsTestSystemPrompt, remoteMCPServerKind, componentMuster, skills)
+%s%s`, agentTemplateAPIVersion, name, kagentNamespace, strings.Join(labels, "\n    "), description, modelConfig, skillsTestSystemPrompt, tools, skills)
 }
 
 // goldenBoot is how waiting on a template's golden boot ended: Ready on the
@@ -460,7 +493,7 @@ func terminalHarnessFailure(h *harnessStatus) (string, bool) {
 // skillsGoldenBootFailed is the negative outcome: the evidence, the control
 // boot, and the FAIL verdict that carries the versions — the finding for the
 // line's upstream issue.
-func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestOptions, boot goldenBoot, facts lineFacts, admission map[string]string) error {
+func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestOptions, boot goldenBoot, facts lineFacts, shape skillsTemplateShape) error {
 	harness := boot.template.harness(kagentHarness)
 	verdict := fmt.Sprintf("never became Ready within %s", opts.ReadyTimeout)
 	if boot.terminal {
@@ -475,7 +508,7 @@ func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestO
 
 	step("The control: the same template without the skill, up to %s", skillsControlTimeout)
 	control := "not booted"
-	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestControlAgent, opts.ModelConfig, nil, admission))); err != nil {
+	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestControlAgent, opts.ModelConfig, nil, shape))); err != nil {
 		control = "could not be applied: " + err.Error()
 	} else if boot, err := waitGoldenBoot(skillsTestControlAgent, kagentHarness, skillsControlTimeout); err != nil {
 		control = "could not be read: " + err.Error()

--- a/internal/lab/skillstest.go
+++ b/internal/lab/skillstest.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"regexp"
 	"slices"
@@ -268,16 +269,17 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	cleanup()
 	defer cleanup()
 
+	admission := harnessAdmissionLabels()
 	step("Applying AgentTemplate %s on Harness %s: skill %s from %s @ %.12s%s, tools from %s", skillsTestAgent, kagentHarness, fixture.name(), fixture.Repo, fixture.Commit, fixture.credentialNote(), componentMuster)
 	if fixture.CredentialSecret != "" {
 		if err := requireCredentialRefServed(); err != nil {
 			return err
 		}
 	}
-	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestAgent, opts.ModelConfig, &fixture))); err != nil {
+	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestAgent, opts.ModelConfig, &fixture, admission))); err != nil {
 		return err
 	}
-	note("accepted by the apiserver (the CRD validates the full commit and the relative path)")
+	note("accepted by the apiserver (the CRD validates the full commit and the relative path); labelled %v as the Harness admits", admission)
 
 	step("Waiting up to %s for Ready on Harness %s — the golden boot: the actor starts, fetches the skill, serves readyz, is snapshotted", opts.ReadyTimeout, kagentHarness)
 	boot, err := waitGoldenBoot(skillsTestAgent, kagentHarness, opts.ReadyTimeout)
@@ -285,7 +287,7 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 		return err
 	}
 	if !boot.ready {
-		return skillsGoldenBootFailed(cfg, api, opts, boot, facts)
+		return skillsGoldenBootFailed(cfg, api, opts, boot, facts, admission)
 	}
 	harness := boot.template.harness(kagentHarness)
 	note("Ready after %s: revision %.12s%s", boot.elapsed.Round(time.Second), harness.LatestSuccessfulRevision, warningsNote(harness.Warnings))
@@ -320,13 +322,35 @@ func SkillsTest(cfg *config.Config, email string, opts SkillsTestOptions) error 
 	return nil
 }
 
+// harnessAdmissionLabels are the labels the platform Harness admits
+// (spec.allowedAgentTemplates.selector.matchLabels): the proof's templates
+// carry them, so the Harness picks them up whichever label the platform
+// chose — kagent's default kagent.dev/harness: <name>, or the chart's own.
+// A Harness that cannot be read leaves kagent's default.
+func harnessAdmissionLabels() map[string]string {
+	fallback := map[string]string{harnessLabel: kagentHarness}
+	h, err := readKagentObject(harnessResource, kagentHarness)
+	if err != nil {
+		return fallback
+	}
+	labels, found, _ := unstructured.NestedStringMap(h.Object, "spec", "allowedAgentTemplates", "selector", "matchLabels")
+	if !found || len(labels) == 0 {
+		return fallback
+	}
+	return labels
+}
+
 // skillsAgentTemplate is the proof's AgentTemplate: the Go ADK Harness, the
 // ModelConfig, the terse prompt, the shared muster server as its tools (the
-// fleet's shape: skills and tools), labelled as agentlab's — and, given a
-// fixture (nil is the control), one git skill pinned to its full commit,
-// selected by its directory within the repository, with the fixture's
-// credentialRef when it names a Secret.
-func skillsAgentTemplate(name, modelConfig string, fixture *SkillsFixture) string {
+// fleet's shape: skills and tools), labelled as agentlab's and as the
+// Harness admits — and, given a fixture (nil is the control), one git skill
+// pinned to its full commit, selected by its directory within the
+// repository, with the fixture's credentialRef when it names a Secret.
+func skillsAgentTemplate(name, modelConfig string, fixture *SkillsFixture, admission map[string]string) string {
+	labels := []string{managedByLabel + ": " + managedByAgentlabValue}
+	for _, key := range slices.Sorted(maps.Keys(admission)) {
+		labels = append(labels, key+": "+admission[key])
+	}
 	skills := ""
 	description := "Throwaway agent of `agentlab skills-test` (the control: the same template without the skill); deleted by the same run."
 	if fixture != nil {
@@ -353,8 +377,7 @@ metadata:
   name: %s
   namespace: %s
   labels:
-    %s: agentlab
-    %s: %s
+    %s
 spec:
   description: %q
   modelConfig:
@@ -365,7 +388,7 @@ spec:
         server:
           kind: %s
           name: %s
-%s`, agentTemplateAPIVersion, name, kagentNamespace, managedByLabel, harnessLabel, kagentHarness, description, modelConfig, skillsTestSystemPrompt, remoteMCPServerKind, componentMuster, skills)
+%s`, agentTemplateAPIVersion, name, kagentNamespace, strings.Join(labels, "\n    "), description, modelConfig, skillsTestSystemPrompt, remoteMCPServerKind, componentMuster, skills)
 }
 
 // goldenBoot is how waiting on a template's golden boot ended: Ready on the
@@ -437,7 +460,7 @@ func terminalHarnessFailure(h *harnessStatus) (string, bool) {
 // skillsGoldenBootFailed is the negative outcome: the evidence, the control
 // boot, and the FAIL verdict that carries the versions — the finding for the
 // line's upstream issue.
-func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestOptions, boot goldenBoot, facts lineFacts) error {
+func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestOptions, boot goldenBoot, facts lineFacts, admission map[string]string) error {
 	harness := boot.template.harness(kagentHarness)
 	verdict := fmt.Sprintf("never became Ready within %s", opts.ReadyTimeout)
 	if boot.terminal {
@@ -452,7 +475,7 @@ func skillsGoldenBootFailed(cfg *config.Config, api *kagentAPI, opts SkillsTestO
 
 	step("The control: the same template without the skill, up to %s", skillsControlTimeout)
 	control := "not booted"
-	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestControlAgent, opts.ModelConfig, nil))); err != nil {
+	if _, err := applyManifests(context.Background(), []byte(skillsAgentTemplate(skillsTestControlAgent, opts.ModelConfig, nil, admission))); err != nil {
 		control = "could not be applied: " + err.Error()
 	} else if boot, err := waitGoldenBoot(skillsTestControlAgent, kagentHarness, skillsControlTimeout); err != nil {
 		control = "could not be read: " + err.Error()

--- a/internal/lab/skillstest_test.go
+++ b/internal/lab/skillstest_test.go
@@ -90,8 +90,15 @@ func TestSkillsAgentTemplate(t *testing.T) {
 }
 
 // kagentAdmission is kagent's default admission label, what the tests
-// render unless they test the Harness's own.
+// render unless they test the Harness's own; platformHarnessLabel is the
+// connectivity chart's; the fixture names below are the test's.
 var kagentAdmission = skillsTemplateShape{admission: map[string]string{harnessLabel: kagentHarness}, musterTools: true}
+
+const (
+	platformHarnessLabel = "agent-platform.giantswarm.io/harness"
+	exampleRepo          = "https://example.com/x"
+	gitAuthObject        = "skills-git-auth"
+)
 
 // TestSkillsAgentTemplateAdmissionLabels: the template carries the labels the
 // Harness admits — the platform's own label here — and not kagent's default
@@ -99,12 +106,12 @@ var kagentAdmission = skillsTemplateShape{admission: map[string]string{harnessLa
 func TestSkillsAgentTemplateAdmissionLabels(t *testing.T) {
 	fixture, _ := SkillsFixture{}.resolve()
 	var obj map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, skillsTemplateShape{admission: map[string]string{"agent-platform.giantswarm.io/harness": "kagent"}})), &obj); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, skillsTemplateShape{admission: map[string]string{platformHarnessLabel: kagentHarness}})), &obj); err != nil {
 		t.Fatal(err)
 	}
 	u := &unstructured.Unstructured{Object: obj}
 	labels := u.GetLabels()
-	if labels["agent-platform.giantswarm.io/harness"] != "kagent" || labels[managedByLabel] != managedByAgentlabValue {
+	if labels[platformHarnessLabel] != kagentHarness || labels[managedByLabel] != managedByAgentlabValue {
 		t.Errorf("labels = %v", labels)
 	}
 	if _, has := labels[harnessLabel]; has {
@@ -122,7 +129,7 @@ func TestSkillsAgentTemplateAdmissionLabels(t *testing.T) {
 func TestSkillsFixturePrivate(t *testing.T) {
 	fixture, err := SkillsFixture{
 		Repo: "https://github.com/acme/private-skills", Commit: strings.Repeat("c", 40), Skill: "skills/runbooks",
-		Question: "which flag renders a recipe?", Expect: "--render", CredentialSecret: "skills-git-auth",
+		Question: "which flag renders a recipe?", Expect: "--render", CredentialSecret: gitAuthObject,
 	}.resolve()
 	if err != nil {
 		t.Fatal(err)
@@ -146,9 +153,9 @@ func TestSkillsFixturePrivate(t *testing.T) {
 	url, _, _ := unstructured.NestedString(skill, "source", "git", "url")
 	commit, _, _ := unstructured.NestedString(skill, "source", "git", "commit")
 	path, _, _ := unstructured.NestedString(skill, "source", "path")
-	secret, _, _ := unstructured.NestedString(skill, "source", "git", "credentialRef", nameKey)
+	refName, _, _ := unstructured.NestedString(skill, "source", "git", "credentialRef", nameKey)
 	key, _, _ := unstructured.NestedString(skill, "source", "git", "credentialRef", "key")
-	if name != "runbooks" || url != fixture.Repo || commit != fixture.Commit || path != "skills/runbooks" || secret != "skills-git-auth" || key != skillsCredentialKey {
+	if name != "runbooks" || url != fixture.Repo || commit != fixture.Commit || path != "skills/runbooks" || refName != gitAuthObject || key != skillsCredentialKey {
 		t.Errorf("skill = %v", skill)
 	}
 
@@ -176,10 +183,10 @@ func TestSkillsFixtureResolve(t *testing.T) {
 		fixture SkillsFixture
 		want    string
 	}{
-		"missing fields": {SkillsFixture{Repo: "https://example.com/x"}, "missing: --skill-commit, --skill-path, --skill-question, --skill-expect"},
-		"short commit":   {SkillsFixture{Repo: "https://example.com/x", Commit: "abc123", Skill: "s", Question: "q", Expect: "e"}, "full 40- or 64-hex"},
+		"missing fields": {SkillsFixture{Repo: exampleRepo}, "missing: --skill-commit, --skill-path, --skill-question, --skill-expect"},
+		"short commit":   {SkillsFixture{Repo: exampleRepo, Commit: "abc123", Skill: "s", Question: "q", Expect: "e"}, "full 40- or 64-hex"},
 		"not a url":      {SkillsFixture{Repo: "git@example.com:x", Commit: full, Skill: "s", Question: "q", Expect: "e"}, "http(s) git URL"},
-		"bad path":       {SkillsFixture{Repo: "https://example.com/x", Commit: full, Skill: "../s", Question: "q", Expect: "e"}, "--skill-path"},
+		"bad path":       {SkillsFixture{Repo: exampleRepo, Commit: full, Skill: "../s", Question: "q", Expect: "e"}, "--skill-path"},
 		"secret on http": {SkillsFixture{Repo: "http://example.com/x", Commit: full, Skill: "s", Question: "q", Expect: "e", CredentialSecret: "t"}, "https://"},
 	}
 	for name, tc := range cases {
@@ -190,7 +197,7 @@ func TestSkillsFixtureResolve(t *testing.T) {
 			}
 		})
 	}
-	ok, err := SkillsFixture{Repo: "https://example.com/x", Commit: full, Skill: "/dir/skill/", Question: "q", Expect: "e"}.resolve()
+	ok, err := SkillsFixture{Repo: exampleRepo, Commit: full, Skill: "/dir/skill/", Question: "q", Expect: "e"}.resolve()
 	if err != nil || ok.Skill != "dir/skill" || ok.name() != "skill" {
 		t.Errorf("resolve() = %+v, %v", ok, err)
 	}

--- a/internal/lab/skillstest_test.go
+++ b/internal/lab/skillstest_test.go
@@ -46,13 +46,13 @@ func TestSkillsAgentTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	var obj map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture)), &obj); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, kagentAdmission)), &obj); err != nil {
 		t.Fatal(err)
 	}
 	u := &unstructured.Unstructured{Object: obj}
 	if u.GetAPIVersion() != agentTemplateAPIVersion || u.GetKind() != "AgentTemplate" || u.GetNamespace() != kagentNamespace ||
 		u.GetLabels()[harnessLabel] != kagentHarness || u.GetLabels()[managedByLabel] != managedByAgentlabValue {
-		t.Errorf("template head:\n%s", skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture))
+		t.Errorf("template head:\n%s", skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, kagentAdmission))
 	}
 	template, err := agentTemplateFrom(u)
 	if err != nil {
@@ -78,7 +78,7 @@ func TestSkillsAgentTemplate(t *testing.T) {
 	}
 
 	var control map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestControlAgent, defaultModelConfig, nil)), &control); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestControlAgent, defaultModelConfig, nil, kagentAdmission)), &control); err != nil {
 		t.Fatal(err)
 	}
 	if _, found, _ := unstructured.NestedSlice(control, "spec", "skills"); found {
@@ -86,6 +86,29 @@ func TestSkillsAgentTemplate(t *testing.T) {
 	}
 	if description, _, _ := unstructured.NestedString(control, "spec", "description"); !strings.Contains(description, "control") {
 		t.Errorf("the control's description does not say so: %q", description)
+	}
+}
+
+// kagentAdmission is kagent's default admission label, what the tests
+// render unless they test the Harness's own.
+var kagentAdmission = map[string]string{harnessLabel: kagentHarness}
+
+// TestSkillsAgentTemplateAdmissionLabels: the template carries the labels the
+// Harness admits — the platform's own label here — and not kagent's default
+// when the Harness does not select on it; agentlab's managed-by label stays.
+func TestSkillsAgentTemplateAdmissionLabels(t *testing.T) {
+	fixture, _ := SkillsFixture{}.resolve()
+	var obj map[string]any
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, map[string]string{"agent-platform.giantswarm.io/harness": "kagent"})), &obj); err != nil {
+		t.Fatal(err)
+	}
+	u := &unstructured.Unstructured{Object: obj}
+	labels := u.GetLabels()
+	if labels["agent-platform.giantswarm.io/harness"] != "kagent" || labels[managedByLabel] != managedByAgentlabValue {
+		t.Errorf("labels = %v", labels)
+	}
+	if _, has := labels[harnessLabel]; has {
+		t.Errorf("kagent's default label rendered although the Harness does not select on it: %v", labels)
 	}
 }
 
@@ -108,7 +131,7 @@ func TestSkillsFixturePrivate(t *testing.T) {
 		t.Errorf("prompt = %q", fixture.prompt())
 	}
 	var obj map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture)), &obj); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, kagentAdmission)), &obj); err != nil {
 		t.Fatal(err)
 	}
 	skills, _, _ := unstructured.NestedSlice(obj, "spec", "skills")
@@ -128,7 +151,7 @@ func TestSkillsFixturePrivate(t *testing.T) {
 
 	public, _ := SkillsFixture{}.resolve()
 	var anonymous map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &public)), &anonymous); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &public, kagentAdmission)), &anonymous); err != nil {
 		t.Fatal(err)
 	}
 	publicSkills, _, _ := unstructured.NestedSlice(anonymous, "spec", "skills")

--- a/internal/lab/skillstest_test.go
+++ b/internal/lab/skillstest_test.go
@@ -41,14 +41,18 @@ func bootTemplate(name, readyStatus, reason, message string) *unstructured.Unstr
 // pinned to the fixture's full commit and selected by its directory; the
 // control carries no skills at all.
 func TestSkillsAgentTemplate(t *testing.T) {
+	fixture, err := SkillsFixture{}.resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
 	var obj map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, true)), &obj); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture)), &obj); err != nil {
 		t.Fatal(err)
 	}
 	u := &unstructured.Unstructured{Object: obj}
 	if u.GetAPIVersion() != agentTemplateAPIVersion || u.GetKind() != "AgentTemplate" || u.GetNamespace() != kagentNamespace ||
 		u.GetLabels()[harnessLabel] != kagentHarness || u.GetLabels()[managedByLabel] != managedByAgentlabValue {
-		t.Errorf("template head:\n%s", skillsAgentTemplate(skillsTestAgent, defaultModelConfig, true))
+		t.Errorf("template head:\n%s", skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture))
 	}
 	template, err := agentTemplateFrom(u)
 	if err != nil {
@@ -74,7 +78,7 @@ func TestSkillsAgentTemplate(t *testing.T) {
 	}
 
 	var control map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestControlAgent, defaultModelConfig, false)), &control); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestControlAgent, defaultModelConfig, nil)), &control); err != nil {
 		t.Fatal(err)
 	}
 	if _, found, _ := unstructured.NestedSlice(control, "spec", "skills"); found {
@@ -82,6 +86,87 @@ func TestSkillsAgentTemplate(t *testing.T) {
 	}
 	if description, _, _ := unstructured.NestedString(control, "spec", "description"); !strings.Contains(description, "control") {
 		t.Errorf("the control's description does not say so: %q", description)
+	}
+}
+
+// TestSkillsFixturePrivate: a fixture of the caller's renders its repository,
+// commit and directory (the last element the skill's name) and, when it names
+// a Secret, the source's credentialRef on the token key — nothing else about
+// the template changes; the public fixture renders no credentialRef.
+func TestSkillsFixturePrivate(t *testing.T) {
+	fixture, err := SkillsFixture{
+		Repo: "https://github.com/acme/private-skills", Commit: strings.Repeat("c", 40), Skill: "skills/runbooks",
+		Question: "which flag renders a recipe?", Expect: "--render", CredentialSecret: "skills-git-auth",
+	}.resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fixture.name() != "runbooks" {
+		t.Errorf("name = %q", fixture.name())
+	}
+	if !strings.Contains(fixture.prompt(), "named runbooks") || !strings.Contains(fixture.prompt(), "which flag renders a recipe?") {
+		t.Errorf("prompt = %q", fixture.prompt())
+	}
+	var obj map[string]any
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture)), &obj); err != nil {
+		t.Fatal(err)
+	}
+	skills, _, _ := unstructured.NestedSlice(obj, "spec", "skills")
+	if len(skills) != 1 {
+		t.Fatalf("skills = %v", skills)
+	}
+	skill, _ := skills[0].(map[string]any)
+	name, _, _ := unstructured.NestedString(skill, nameKey)
+	url, _, _ := unstructured.NestedString(skill, "source", "git", "url")
+	commit, _, _ := unstructured.NestedString(skill, "source", "git", "commit")
+	path, _, _ := unstructured.NestedString(skill, "source", "path")
+	secret, _, _ := unstructured.NestedString(skill, "source", "git", "credentialRef", nameKey)
+	key, _, _ := unstructured.NestedString(skill, "source", "git", "credentialRef", "key")
+	if name != "runbooks" || url != fixture.Repo || commit != fixture.Commit || path != "skills/runbooks" || secret != "skills-git-auth" || key != skillsCredentialKey {
+		t.Errorf("skill = %v", skill)
+	}
+
+	public, _ := SkillsFixture{}.resolve()
+	var anonymous map[string]any
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &public)), &anonymous); err != nil {
+		t.Fatal(err)
+	}
+	publicSkills, _, _ := unstructured.NestedSlice(anonymous, "spec", "skills")
+	if _, found, _ := unstructured.NestedMap(publicSkills[0].(map[string]any), "source", "git", "credentialRef"); found {
+		t.Error("the public fixture renders a credentialRef")
+	}
+}
+
+// TestSkillsFixtureResolve: the zero value is the public fixture; a fixture
+// of the caller's needs every field, a full commit and an http(s) URL, and a
+// Secret only on https.
+func TestSkillsFixtureResolve(t *testing.T) {
+	public, err := SkillsFixture{}.resolve()
+	if err != nil || public.Repo != skillsTestRepo || public.Commit != skillsTestCommit || public.Skill != skillsTestSkill || public.Question != skillsTestQuestion || public.Expect != skillsTestFact {
+		t.Errorf("public fixture = %+v, %v", public, err)
+	}
+	full := strings.Repeat("a", 40)
+	cases := map[string]struct {
+		fixture SkillsFixture
+		want    string
+	}{
+		"missing fields": {SkillsFixture{Repo: "https://example.com/x"}, "missing: --skill-commit, --skill-path, --skill-question, --skill-expect"},
+		"short commit":   {SkillsFixture{Repo: "https://example.com/x", Commit: "abc123", Skill: "s", Question: "q", Expect: "e"}, "full 40- or 64-hex"},
+		"not a url":      {SkillsFixture{Repo: "git@example.com:x", Commit: full, Skill: "s", Question: "q", Expect: "e"}, "http(s) git URL"},
+		"bad path":       {SkillsFixture{Repo: "https://example.com/x", Commit: full, Skill: "../s", Question: "q", Expect: "e"}, "--skill-path"},
+		"secret on http": {SkillsFixture{Repo: "http://example.com/x", Commit: full, Skill: "s", Question: "q", Expect: "e", CredentialSecret: "t"}, "https://"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := tc.fixture.resolve()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("resolve() = %v, want %q", err, tc.want)
+			}
+		})
+	}
+	ok, err := SkillsFixture{Repo: "https://example.com/x", Commit: full, Skill: "/dir/skill/", Question: "q", Expect: "e"}.resolve()
+	if err != nil || ok.Skill != "dir/skill" || ok.name() != "skill" {
+		t.Errorf("resolve() = %+v, %v", ok, err)
 	}
 }
 

--- a/internal/lab/skillstest_test.go
+++ b/internal/lab/skillstest_test.go
@@ -91,7 +91,7 @@ func TestSkillsAgentTemplate(t *testing.T) {
 
 // kagentAdmission is kagent's default admission label, what the tests
 // render unless they test the Harness's own.
-var kagentAdmission = map[string]string{harnessLabel: kagentHarness}
+var kagentAdmission = skillsTemplateShape{admission: map[string]string{harnessLabel: kagentHarness}, musterTools: true}
 
 // TestSkillsAgentTemplateAdmissionLabels: the template carries the labels the
 // Harness admits — the platform's own label here — and not kagent's default
@@ -99,7 +99,7 @@ var kagentAdmission = map[string]string{harnessLabel: kagentHarness}
 func TestSkillsAgentTemplateAdmissionLabels(t *testing.T) {
 	fixture, _ := SkillsFixture{}.resolve()
 	var obj map[string]any
-	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, map[string]string{"agent-platform.giantswarm.io/harness": "kagent"})), &obj); err != nil {
+	if err := yaml.Unmarshal([]byte(skillsAgentTemplate(skillsTestAgent, defaultModelConfig, &fixture, skillsTemplateShape{admission: map[string]string{"agent-platform.giantswarm.io/harness": "kagent"}})), &obj); err != nil {
 		t.Fatal(err)
 	}
 	u := &unstructured.Unstructured{Object: obj}
@@ -109,6 +109,9 @@ func TestSkillsAgentTemplateAdmissionLabels(t *testing.T) {
 	}
 	if _, has := labels[harnessLabel]; has {
 		t.Errorf("kagent's default label rendered although the Harness does not select on it: %v", labels)
+	}
+	if _, found, _ := unstructured.NestedSlice(obj, "spec", "tools"); found {
+		t.Errorf("tools rendered although the platform has no shared muster server: %v", obj["spec"])
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -741,6 +741,12 @@ func skillsTestCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&opts.ModelConfig, "model-config", "", "the kagent ModelConfig the throwaway agent runs on (default: default-model-config, the Anthropic one the lab renders from $ANTHROPIC_API_KEY)")
 	cmd.Flags().DurationVar(&opts.ReadyTimeout, "ready-timeout", lab.SkillsTestReadyTimeout, "how long the golden boot may take to reach Ready on the Harness before the proof reports the failure")
+	cmd.Flags().StringVar(&opts.Fixture.Repo, "skill-repo", "", "another fixture: the git repository of the skill to boot (an http(s) URL), with --skill-commit, --skill-path, --skill-question and --skill-expect (default: the public fixture, agent-self-awareness of giantswarm/agent-skills)")
+	cmd.Flags().StringVar(&opts.Fixture.Commit, "skill-commit", "", "the full 40- or 64-hex commit id the skill is pinned to")
+	cmd.Flags().StringVar(&opts.Fixture.Skill, "skill-path", "", "the skill's directory within the repository; its last element is the skill's name")
+	cmd.Flags().StringVar(&opts.Fixture.Question, "skill-question", "", "the question the turn asks the agent to answer from the skill's text only")
+	cmd.Flags().StringVar(&opts.Fixture.Expect, "skill-expect", "", "the answer only the skill's text has; the turn passes when the reply names the skill and carries it (case-insensitive)")
+	cmd.Flags().StringVar(&opts.Fixture.CredentialSecret, "skill-secret", "", "a private repository: the Secret in the kagent namespace whose `token` key holds a read token for the repository's host, referenced as skills[].source.git.credentialRef; the Secret is yours to create, the proof never reads it")
 	return cmd
 }
 


### PR DESCRIPTION
## What

`agentlab skills-test` grows a fixture of the caller's next to the fixed public one:

- `--skill-repo`, `--skill-commit`, `--skill-path` (the skill's directory within the repository; its last element is the skill's name), `--skill-question`, `--skill-expect` (the answer only the skill's text has) — all five together replace the public fixture; the zero value keeps today's run unchanged.
- `--skill-secret` — a private repository: the Secret in the kagent namespace whose `token` key holds a read token for the repository's host, rendered as the source's `skills[].source.git.credentialRef {name, key: token}`. The Secret is the operator's to create; the proof never reads it. Against a kagent whose served `AgentTemplate` CRD lacks `credentialRef` the proof refuses to run the private fixture (that kagent would prune the field and fetch anonymously, failing the boot for the wrong reason).
- The boot-failure evidence also greps the worker log for git's authentication words (`authentication`, `401`, `credential`).

`docs/platform.md` describes the flags in the skills-proof section.

## Why

The kagent API v2 line gains a per-source credential for private git skill sources (giantswarm/kagent-upstream#13; the spike giantswarm/giantswarm#37321). Its evidence is this proof on a private fixture: the skill lands and answers a turn, a missing Secret shows as `ResolvedRefs=False`, a wrong token as a failed golden boot with git's error in the worker log. The same flags let the fleet cut-overs prove any agent's skill repository.

## Verification

- `go build ./...`, `go vet`, gofmt clean; `go test ./internal/lab/ -run 'Skills|Fixture|TerminalHarness'` green (the fixture's template renders `credentialRef` on the token key and nothing else changes; the public fixture renders none; `resolve()` rejects a partial fixture, a short commit, a non-http(s) URL, a `..` path and a Secret on an http URL).
- Lab: the default run (public fixture) and the private fixture with `--skill-secret` on the kagent line's build that carries `credentialRef`, plus the two failure modes — recorded on giantswarm/giantswarm#37321 before this merges.