### PR TITLE
feat(dev-images): a harness target by digest and a controller target that follows the line — the Go ADK build through a lab registry, the kagent controller's image name from the render

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -95,7 +95,8 @@ internal/lab/                    everything operational:
   oidc.go login.go browser.go      the lab's Dex clients: password grant, authorization-code flow
   test.go                          RBAC assertions for every configured user
   platform.go platformtest.go      agent platform install + the headless MCP proof
-  postrenderers.go                 the lab's per-component postRenderers patches (hostNetwork, sidecar, nodePort, dev images)
+  postrenderers.go                 the lab's per-component postRenderers patches (hostNetwork, sidecar, nodePort, dev-image overrides)
+  devimages.go                     the dev-image swap: image names resolved from the component renders, the lab registry + the digest-pinned Harness image
   fluxreleases.go                  image preload from the chart's rendered OCIRepositories/HelmReleases, each at the version Flux would pull (semverFilter included)
   helm.go restclient.go            the embedded Helm 4 (upgrade-or-install with the kstatus wait, offline renders, probes, uninstalls); the lab kubeconfig as a client-go REST client getter
   resources.go                     docker CPU/memory: the requests table and the floors `up` enforces

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -78,36 +78,100 @@ the boot says which chart it installed. The directory is read, never written.
 ## Dev images
 
 To run a component from a build of your own, build the image, and name it
-under `platform.devImages` keyed by the chart's component name (`muster`,
-`backstage`, `kagent` — the controller —, `mcp-kubernetes`, `model-manager`,
-`agent-manager`):
+under `platform.devImages`. The targets are the chart's component names for
+the Deployments the lab can swap — `muster`, `backstage`, `kagent` (the
+controller), `mcp-kubernetes`, `model-manager`, `agent-manager` — and
+`harness`, the platform Harness's runtime image (the Go ADK every agent runs
+on under kagent API v2):
 
 ```yaml
 platform:
   devImages:
     muster: muster:dev-1a2b3c
     backstage: backstage-dev:my-feature-4d5e6f
+    kagent: kagent-controller:dev-7e8f9a      # the line's controller, built from go/ of giantswarm/kagent-upstream
+    harness: golang-adk:dev-7e8f9a            # the Go ADK, same checkout, BUILD_PACKAGE=adk/cmd/main.go
 ```
+
+Either way the swap is part of the release: `agentlab platform` renders it
+into the values it installs, so the same plain `helm upgrade` applies it, and
+removing the entry restores the chart's image on the next run. Use a
+distinctive tag per build — kind's containerd keeps running the old bits
+under a reused tag, and a Harness digest that did not change recompiles
+nothing.
+
+### Deployment targets
 
 `agentlab platform` side-loads the image from the host docker cache into the
 node, checks the node lists it before anything installs (a missing image
 fails right there with its fix, instead of five minutes later as an
 `ImagePullBackOff`, a helm-controller timeout and a rollback to the chart's
 image), and renders it into that component's `postRenderers` as a Kustomize
-image override with `imagePullPolicy: IfNotPresent`, so the swap is part of
-the release: the same plain `helm upgrade` applies it, `kubectl get deploy -o
-jsonpath` shows the new image, and removing the entry restores the chart's
-image on the next run. Use a distinctive tag per build — kind's containerd
-keeps running the old bits under a reused tag. And make it a build of its
-own, not a re-tag of a registry image the kubelet has pulled (a chart that
-pulls `Always`, like Backstage's, makes the kubelet pull): since Kubernetes
-1.33 the kubelet remembers which image IDs it pulled and re-pulls a pod's ref
-that maps to one of them (`KubeletEnsureSecretPulledImages`), so such a
-re-tag ends in `ImagePullBackOff` against Docker Hub while a real build — a
-new image ID, side-loaded, never pulled by the kubelet — is used as is. (A `kubectl patch` on the
-Deployment still works for a quick look, but only until helm-controller's
-next release of that component overwrites it — the values are the durable
-path.)
+image override with `imagePullPolicy: IfNotPresent`; `kubectl get deploy -o
+jsonpath` shows the new image. Make it a build of its own, not a re-tag of a
+registry image the kubelet has pulled (a chart that pulls `Always`, like
+Backstage's, makes the kubelet pull): since Kubernetes 1.33 the kubelet
+remembers which image IDs it pulled and re-pulls a pod's ref that maps to one
+of them (`KubeletEnsureSecretPulledImages`), so such a re-tag ends in
+`ImagePullBackOff` against Docker Hub while a real build — a new image ID,
+side-loaded, never pulled by the kubelet — is used as is. (A `kubectl patch`
+on the Deployment still works for a quick look, but only until
+helm-controller's next release of that component overwrites it — the values
+are the durable path.)
+
+The image name the override replaces is read off the component chart's
+render, the one the boot renders anyway to side-load the platform images —
+not from a table, because it differs between lines: the `kagent` target
+replaces `gsoci.azurecr.io/giantswarm/kagent-controller` under the 3.x meta
+chart (the wrapper chart) and `ghcr.io/giantswarm/kagent/controller` under
+4.x (the kagent line's own chart), whatever Deployment `kagent-controller`'s
+`controller` container names. A Kustomize image override whose name is in no
+rendered object matches nothing, and kustomize drops it without a word — so
+a target whose chart rendered without the Deployment and container the lab
+patches is **refused before the install**, naming both (`platform.devImages.kagent:
+the kagent chart's render has no Deployment kagent-controller with a container
+controller …`); a chart that did not render at all (the preload reports why)
+falls back to the table's name with a note that it is unverified.
+
+### The `harness` target
+
+Under kagent API v2 an agent runs on the platform Harness's workload image,
+not on a Deployment the lab could patch: the connectivity chart renders the
+image **by digest** into the `Harness` object `kagent` (the CRD accepts no
+tag), and Substrate's atelet fetches it from a registry into its own layer
+cache — the actors' overlay lowerdirs — never through the node's containerd,
+so a side-load is invisible to it. The lab therefore runs a **registry**
+for this target: a `registry` container named `<clusterName>-registry` on
+the kind docker network, published on the host's loopback
+(`platform.devRegistryPort`, default 5001, kind's documented local-registry
+port; created on demand, removed by `agentlab down`). `agentlab platform`
+tags the build into it (`localhost:<port>/<path of your ref>:<tag>`), pushes,
+reads the manifest digest the registry computed, and forwards
+`kagent.harness.image: localhost:<port>/<path>@sha256:<digest>` through the
+meta chart to the connectivity chart. atelet's side of the pattern,
+`--localhost-registry-replacement=<clusterName>-registry:5000` (a `localhost`
+registry in an image ref is rewritten to that endpoint and pulled over plain
+HTTP), is part of the lab shape whenever the agents are on — through the
+meta chart's `substrate.atelet.extraArgs`, forwarded to its substrate
+component — not only while a dev image is configured: the flag is inert for every other
+ref, and having it in place before a swap means the Harness's new digest
+(the connectivity release) can never race ahead of the atelet roll (the
+substrate release) that would carry it. The boot then asserts the Harness
+pins the dev digest, and — because a **digest-pinned Harness recompiles
+every template it admits** (a new golden snapshot per revision) — lists the
+admitted templates as they come back Ready on it
+(`Harness kagent runs localhost:5001/golang-adk@sha256:…; 1 admitted templates
+recompiled on it: my-agent 88c11e… -> ebfce6…`). Removing the entry restores
+the chart's digest on the next run — again one `helm upgrade`, again a
+recompile. A `platform.valuesFiles` overlay that sets `kagent.harness.image`
+itself (the way a lab pins a published build) or replaces
+`substrate.atelet.extraArgs` (lists replace in a Helm merge) is refused while
+the target is configured.
+
+Because atelet keys its cache by digest, the kubelet re-pull trap above does
+not apply here, and a pushed image is pulled once per node. The mechanism
+needs the platform Harness, so the target is for the 4.x meta chart with
+the agents on; the 3.x line has no Harness.
 
 muster runs with `hostNetwork`, so it binds `:8090` on the node, and the
 rendered kind config publishes that onto the Mac (host port `platform.musterPort`,

--- a/internal/config/chart_test.go
+++ b/internal/config/chart_test.go
@@ -81,6 +81,30 @@ func TestChartSourceValidation(t *testing.T) {
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("devImages for muster, backstage, kagent: %v", err)
 	}
+	// The harness target is the platform Harness's image: it comes with the
+	// agents, and the registry that serves it has a host port of its own.
+	cfg.Platform.DevImages = map[string]string{DevImageHarness: "golang-adk:dev-139"}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("devImages.harness with agents on: %v", err)
+	}
+	if cfg.Platform.DevRegistryPort != DefaultDevRegistryPort {
+		t.Errorf("default devRegistryPort = %d, want %d", cfg.Platform.DevRegistryPort, DefaultDevRegistryPort)
+	}
+	cfg.Platform.DevRegistryPort = 0
+	cfg.Normalize()
+	if cfg.Platform.DevRegistryPort != DefaultDevRegistryPort {
+		t.Errorf("Normalize left devRegistryPort %d, want the default", cfg.Platform.DevRegistryPort)
+	}
+	cfg.Platform.DevRegistryPort = 70000
+	if err := cfg.Validate(); err == nil {
+		t.Error("devRegistryPort out of range: want an error")
+	}
+	cfg.Platform.DevRegistryPort = DefaultDevRegistryPort
+	cfg.Platform.Agents = false
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "platform.agents") {
+		t.Errorf("devImages.harness without agents: want the error naming platform.agents, got %v", err)
+	}
+	cfg.Platform.Agents = true
 
 	cfg.Platform.ValuesFiles = []string{filepath.Join(t.TempDir(), "missing.yaml")}
 	if err := cfg.Validate(); err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,10 +99,23 @@ const DefaultChartVersion = "4.7.11"
 // ChartRepository is where the agent-platform chart releases live.
 const ChartRepository = "oci://gsoci.azurecr.io/charts/giantswarm/agent-platform"
 
-// DevImageComponents are the components whose image platform.devImages can
-// swap: the agent-platform chart's component names (its `components.<name>`
-// entries) for the workloads the lab's dev loops build from a checkout.
-var DevImageComponents = []string{"muster", "backstage", "kagent", "mcp-kubernetes", "model-manager", "agent-manager"}
+// DevImageComponents are the targets platform.devImages can swap: the
+// agent-platform chart's component names (its `components.<name>` entries)
+// for the Deployments the lab's dev loops build from a checkout, plus
+// DevImageHarness for the platform Harness's runtime image.
+var DevImageComponents = []string{"muster", "backstage", "kagent", "mcp-kubernetes", "model-manager", "agent-manager", DevImageHarness}
+
+// DevImageHarness is the devImages key of the platform Harness's workload
+// image — the Go ADK runtime every agent runs on under kagent API v2. Not a
+// Deployment: the connectivity chart renders the image by digest into the
+// `Harness` object, and Substrate's atelet pulls it from a registry into its
+// own layer cache, so the lab pushes the local build to its registry
+// (DevRegistryPort) and forwards the digest through kagent.harness.image.
+const DevImageHarness = "harness"
+
+// DefaultDevRegistryPort is the host port of the lab registry when
+// agentlab.yaml sets none: kind's documented local-registry port.
+const DefaultDevRegistryPort = 5001
 
 type User struct {
 	Email        string   `yaml:"email"`
@@ -187,14 +200,27 @@ type Platform struct {
 	// (or the key is dropped). Meaningless without chartBranch.
 	ChartPinned bool `yaml:"chartPinned,omitempty"`
 	// DevImages swaps a component's image for a build of your own (the lab's
-	// dev-image loop): component name -> image ref (`muster: muster:dev-1a2b`).
-	// `agentlab platform` side-loads the ref from the host docker cache and
-	// renders it into the component's HelmRelease as a kustomize image
-	// override (postRenderers) with imagePullPolicy IfNotPresent, so the swap
-	// is part of the release — a plain `helm upgrade` applies it, and removing
-	// the entry restores the chart's image on the next run. Keys are the
-	// DevImageComponents.
+	// dev-image loop): target -> image ref (`muster: muster:dev-1a2b`). Keys
+	// are the DevImageComponents. For a Deployment target `agentlab platform`
+	// side-loads the ref from the host docker cache, resolves the image name
+	// it replaces from the component chart's render (the kagent controller is
+	// `ghcr.io/giantswarm/kagent/controller` on the 4.x line and
+	// `gsoci.azurecr.io/giantswarm/kagent-controller` on 3.x — a target that
+	// matches nothing in the render is an error before the install, never a
+	// silently dropped override) and renders it into the component's
+	// HelmRelease as a kustomize image override (postRenderers) with
+	// imagePullPolicy IfNotPresent. For the `harness` target it pushes the
+	// build to the lab registry and forwards the digest as
+	// kagent.harness.image, so the platform Harness runs it and recompiles
+	// every admitted template. Either way the swap is part of the release — a
+	// plain `helm upgrade` applies it, and removing the entry restores the
+	// chart's image (or digest) on the next run.
 	DevImages map[string]string `yaml:"devImages,omitempty"`
+	// DevRegistryPort is the host port (127.0.0.1) of the lab registry that
+	// serves the `harness` dev image: a `registry` container on the kind
+	// docker network, created on demand by `agentlab platform` and removed by
+	// `agentlab down`. Unset means DefaultDevRegistryPort.
+	DevRegistryPort int `yaml:"devRegistryPort,omitempty"`
 	// ValuesFiles are extra Helm values files merged over the lab's rendered
 	// values before the meta chart install, in order, with `helm -f`
 	// semantics (maps merge, lists replace, the later file wins): a lab that
@@ -466,6 +492,9 @@ func Default() *Config {
 			Domain:        "127.0.0.1.nip.io",
 			GatewayPort:   443,
 			ChartVersion:  DefaultChartVersion,
+			// The lab registry behind the `harness` dev image; a container
+			// on the kind network, so no node port mapping is involved.
+			DevRegistryPort: DefaultDevRegistryPort,
 		},
 		Backstage: Backstage{
 			Enabled: true,
@@ -640,6 +669,9 @@ func (c *Config) Normalize() {
 	if len(c.Platform.DevImages) == 0 {
 		c.Platform.DevImages = nil
 	}
+	if c.Platform.DevRegistryPort == 0 {
+		c.Platform.DevRegistryPort = DefaultDevRegistryPort
+	}
 	if len(c.Platform.ValuesFiles) == 0 {
 		c.Platform.ValuesFiles = nil
 	}
@@ -804,10 +836,18 @@ func (c *Config) Validate() error {
 	}
 	for component, ref := range c.Platform.DevImages {
 		if !slices.Contains(DevImageComponents, component) {
-			return fmt.Errorf("platform.devImages: unknown component %q (one of %s)", component, strings.Join(DevImageComponents, ", "))
+			return fmt.Errorf("platform.devImages: unknown target %q (one of %s)", component, strings.Join(DevImageComponents, ", "))
 		}
 		if err := ValidateImageRef(ref); err != nil {
 			return fmt.Errorf("platform.devImages.%s %q: %w", component, ref, err)
+		}
+	}
+	if _, ok := c.Platform.DevImages[DevImageHarness]; ok && !c.Platform.Agents {
+		return fmt.Errorf("platform.devImages.%s: the platform Harness comes with the agents (platform.agents: true)", DevImageHarness)
+	}
+	if c.Platform.DevRegistryPort != 0 {
+		if err := ValidatePort(strconv.Itoa(c.Platform.DevRegistryPort)); err != nil {
+			return fmt.Errorf("platform.devRegistryPort: %w", err)
 		}
 	}
 	for _, path := range c.Platform.ValuesFiles {

--- a/internal/lab/certs.go
+++ b/internal/lab/certs.go
@@ -52,7 +52,7 @@ const (
 // dexSANNames are the DNS names of the Dex server cert: the issuer name
 // (localhost — see docs/identity.md on why not 127.0.0.1) plus the in-cluster
 // service names. Also the fixed half of the CA's name constraints.
-var dexSANNames = []string{"localhost", componentDex, "dex.dex.svc", "dex.dex.svc.cluster.local"}
+var dexSANNames = []string{localhostName, componentDex, "dex.dex.svc", "dex.dex.svc.cluster.local"}
 
 // permittedDNSNames is the CA's DNS name-constraint allowlist: the platform
 // domain plus the fixed lab names. Everything a lab leaf will ever carry,

--- a/internal/lab/devimages.go
+++ b/internal/lab/devimages.go
@@ -1,0 +1,600 @@
+package lab
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// The dev-image swap (platform.devImages) as one `agentlab platform` run
+// applies it. Two mechanisms, one values change each:
+//
+//   - A DEPLOYMENT target (muster, backstage, the kagent controller, the MCP
+//     servers) is side-loaded into the node and rendered as a kustomize image
+//     override on that component's HelmRelease (postrenderers.go). The name
+//     the override replaces is read off the component chart's render — the
+//     same render the preload scrapes its images from — because it differs
+//     between lines: the kagent controller is
+//     gsoci.azurecr.io/giantswarm/kagent-controller in the 3.x wrapper chart
+//     and ghcr.io/giantswarm/kagent/controller on the kagent line. An
+//     override whose name is in no rendered Deployment matches nothing, and
+//     kustomize drops it without a word; the swap refuses to install such an
+//     override and names the Deployment it looked for.
+//
+//   - The HARNESS target is the platform Harness's workload image, the Go ADK
+//     runtime every agent runs on under kagent API v2. Nothing on the node's
+//     containerd pulls it: the connectivity chart renders it BY DIGEST into
+//     the `Harness` object (the CRD accepts no tag), and Substrate's atelet
+//     fetches it from a registry into its own layer cache (the actors'
+//     overlay lowerdirs) — a side-load is invisible to it. So the lab runs a
+//     registry: a `registry` container on the kind docker network, published
+//     on the host's loopback (platform.devRegistryPort), the pattern kind
+//     documents for local registries and the one atelet's
+//     --localhost-registry-replacement exists for. The build is pushed there,
+//     the Harness pins `localhost:<port>/<repo>@sha256:<digest>` (the digest
+//     the registry computed for the pushed manifest), and atelet rewrites the
+//     localhost registry to the container's endpoint on the kind network,
+//     plain HTTP. The digest reaches the Harness through the connectivity
+//     values (kagent.harness.image, the values template), and the atelet flag
+//     through the substrate values — the latter with the agents rather than
+//     with the target, because it is inert for every other ref and the
+//     Harness (connectivity's object) and atelet (substrate's) reconcile
+//     independently: a flag that only arrived with the swap could lose the
+//     race to the Harness's new digest and fail the first golden boot. Both
+//     are part of the release, so a plain `helm upgrade` applies them and
+//     removing the entry restores the chart's digest on the next run. A
+//     changed Harness image recompiles every template the Harness admits (a
+//     new golden snapshot per revision); the boot reports which and waits
+//     for them.
+
+// devRegistryImage is the registry the lab runs for the `harness` dev image:
+// the CNCF Distribution registry, Docker Hub's official image, pinned.
+const devRegistryImage = "registry:3.0.0"
+
+// devRegistryContainerPort is the port the registry listens on inside its
+// container; the kind-network endpoint atelet dials.
+const devRegistryContainerPort = 5000
+
+// devRegistryWaitAttempts bounds the wait for a freshly created registry to
+// answer /v2/ (one second apart).
+const devRegistryWaitAttempts = 30
+
+// platformHarness is the one Harness the connectivity chart renders — the Go
+// ADK runtime, named `kagent` — whose image the `harness` target replaces.
+const platformHarness = "kagent"
+
+// harnessRecompileTimeout bounds the wait for the admitted templates to
+// recompile on the new Harness image: a golden boot per template on a worker
+// of the pool, first pulls included.
+const harnessRecompileTimeout = 5 * time.Minute
+
+// devImages is the swap of one run: what the values need that the config
+// alone cannot say.
+type devImages struct {
+	// names is the chart image name each configured Deployment target
+	// replaces, from the component render.
+	names map[string]string
+	// harness is the `harness` dev image as the platform Harness pins it —
+	// the lab registry's ref by digest; "" without the target.
+	harness string
+}
+
+// prepareDevImages resolves and stages the configured dev images before the
+// install: the Deployment targets' image names from the component renders
+// (refusing an override that matches nothing), their side-load into the node
+// with the node's own image list as the check, and the `harness` image pushed
+// to the lab registry and pinned by digest. renders is the component renders
+// keyed by release name (platformImages).
+func prepareDevImages(cfg *config.Config, renders map[string]string) (*devImages, error) {
+	names, err := resolveDevImageNames(cfg, renders)
+	if err != nil {
+		return nil, err
+	}
+	dev := &devImages{names: names}
+	// The Deployment targets are builds of this host: never pullable, always
+	// side-loaded, so their pods find them under imagePullPolicy IfNotPresent
+	// — which is why each ref is then verified in the node's own image list
+	// before the install (ensureNodeImages): a missing one would surface
+	// five minutes later as an ImagePullBackOff, helm-controller's upgrade
+	// timeout and a rollback to the chart's image.
+	if refs := devImageRefs(cfg); len(refs) > 0 {
+		if res := sideloadImages(cfg, hostPullImages(refs)); res.n > 0 {
+			note("side-loaded %d dev images (%s)", res.n, res.d)
+		}
+		if err := ensureNodeImages(cfg, refs); err != nil {
+			return nil, err
+		}
+	}
+	if ref := harnessDevImage(cfg); ref != "" {
+		step("Pushing the harness dev image %s to the lab registry", ref)
+		if err := ensureDevRegistry(cfg); err != nil {
+			return nil, err
+		}
+		pinned, err := pushDevImage(cfg, ref)
+		if err != nil {
+			return nil, err
+		}
+		dev.harness = pinned
+		note("the platform Harness %s pins %s (atelet reaches the registry as %s)", platformHarness, pinned, devRegistryEndpoint(cfg))
+	}
+	return dev, nil
+}
+
+// templateData is the values template's mutator for this swap: the
+// postRenderers with the resolved names, and the Harness pin.
+func (d *devImages) templateData(cfg *config.Config) (func(*tmplData), error) {
+	postRenderers, err := componentPostRenderers(cfg, d.names)
+	if err != nil {
+		return nil, err
+	}
+	return func(t *tmplData) {
+		t.PostRenderers = postRenderers
+		t.HarnessDevImage = d.harness
+	}, nil
+}
+
+// registryFlag is atelet's flag for the lab registry as the substrate values
+// carry it.
+func registryFlag(cfg *config.Config) string {
+	return "--localhost-registry-replacement=" + devRegistryEndpoint(cfg)
+}
+
+// checkValues asserts the merged values still carry the swap's two keys: a
+// platform.valuesFiles overlay that sets kagent.harness.image itself (the
+// way a lab pins a published build) wins the merge and the swap would be a
+// silent no-op; one that sets substrate.atelet.extraArgs replaces the list
+// (Helm merges maps, not lists) and atelet could not reach the registry.
+func (d *devImages) checkValues(cfg *config.Config, values map[string]any) error {
+	if d.harness == "" {
+		return nil
+	}
+	if got := nestedString(values, "kagent", "harness", "image"); got != d.harness {
+		return fmt.Errorf("platform.devImages.%s: the merged values pin kagent.harness.image to %q, not to the dev image %s — a platform.valuesFiles overlay sets it; drop that key from the overlay while the dev image is configured", config.DevImageHarness, got, d.harness)
+	}
+	if args, _ := nestedValue(values, "substrate", "atelet", "extraArgs").([]any); !slices.Contains(args, any(registryFlag(cfg))) {
+		return fmt.Errorf("platform.devImages.%s: the merged values' substrate.atelet.extraArgs %v lack %s — a platform.valuesFiles overlay replaces the list; add the flag to the overlay's list or drop the key", config.DevImageHarness, args, registryFlag(cfg))
+	}
+	return nil
+}
+
+// nestedValue walks a values map along the keys and returns what is there,
+// nil when any level is missing or not a map.
+func nestedValue(values map[string]any, keys ...string) any {
+	var cur any = values
+	for _, k := range keys {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		if cur, ok = m[k]; !ok {
+			return nil
+		}
+	}
+	return cur
+}
+
+// nestedString is nestedValue for a string: "" when it is not one.
+func nestedString(values map[string]any, keys ...string) string {
+	s, _ := nestedValue(values, keys...).(string)
+	return s
+}
+
+// resolveDevImageNames reads, for every configured Deployment target, the
+// image name the component chart renders on its Deployment/container off
+// the component renders (keyed by release name — the meta chart names a
+// component's HelmRelease after the component). A target whose chart
+// rendered but has no such Deployment/container is an error: the override
+// would match nothing and kustomize drops it silently, so the chart's shape
+// changed under the lab's table. A target whose chart did not render at all
+// (a registry hiccup; the preload already reported it) falls back to the
+// table's name, unverified, and says so.
+func resolveDevImageNames(cfg *config.Config, renders map[string]string) (map[string]string, error) {
+	names := map[string]string{}
+	for _, component := range slices.Sorted(maps.Keys(cfg.Platform.DevImages)) {
+		target, ok := devImageTargets[component]
+		if !ok {
+			continue
+		}
+		rendered, ok := renders[component]
+		if !ok {
+			note("platform.devImages.%s: the %s chart did not render here, so the override targets the table's image name %s unverified", component, component, target.image)
+			names[component] = target.image
+			continue
+		}
+		image, ok := renderedContainerImage(rendered, target.deployment, target.container)
+		if !ok {
+			return nil, fmt.Errorf("platform.devImages.%s: the %s chart's render has no Deployment %s with a container %s — the image override would match nothing and kustomize would drop it silently; the chart's shape changed (compare `helm template` of the component with devImageTargets)", component, component, target.deployment, target.container)
+		}
+		names[component] = imageName(image)
+		note("platform.devImages.%s replaces %s (Deployment %s, container %s in the %s chart's render)", component, names[component], target.deployment, target.container, component)
+	}
+	return names, nil
+}
+
+// renderedWorkload is the part of a rendered Deployment the name resolution
+// reads: its name and its containers' names and images.
+type renderedWorkload struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Template struct {
+			Spec struct {
+				Containers []struct {
+					Name  string `yaml:"name"`
+					Image string `yaml:"image"`
+				} `yaml:"containers"`
+			} `yaml:"spec"`
+		} `yaml:"template"`
+	} `yaml:"spec"`
+}
+
+// renderedContainerImage finds the image of the named container of the
+// named Deployment in a multi-document render. Documents that are not
+// objects (comments, empty separators) are skipped.
+func renderedContainerImage(rendered, deployment, container string) (string, bool) {
+	dec := yaml.NewDecoder(strings.NewReader(rendered))
+	for {
+		var doc renderedWorkload
+		err := dec.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			return "", false
+		}
+		if err != nil {
+			continue
+		}
+		if doc.Kind != kindDeployment || doc.Metadata.Name != deployment {
+			continue
+		}
+		for _, c := range doc.Spec.Template.Spec.Containers {
+			if c.Name == container && c.Image != "" {
+				return c.Image, true
+			}
+		}
+	}
+}
+
+// imageName is a ref without its tag or digest — the name kustomize's image
+// transformer matches on. A registry port sits before the first slash, so
+// only a colon after the last slash is a tag separator.
+func imageName(ref string) string {
+	if repo, _, ok := strings.Cut(ref, "@"); ok {
+		ref = repo
+	}
+	slash := strings.LastIndex(ref, "/")
+	if colon := strings.LastIndex(ref, ":"); colon > slash {
+		return ref[:colon]
+	}
+	return ref
+}
+
+// devRegistryName is the registry container: one per cluster, named after
+// it, on the kind docker network next to the node.
+func devRegistryName(cfg *config.Config) string { return cfg.ClusterName + "-registry" }
+
+// devRegistryEndpoint is the registry as pods reach it on the kind network:
+// the container's name (docker's embedded DNS resolves it, and CoreDNS
+// forwards to the node's resolver) and its own port.
+func devRegistryEndpoint(cfg *config.Config) string {
+	return devRegistryName(cfg) + ":" + strconv.Itoa(devRegistryContainerPort)
+}
+
+// devRegistryHost is the registry as the host spells it — and as the Harness
+// ref spells it, so atelet's localhost rewrite applies: docker treats a
+// localhost registry as insecure without daemon configuration, and so does
+// atelet.
+func devRegistryHost(cfg *config.Config) string {
+	return localhostName + ":" + strconv.Itoa(cfg.Platform.DevRegistryPort)
+}
+
+// devRegistryURL is the registry's API on the host loopback.
+func devRegistryURL(cfg *config.Config) string {
+	return "http://127.0.0.1:" + strconv.Itoa(cfg.Platform.DevRegistryPort)
+}
+
+// ensureDevRegistry has the lab registry running on the kind network and
+// published on the configured host port, creating or restarting the
+// container as needed, and waits for its API. An existing registry that
+// publishes another port is refused rather than silently used: the Harness
+// ref carries the configured port.
+func ensureDevRegistry(cfg *config.Config) error {
+	name := devRegistryName(cfg)
+	state, err := nodeState(name)
+	switch {
+	case err != nil:
+		hostPullImages([]string{devRegistryImage})
+		args := []string{"run", "-d", "--restart=always", "--name", name, "--network", kindDockerNetwork,
+			"-p", fmt.Sprintf("127.0.0.1:%d:%d", cfg.Platform.DevRegistryPort, devRegistryContainerPort), devRegistryImage}
+		if err := runQuiet(dockerBin, args...); err != nil {
+			return fmt.Errorf("creating the lab registry %s: %w\n(another process holding 127.0.0.1:%d? set platform.devRegistryPort to a free port)", name, err, cfg.Platform.DevRegistryPort)
+		}
+		note("created the lab registry %s (%s on the %s network, published on %s)", name, devRegistryImage, kindDockerNetwork, devRegistryHost(cfg))
+	case state == stateRunning:
+	case state == statePaused:
+		if err := runQuiet(dockerBin, verbUnpause, name); err != nil {
+			return fmt.Errorf("resuming the lab registry %s: %w", name, err)
+		}
+	default:
+		if err := runQuiet(dockerBin, verbStart, name); err != nil {
+			return fmt.Errorf("starting the lab registry %s (%s): %w", name, state, err)
+		}
+		note("started the lab registry %s (was %s)", name, state)
+	}
+	if port, err := devRegistryPublishedPort(name); err != nil {
+		return err
+	} else if port != cfg.Platform.DevRegistryPort {
+		return fmt.Errorf("the lab registry %s publishes 127.0.0.1:%d, but platform.devRegistryPort is %d: `docker rm -f %s` and re-run, or set the port back", name, port, cfg.Platform.DevRegistryPort, name)
+	}
+	url := devRegistryURL(cfg) + "/v2/"
+	client := &http.Client{Timeout: 3 * time.Second}
+	if !waitFor(devRegistryWaitAttempts, time.Second, func() bool {
+		resp, err := client.Get(url)
+		if err != nil {
+			return false
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode == http.StatusOK
+	}) {
+		return fmt.Errorf("the lab registry %s does not answer on %s (`docker logs %s`)", name, url, name)
+	}
+	return nil
+}
+
+// devRegistryPublishedPort reads the host port the registry container
+// publishes its registry port on.
+func devRegistryPublishedPort(name string) (int, error) {
+	format := fmt.Sprintf(`{{(index (index .NetworkSettings.Ports "%d/tcp") 0).HostPort}}`, devRegistryContainerPort)
+	out, err := outputQuiet(dockerBin, "inspect", "-f", format, name)
+	if err != nil {
+		return 0, fmt.Errorf("reading the lab registry's published port: %w", err)
+	}
+	port, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("the lab registry %s publishes no port %d/tcp (%q)", name, devRegistryContainerPort, strings.TrimSpace(out))
+	}
+	return port, nil
+}
+
+// removeDevRegistry removes the lab registry container with its storage;
+// nothing to do when there is none. Best-effort, for `agentlab down`.
+func removeDevRegistry(cfg *config.Config) {
+	name := devRegistryName(cfg)
+	if _, err := nodeState(name); err != nil {
+		return
+	}
+	if err := runQuiet(dockerBin, "rm", "-f", "-v", name); err != nil {
+		note("removing the lab registry %s failed (%v); `docker rm -f -v %s` removes it", name, err, name)
+		return
+	}
+	note("removed the lab registry %s", name)
+}
+
+// pushDevImage tags the local build into the lab registry, pushes it, and
+// returns the ref the Harness pins: the registry's host spelling with the
+// manifest digest the registry computed for what landed — the digest atelet
+// keys its cache by.
+func pushDevImage(cfg *config.Config, ref string) (string, error) {
+	repo, tag := devImageRepoTag(ref)
+	pushRef := devRegistryHost(cfg) + "/" + repo + ":" + tag
+	if err := runQuiet(dockerBin, "tag", ref, pushRef); err != nil {
+		return "", fmt.Errorf("tagging %s for the lab registry: %w (is the image in the host docker cache? `docker image inspect %s`)", ref, err, ref)
+	}
+	args := []string{"push", pushRef}
+	if dockerIsPodman() {
+		args = []string{"push", "--tls-verify=false", pushRef}
+	}
+	if err := runQuiet(dockerBin, args...); err != nil {
+		return "", fmt.Errorf("pushing %s to the lab registry: %w", pushRef, err)
+	}
+	digest, err := registryManifestDigest(devRegistryURL(cfg), repo, tag)
+	if err != nil {
+		return "", err
+	}
+	return devRegistryHost(cfg) + "/" + repo + "@" + digest, nil
+}
+
+// devImageRepoTag splits a local ref into the repository path the lab
+// registry serves it under and a tag: the registry host of the ref (when it
+// names one) is dropped, the path kept; a digest ref gets a tag derived from
+// the digest.
+func devImageRepoTag(ref string) (repo, tag string) {
+	path := ref
+	if first, rest, ok := strings.Cut(ref, "/"); ok && (strings.ContainsAny(first, ".:") || first == localhostName) {
+		path = rest
+	}
+	if repo, digest, ok := strings.Cut(path, "@"); ok {
+		hex := strings.TrimPrefix(digest, "sha256:")
+		return repo, "sha256-" + hex[:min(12, len(hex))]
+	}
+	slash := strings.LastIndex(path, "/")
+	if colon := strings.LastIndex(path, ":"); colon > slash {
+		return path[:colon], path[colon+1:]
+	}
+	return path, "latest"
+}
+
+// manifestAccept lists the manifest media types a registry may answer with —
+// an OCI or Docker image manifest, or an index — so the digest is the one of
+// what `docker push` uploaded, whichever form it took.
+const manifestAccept = "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, " +
+	"application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json"
+
+// digestRe is a sha256 digest as the registry and the Harness CRD spell it.
+var digestRe = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+
+// registryManifestDigest asks the registry (distribution API) for the
+// digest of a tag's manifest: the Docker-Content-Digest header of a HEAD.
+func registryManifestDigest(registryURL, repo, tag string) (string, error) {
+	url := registryURL + "/v2/" + repo + "/manifests/" + tag
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodHead, url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", manifestAccept)
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("reading the pushed manifest's digest from the lab registry: %w", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("reading the pushed manifest's digest from the lab registry: %s %s", url, resp.Status)
+	}
+	digest := resp.Header.Get("Docker-Content-Digest")
+	if !digestRe.MatchString(digest) {
+		return "", fmt.Errorf("the lab registry answered %s with digest %q, not a sha256 digest", url, digest)
+	}
+	return digest, nil
+}
+
+// harnessState is what the boot records about the platform Harness before
+// the install, to say afterwards what the swap changed: the image it ran and
+// the desired revision of every template it admits.
+type harnessState struct {
+	image     string
+	revisions map[string]string
+}
+
+// readHarnessState reads the platform Harness's image and its admitted
+// templates' desired revisions; a Harness that is not there yet (a first
+// install) reads as empty.
+func readHarnessState(ctx context.Context) (harnessState, error) {
+	st := harnessState{revisions: map[string]string{}}
+	gvr, err := gvrFor(harnessResource)
+	if err != nil {
+		return st, nil // the CRD is not served yet: a first install
+	}
+	harness, err := getObject(ctx, gvr, kagentNamespace, platformHarness)
+	if err != nil {
+		return st, nil
+	}
+	st.image, _, _ = unstructured.NestedString(harness.Object, "spec", "workload", "image")
+	templates, err := admittedTemplates(ctx, harness)
+	if err != nil {
+		return st, err
+	}
+	for name, t := range templates {
+		if h := t.harness(platformHarness); h != nil {
+			st.revisions[name] = h.DesiredRevision
+		}
+	}
+	return st, nil
+}
+
+// admittedTemplates lists the AgentTemplates the Harness admits — those its
+// allowedAgentTemplates selector matches, in its namespace — by name.
+func admittedTemplates(ctx context.Context, harness *unstructured.Unstructured) (map[string]*agentTemplate, error) {
+	labels, _, _ := unstructured.NestedStringMap(harness.Object, "spec", "allowedAgentTemplates", "selector", "matchLabels")
+	var terms []string
+	for _, k := range slices.Sorted(maps.Keys(labels)) {
+		terms = append(terms, k+"="+labels[k])
+	}
+	gvr, err := gvrFor(agentTemplateResource)
+	if err != nil {
+		return nil, err
+	}
+	objs, err := listObjects(ctx, gvr, harness.GetNamespace(), strings.Join(terms, ","))
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]*agentTemplate{}
+	for i := range objs {
+		t, err := agentTemplateFrom(&objs[i])
+		if err != nil {
+			return nil, err
+		}
+		out[objs[i].GetName()] = t
+	}
+	return out, nil
+}
+
+// reportHarnessDevImage checks, after the install, that the platform Harness
+// runs the dev image and waits for the templates it admits to recompile on
+// it: a Harness image change moves every admitted template's desired
+// revision, and the template is back once its latest successful revision is
+// that one and Ready holds. A Harness that already ran the image (a re-run)
+// changed nothing, so its templates only have to be Ready. The wait is a
+// note when it runs out — the proofs are where a template that never comes
+// back fails.
+func reportHarnessDevImage(ctx context.Context, dev *devImages, before harnessState) error {
+	gvr, err := gvrFor(harnessResource)
+	if err != nil {
+		return fmt.Errorf("the platform Harness's CRD (%s) is not served: %w", harnessResource, err)
+	}
+	harness, err := getObject(ctx, gvr, kagentNamespace, platformHarness)
+	if err != nil {
+		return err
+	}
+	image, _, _ := unstructured.NestedString(harness.Object, "spec", "workload", "image")
+	if image != dev.harness {
+		return fmt.Errorf("the platform Harness %s runs %s, not the dev image %s: the connectivity chart did not forward kagent.harness.image (check the merged values in %s)", platformHarness, image, dev.harness, StateDir+"/agent-platform-values.yaml")
+	}
+	changed := before.image != image
+	if changed {
+		step("Waiting for the templates Harness %s admits to recompile on %s", platformHarness, image)
+	}
+	var pending []string
+	var done []string
+	deadline := time.Now().Add(harnessRecompileTimeout)
+	for {
+		templates, err := admittedTemplates(ctx, harness)
+		if err != nil {
+			return err
+		}
+		pending, done = pending[:0], done[:0]
+		for _, name := range slices.Sorted(maps.Keys(templates)) {
+			h := templates[name].harness(platformHarness)
+			if h == nil {
+				pending = append(pending, name+" (no status for the Harness yet)")
+				continue
+			}
+			ready, message := h.condition("Ready")
+			recompiled := !changed || h.DesiredRevision != before.revisions[name]
+			if recompiled && h.LatestSuccessfulRevision == h.DesiredRevision && ready == conditionTrue {
+				done = append(done, fmt.Sprintf("%s %s", name, revisionChange(before.revisions[name], h.DesiredRevision)))
+				continue
+			}
+			pending = append(pending, fmt.Sprintf("%s (Ready=%s %s)", name, ready, message))
+		}
+		if len(pending) == 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Second)
+	}
+	sort.Strings(done)
+	switch {
+	case len(done) == 0 && len(pending) == 0:
+		note("Harness %s runs %s; it admits no template yet — the next one compiles on it", platformHarness, image)
+	case changed:
+		note("Harness %s runs %s; %d admitted templates recompiled on it: %s", platformHarness, image, len(done), strings.Join(done, ", "))
+	default:
+		note("Harness %s already ran %s; %d admitted templates Ready on it", platformHarness, image, len(done))
+	}
+	if len(pending) > 0 {
+		warn("%d templates Harness %s admits have not recompiled after %s: %s", len(pending), platformHarness, harnessRecompileTimeout, strings.Join(pending, "; "))
+	}
+	return nil
+}
+
+// revisionChange words a template's revision move, `abc123 -> def456`, or
+// just the revision when there was none before.
+func revisionChange(from, to string) string {
+	if from == "" || from == to {
+		return to
+	}
+	return from + " -> " + to
+}

--- a/internal/lab/devimages_test.go
+++ b/internal/lab/devimages_test.go
@@ -1,0 +1,318 @@
+package lab
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// A kagent chart render of each line, reduced to what the name resolution
+// reads: the controller Deployment and its containers.
+const (
+	lineKagentRender = `---
+# Source: kagent/templates/ui-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kagent-ui
+spec:
+  template:
+    spec:
+      containers:
+        - name: ui
+          image: "ghcr.io/giantswarm/kagent/ui:0.11.0-gs.3"
+---
+# Source: kagent/templates/controller-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kagent-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: controller
+          image: ghcr.io/giantswarm/kagent/controller:0.11.0-gs.3
+          imagePullPolicy: IfNotPresent
+`
+	wrapperKagentRender = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kagent-controller
+data:
+  IMAGE_TAG: 0.10.1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kagent-controller
+spec:
+  template:
+    spec:
+      containers:
+        - name: controller
+          image: gsoci.azurecr.io/giantswarm/kagent-controller:0.10.1
+`
+)
+
+// The controller override replaces whatever name the line the lab follows
+// renders on Deployment kagent-controller's `controller` container: the fork's
+// name on the kagent line, the wrapper's on 3.x. A target whose chart rendered
+// without that Deployment/container is refused (kustomize would drop the
+// override silently); one whose chart did not render at all falls back to the
+// table's name.
+func TestResolveDevImageNames(t *testing.T) {
+	cfg := config.Default()
+	cfg.Platform.DevImages = map[string]string{componentKagent: devControllerRef, config.DevImageHarness: devHarnessRef}
+
+	names, err := resolveDevImageNames(cfg, map[string]string{componentKagent: lineKagentRender})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := names[componentKagent]; got != lineControllerImage {
+		t.Errorf("kagent line: resolved %q, want %q", got, lineControllerImage)
+	}
+	if _, ok := names[config.DevImageHarness]; ok {
+		t.Errorf("the harness target resolves no Deployment name, got %q", names[config.DevImageHarness])
+	}
+
+	names, err = resolveDevImageNames(cfg, map[string]string{componentKagent: wrapperKagentRender})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := names[componentKagent], "gsoci.azurecr.io/giantswarm/kagent-controller"; got != want {
+		t.Errorf("3.x wrapper: resolved %q, want %q", got, want)
+	}
+
+	// The chart rendered, but not the Deployment/container the swap patches.
+	_, err = resolveDevImageNames(cfg, map[string]string{componentKagent: strings.ReplaceAll(lineKagentRender, "name: controller\n", "name: manager\n")})
+	if err == nil || !strings.Contains(err.Error(), "no Deployment kagent-controller with a container controller") || !strings.Contains(err.Error(), "match nothing") {
+		t.Errorf("unmatched target: want the refusal naming the Deployment and the silent drop, got %v", err)
+	}
+
+	// No render for the component at all: the table's name, unverified.
+	names, err = resolveDevImageNames(cfg, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := names[componentKagent]; got != devImageTargets[componentKagent].image {
+		t.Errorf("no render: want the table's fallback %q, got %q", devImageTargets[componentKagent].image, got)
+	}
+	names, err = resolveDevImageNames(cfg, nil)
+	if err != nil || names[componentKagent] != devImageTargets[componentKagent].image {
+		t.Errorf("nil renders: want the table's fallback, got %v %v", names, err)
+	}
+}
+
+func TestRenderedContainerImage(t *testing.T) {
+	if img, ok := renderedContainerImage(lineKagentRender, "kagent-controller", "controller"); !ok || img != "ghcr.io/giantswarm/kagent/controller:0.11.0-gs.3" {
+		t.Errorf("controller image = %q, %v", img, ok)
+	}
+	if img, ok := renderedContainerImage(lineKagentRender, "kagent-ui", "ui"); !ok || img != "ghcr.io/giantswarm/kagent/ui:0.11.0-gs.3" {
+		t.Errorf("quoted image = %q, %v", img, ok)
+	}
+	if _, ok := renderedContainerImage(lineKagentRender, "kagent-controller", "ui"); ok {
+		t.Error("the ui container is not on the controller Deployment")
+	}
+	if _, ok := renderedContainerImage("# nothing rendered\n", "kagent-controller", "controller"); ok {
+		t.Error("an empty render has no Deployment")
+	}
+	// A document that is no object (a stray scalar) does not stop the scan.
+	if img, ok := renderedContainerImage("---\njust a string\n"+lineKagentRender, "kagent-controller", "controller"); !ok || img == "" {
+		t.Error("a non-object document must be skipped, not fatal")
+	}
+}
+
+func TestImageName(t *testing.T) {
+	cases := map[string]string{
+		"ghcr.io/giantswarm/kagent/controller:0.11.0-gs.3":                "ghcr.io/giantswarm/kagent/controller",
+		"gsoci.azurecr.io/giantswarm/kagent-controller:0.10.1":            "gsoci.azurecr.io/giantswarm/kagent-controller",
+		"localhost:5001/golang-adk@sha256:" + strings.Repeat("a", 64):     "localhost:5001/golang-adk",
+		"localhost:5001/golang-adk:dev@sha256:" + strings.Repeat("a", 64): "localhost:5001/golang-adk",
+		"registry:5000/team/muster":                                       "registry:5000/team/muster",
+		componentMuster:                                                   componentMuster,
+	}
+	for ref, want := range cases {
+		if got := imageName(ref); got != want {
+			t.Errorf("imageName(%q) = %q, want %q", ref, got, want)
+		}
+	}
+}
+
+// The lab registry serves the harness image under the ref's path, the ref's
+// own registry dropped, its tag kept; a digest ref gets a tag of its own.
+func TestDevImageRepoTag(t *testing.T) {
+	cases := []struct{ ref, repo, tag string }{
+		{"golang-adk:dev-139-abc1234", devHarnessRepo, "dev-139-abc1234"},
+		{"giantswarm/kagent/golang-adk:dev", "giantswarm/kagent/golang-adk", devTag},
+		{"ghcr.io/giantswarm/kagent/golang-adk:0.11.0-gs.3", "giantswarm/kagent/golang-adk", "0.11.0-gs.3"},
+		{"localhost:5000/golang-adk:dev", devHarnessRepo, devTag},
+		{"registry:5000/team/golang-adk:dev", "team/golang-adk", devTag},
+		{"golang-adk@sha256:" + strings.Repeat("ab", 32), devHarnessRepo, "sha256-abababababab"},
+	}
+	for _, c := range cases {
+		repo, tag := devImageRepoTag(c.ref)
+		if repo != c.repo || tag != c.tag {
+			t.Errorf("devImageRepoTag(%q) = %q, %q; want %q, %q", c.ref, repo, tag, c.repo, c.tag)
+		}
+	}
+}
+
+// The registry's spellings: the container named after the cluster on the
+// kind network (atelet's replacement endpoint), the host's loopback port for
+// docker push and the Harness ref.
+func TestDevRegistryNames(t *testing.T) {
+	cfg := config.Default()
+	cfg.ClusterName = "agentlab-dev2"
+	cfg.Platform.DevRegistryPort = 5011
+	if got := devRegistryName(cfg); got != "agentlab-dev2-registry" {
+		t.Errorf("name = %q", got)
+	}
+	if got := devRegistryEndpoint(cfg); got != "agentlab-dev2-registry:5000" {
+		t.Errorf("endpoint = %q", got)
+	}
+	if got := devRegistryHost(cfg); got != "localhost:5011" {
+		t.Errorf("host = %q", got)
+	}
+	if got := devRegistryURL(cfg); got != "http://127.0.0.1:5011" {
+		t.Errorf("url = %q", got)
+	}
+}
+
+// The pinned digest is the registry's own answer for the pushed tag's
+// manifest (Docker-Content-Digest of a HEAD with the manifest media types),
+// and anything but a sha256 digest is refused.
+func TestRegistryManifestDigest(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("3f", 32)
+	var accept string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead || r.URL.Path != "/v2/giantswarm/kagent/golang-adk/manifests/dev-139" {
+			http.NotFound(w, r)
+			return
+		}
+		accept = r.Header.Get("Accept")
+		w.Header().Set("Docker-Content-Digest", digest)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	got, err := registryManifestDigest(srv.URL, "giantswarm/kagent/golang-adk", "dev-139")
+	if err != nil || got != digest {
+		t.Errorf("digest = %q, %v", got, err)
+	}
+	for _, mt := range []string{"application/vnd.oci.image.index.v1+json", "application/vnd.docker.distribution.manifest.v2+json"} {
+		if !strings.Contains(accept, mt) {
+			t.Errorf("Accept lacks %s: %q", mt, accept)
+		}
+	}
+	if _, err := registryManifestDigest(srv.URL, "giantswarm/kagent/golang-adk", "missing"); err == nil || !strings.Contains(err.Error(), "404") {
+		t.Errorf("a missing tag must fail with the status, got %v", err)
+	}
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Docker-Content-Digest", "md5:abc")
+	}))
+	defer bad.Close()
+	if _, err := registryManifestDigest(bad.URL, "x", "y"); err == nil || !strings.Contains(err.Error(), "not a sha256 digest") {
+		t.Errorf("a non-sha256 digest must be refused, got %v", err)
+	}
+}
+
+// The merged values must still pin the Harness to the dev image: an overlay
+// that sets kagent.harness.image wins the merge and is reported.
+func TestDevImagesCheckValues(t *testing.T) {
+	cfg := config.Default()
+	pinned := "localhost:5001/golang-adk@sha256:" + strings.Repeat("3f", 32)
+	dev := &devImages{harness: pinned}
+	// The merged values with kagent.harness.image set to img and atelet's
+	// extraArgs as given.
+	merged := func(img any, extraArgs []any) map[string]any {
+		return map[string]any{
+			componentKagent: map[string]any{config.DevImageHarness: map[string]any{"image": img}},
+			"substrate":     map[string]any{"atelet": map[string]any{"extraArgs": extraArgs}},
+		}
+	}
+	flag := registryFlag(cfg)
+	if flag != "--localhost-registry-replacement=agentlab-registry:5000" {
+		t.Errorf("registryFlag = %q", flag)
+	}
+	if err := dev.checkValues(cfg, merged(pinned, []any{flag})); err != nil {
+		t.Errorf("the pin and the flag survived, got %v", err)
+	}
+	overridden := merged("ghcr.io/giantswarm/kagent/golang-adk@sha256:"+strings.Repeat("a2", 32), []any{flag})
+	if err := dev.checkValues(cfg, overridden); err == nil || !strings.Contains(err.Error(), "platform.valuesFiles") {
+		t.Errorf("an overlay's pin must be reported, got %v", err)
+	}
+	// Lists replace in a Helm merge: an overlay's own extraArgs drop the flag.
+	if err := dev.checkValues(cfg, merged(pinned, []any{"--v=2"})); err == nil || !strings.Contains(err.Error(), "extraArgs") {
+		t.Errorf("an overlay replacing the atelet args must be reported, got %v", err)
+	}
+	if err := dev.checkValues(cfg, merged(pinned, nil)); err == nil {
+		t.Error("missing atelet args must be reported")
+	}
+	if err := (&devImages{}).checkValues(cfg, overridden); err != nil {
+		t.Errorf("without a harness target nothing is checked, got %v", err)
+	}
+	if got := nestedString(map[string]any{componentKagent: "flat"}, componentKagent, config.DevImageHarness, "image"); got != "" {
+		t.Errorf("nestedString through a non-map = %q", got)
+	}
+}
+
+func TestRevisionChange(t *testing.T) {
+	if got := revisionChange("", "r2"); got != "r2" {
+		t.Errorf("first revision: %q", got)
+	}
+	if got := revisionChange("r1", "r2"); got != "r1 -> r2" {
+		t.Errorf("moved revision: %q", got)
+	}
+	if got := revisionChange("r2", "r2"); got != "r2" {
+		t.Errorf("unchanged revision: %q", got)
+	}
+}
+
+// The values template carries the swap the way the chart forwards it: the
+// Harness pin under kagent.harness.image while a harness dev image is
+// configured, the atelet flag under substrate.atelet whenever the agents are.
+func TestValuesTemplateHarnessDevImage(t *testing.T) {
+	cfg := config.Default()
+	cfg.Platform.Agents = true
+	cfg.Platform.DevImages = map[string]string{config.DevImageHarness: devHarnessRef}
+	pinned := "localhost:5001/golang-adk@sha256:" + strings.Repeat("3f", 32)
+	dev := &devImages{harness: pinned}
+	mutate, err := dev.templateData(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := renderTemplate(cfg, platformValuesTemplate, mutate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered := string(out)
+	const flagBlock = "  atelet:\n    extraArgs:\n      - --localhost-registry-replacement=agentlab-registry:5000\n"
+	for _, want := range []string{"    image: " + pinned + "\n", flagBlock} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("values lack %q:\n%s", want, excerptAround(rendered, "  harness:"))
+		}
+	}
+	// Without the target the Harness keeps the chart's digest, but the atelet
+	// flag stays: inert, and in place before any swap.
+	cfg.Platform.DevImages = nil
+	out, err = renderTemplate(cfg, platformValuesTemplate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s := string(out); strings.Contains(s, "\n    image: ") || !strings.Contains(s, flagBlock) {
+		t.Errorf("without a harness dev image the values must not pin the Harness and must still carry the atelet flag:\n%s", excerptAround(s, "substrate:"))
+	}
+	// No agents, no Harness, no flag.
+	cfg.Platform.Agents = false
+	out, err = renderTemplate(cfg, platformValuesTemplate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "localhost-registry-replacement") {
+		t.Errorf("without agents the values must not carry the atelet flag")
+	}
+}

--- a/internal/lab/down.go
+++ b/internal/lab/down.go
@@ -31,6 +31,9 @@ func Down(cfg *config.Config) error {
 	_ = os.Remove(".token")
 	// The exported kubeconfig described a cluster that no longer exists.
 	_ = os.Remove(labKubeconfigPath)
+	// The lab registry (the `harness` dev image, devimages.go) served this
+	// cluster's Harness; its content is a push away on the next lab.
+	removeDevRegistry(cfg)
 	fmt.Println("Lab destroyed. certs/ kept (agentlab certs --force to regenerate).")
 	return nil
 }

--- a/internal/lab/fluxreleases.go
+++ b/internal/lab/fluxreleases.go
@@ -141,10 +141,13 @@ var offlineAPIVersions = []string{
 // each). A release that does not render is reported and skipped: the node
 // pulls whatever the preload misses. The versions picked through a
 // semverFilter come back as "<name> <version>" lines, sorted — the channel
-// evidence the boot log shows.
-func fluxReleaseImages(releases []fluxRelease, apiVersions []string) (images, filtered []string, errs []error) {
+// evidence the boot log shows. The renders themselves come back keyed by
+// release name: what the dev-image swap reads a component's image name off
+// (resolveDevImageNames).
+func fluxReleaseImages(releases []fluxRelease, apiVersions []string) (images, filtered []string, renders map[string]string, errs []error) {
 	var mu sync.Mutex
 	var wg sync.WaitGroup
+	renders = map[string]string{}
 	for _, rel := range releases {
 		wg.Go(func() {
 			rendered, version, err := renderFluxRelease(rel, apiVersions)
@@ -157,13 +160,14 @@ func fluxReleaseImages(releases []fluxRelease, apiVersions []string) (images, fi
 			if rel.Filter != "" {
 				filtered = append(filtered, rel.Name+" "+version)
 			}
+			renders[rel.Name] = rendered
 			images = append(images, scrapeImages(rendered)...)
 		})
 	}
 	wg.Wait()
 	slices.Sort(images)
 	slices.Sort(filtered)
-	return slices.Compact(images), filtered, errs
+	return slices.Compact(images), filtered, renders, errs
 }
 
 // renderFluxRelease renders one component chart offline as helm-controller
@@ -287,10 +291,13 @@ const cnpgRelease = "cloudnative-pg"
 // mcp-prometheus HelmRelease the same way. The images the engine composes at
 // run time — the FluxInstance's source- and helm-controller — are in no
 // render; the snapshot manifest covers them from the second boot on.
-// Best-effort throughout: failures are notes, the node pulls the rest.
-func platformImages(cfg *config.Config, roster *platformRoster) []string {
+// Best-effort throughout: failures are notes, the node pulls the rest. The
+// component renders come back too, keyed by release name (nil without a
+// roster): the dev-image swap reads its image names off them
+// (resolveDevImageNames).
+func platformImages(cfg *config.Config, roster *platformRoster) ([]string, map[string]string) {
 	if roster == nil {
-		return nil
+		return nil, nil
 	}
 	images := scrapeImages(roster.manifest)
 	releases := roster.releases
@@ -305,7 +312,7 @@ func platformImages(cfg *config.Config, roster *platformRoster) []string {
 	if cfg.Platform.Observability {
 		apiVersions = append(slices.Clone(apiVersions), "monitoring.coreos.com/v1")
 	}
-	componentImages, filtered, errs := fluxReleaseImages(releases, apiVersions)
+	componentImages, filtered, renders, errs := fluxReleaseImages(releases, apiVersions)
 	for _, err := range errs {
 		note("component render skipped: %s", excerpt(err.Error(), 300))
 	}
@@ -316,7 +323,7 @@ func platformImages(cfg *config.Config, roster *platformRoster) []string {
 	if len(byDigest) > 0 {
 		note("%d digest-pinned refs are the node's to pull (a saved archive of a digest-only reference imports as an unnamed image the CRI cannot start a pod from):\n      %s", len(byDigest), strings.Join(byDigest, "\n      "))
 	}
-	return images
+	return images, renders
 }
 
 // splitDigestRefs separates the refs a side-load can carry — tagged

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -136,7 +136,7 @@ func PlatformUp(cfg *config.Config, offers Offers) error {
 func platformTopologyFor(cfg *config.Config) platformTopology {
 	var roster *platformRoster
 	if cfg.Platform.Enabled {
-		_, valuesPath, err := renderManifest(cfg, "agent-platform-values.yaml.tmpl")
+		_, valuesPath, err := renderManifest(cfg, platformValuesTemplate)
 		if err == nil {
 			var values map[string]any
 			if values, err = helmValuesFiles(append([]string{valuesPath}, cfg.Platform.ValuesFiles...)...); err == nil {
@@ -312,7 +312,7 @@ func platformUp(cfg *config.Config, header string, offers Offers) error {
 		}
 	}
 
-	_, valuesPath, err := renderManifest(cfg, "agent-platform-values.yaml.tmpl")
+	_, valuesPath, err := renderManifest(cfg, platformValuesTemplate)
 	if err != nil {
 		return err
 	}
@@ -361,20 +361,38 @@ func platformUp(cfg *config.Config, header string, offers Offers) error {
 	// anything this misses is pulled in-node under the install's wait
 	// timeout, exactly as before.
 	step("Side-loading the platform images (the host cache survives `agentlab down`)")
-	sideloadPlatformImages(cfg, platformImages(cfg, roster))
-	// The dev images (platform.devImages) are builds of this host: never
-	// pullable, always side-loaded, so their pods find them under
-	// imagePullPolicy IfNotPresent — which is why each ref is then verified
-	// in the node's own image list before the install (ensureNodeImages): a
-	// missing one would surface five minutes later as an ImagePullBackOff,
-	// helm-controller's upgrade timeout and a rollback to the chart's image.
+	images, renders := platformImages(cfg, roster)
+	sideloadPlatformImages(cfg, images)
+	// The dev images (platform.devImages, devimages.go): the Deployment
+	// targets side-loaded and their chart image names read off the component
+	// renders above, the `harness` image pushed to the lab registry and
+	// pinned by digest — then the values rendered once more with what only
+	// the cluster and the registry could say, so the release carries the
+	// swap. The Harness's state before the install is what the recompile
+	// report afterwards compares against.
+	var dev *devImages
+	var harnessBefore harnessState
 	if len(cfg.Platform.DevImages) > 0 {
-		refs := devImageRefs(cfg)
-		if res := sideloadImages(cfg, hostPullImages(refs)); res.n > 0 {
-			note("side-loaded %d dev images (%s)", res.n, res.d)
-		}
-		if err := ensureNodeImages(cfg, refs); err != nil {
+		if dev, err = prepareDevImages(cfg, renders); err != nil {
 			return err
+		}
+		mutate, err := dev.templateData(cfg)
+		if err != nil {
+			return err
+		}
+		if _, valuesPath, err = renderManifestWith(cfg, platformValuesTemplate, mutate); err != nil {
+			return err
+		}
+		if values, err = helmValuesFiles(append([]string{valuesPath}, cfg.Platform.ValuesFiles...)...); err != nil {
+			return err
+		}
+		if err := dev.checkValues(cfg, values); err != nil {
+			return err
+		}
+		if dev.harness != "" {
+			if harnessBefore, err = readHarnessState(ctx); err != nil {
+				return err
+			}
 		}
 	}
 	// The dex-localhost sidecar the lab patches onto the MCP servers
@@ -415,6 +433,11 @@ func platformUp(cfg *config.Config, header string, offers Offers) error {
 	}
 	if err := waitPlatformReleases(); err != nil {
 		return err
+	}
+	if dev != nil && dev.harness != "" {
+		if err := reportHarnessDevImage(ctx, dev, harnessBefore); err != nil {
+			return err
+		}
 	}
 
 	// The lab's own MCP server for the Prometheus tools rides the same engine
@@ -587,7 +610,7 @@ func platformUp(cfg *config.Config, header string, offers Offers) error {
 %s
 %s
 %s
-%s%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, modelManagerHint(cfg, backendEndpoints), obsHint, devImagesHint(cfg), tryItBlock(cfg))
+%s%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, modelManagerHint(cfg, backendEndpoints), obsHint, devImagesHint(cfg, dev), tryItBlock(cfg))
 	// Everything the platform runs is in the node now — record it so the next
 	// boot side-loads instead of pulling.
 	snapshotPreloadImages(cfg)
@@ -796,15 +819,20 @@ func orNone(s string) string {
 }
 
 // devImagesHint lists the dev images in the boot summary, so a lab running a
-// build of yours says so where you look first.
-func devImagesHint(cfg *config.Config) string {
+// build of yours says so where you look first: the harness target with the
+// registry ref the platform Harness pins.
+func devImagesHint(cfg *config.Config, dev *devImages) string {
 	if len(cfg.Platform.DevImages) == 0 {
 		return ""
 	}
 	var b strings.Builder
 	b.WriteString("\n  Dev images (platform.devImages; remove the entry and re-run `agentlab platform` to restore the chart's):\n")
 	for _, name := range slices.Sorted(maps.Keys(cfg.Platform.DevImages)) {
-		fmt.Fprintf(&b, "    %-16s %s\n", name, cfg.Platform.DevImages[name])
+		ref := cfg.Platform.DevImages[name]
+		if name == config.DevImageHarness && dev != nil && dev.harness != "" {
+			ref += "  (Harness " + platformHarness + " pins " + dev.harness + ")"
+		}
+		fmt.Fprintf(&b, "    %-16s %s\n", name, ref)
 	}
 	return b.String()
 }

--- a/internal/lab/postrenderers.go
+++ b/internal/lab/postrenderers.go
@@ -53,6 +53,13 @@ import (
 //  5. The dev images (platform.devImages): a kustomize image override to the
 //     build on this host plus imagePullPolicy IfNotPresent on its container,
 //     so the side-loaded image is used as is (backstage's chart pulls Always).
+//     The name the override replaces is the component chart's, read from its
+//     render (devimages.go) — the kagent controller's differs between the
+//     lines — and an override that would match nothing in the render is an
+//     error before the install, because kustomize drops it silently. The
+//     `harness` target is not a post-renderer: the platform Harness pins its
+//     image by digest through the connectivity values (kagent.harness.image,
+//     the values template), served by the lab registry.
 //
 // The values-side shape is Flux's: `postRenderers: [{kustomize: {patches:
 // [{target, patch}], images: [{name, newName, newTag}]}}]`.
@@ -108,16 +115,22 @@ type postRenderer struct {
 	} `yaml:"kustomize"`
 }
 
-// devImageTarget is what the dev-image swap of one component has to know
-// about the component chart's render: the image name it replaces and the
-// Deployment/container whose pull policy it relaxes.
+// devImageTarget is what the dev-image swap of one Deployment component has
+// to know about the component chart's render: the Deployment/container whose
+// image it replaces and whose pull policy it relaxes, and the image name the
+// chart renders there when the render itself cannot be asked (`agentlab
+// render`, a component chart that failed to render) — what kustomize matches
+// on (the name without tag). `agentlab platform` resolves the live name from
+// the render instead (resolveDevImageNames).
 type devImageTarget struct {
 	deployment, container, image string
 }
 
-// devImageTargets maps the DevImageComponents to their chart render. Image
-// names are the charts' at global.registry gsoci.azurecr.io — what kustomize
-// matches on (the name without tag).
+// devImageTargets maps the Deployment targets of the DevImageComponents to
+// their chart render. The fallback names are the charts' at global.registry
+// gsoci.azurecr.io; the kagent controller's is the 3.x wrapper's — the kagent
+// line publishes it as ghcr.io/giantswarm/kagent/controller, which the render
+// says.
 var devImageTargets = map[string]devImageTarget{
 	componentMuster:        {componentMuster, componentMuster, "gsoci.azurecr.io/giantswarm/muster"},
 	componentBackstage:     {componentBackstage, componentBackstage, "gsoci.azurecr.io/giantswarm/backstage"},
@@ -125,6 +138,18 @@ var devImageTargets = map[string]devImageTarget{
 	componentMCPKubernetes: {componentMCPKubernetes, componentMCPKubernetes, "gsoci.azurecr.io/giantswarm/mcp-kubernetes"},
 	modelManagerMCPServer:  {modelManagerMCPServer, modelManagerMCPServer, "gsoci.azurecr.io/giantswarm/model-manager"},
 	agentManagerMCPServer:  {agentManagerMCPServer, agentManagerMCPServer, "gsoci.azurecr.io/giantswarm/agent-manager"},
+}
+
+// defaultDevImageNames is the image name per configured Deployment target as
+// the table above has it — the names a render without a cluster uses.
+func defaultDevImageNames(cfg *config.Config) map[string]string {
+	names := map[string]string{}
+	for component := range cfg.Platform.DevImages {
+		if target, ok := devImageTargets[component]; ok {
+			names[component] = target.image
+		}
+	}
+	return names
 }
 
 // hostNetworkPatch is patch 1+2 for a Deployment.
@@ -230,8 +255,11 @@ func sidecarPostRenderer(deployment string, dexPort int) postRenderer {
 
 // componentPostRenderers renders the lab's postRenderers list per component
 // as indented YAML, keyed by the agent-platform component name, for the
-// values template. Components without a patch are absent.
-func componentPostRenderers(cfg *config.Config) (map[string]string, error) {
+// values template. Components without a patch are absent. imageNames is the
+// chart image name each configured Deployment target replaces (resolved from
+// the render, or defaultDevImageNames); a configured target absent from it
+// renders no override.
+func componentPostRenderers(cfg *config.Config, imageNames map[string]string) (map[string]string, error) {
 	patches := map[string][]kustomizePatch{
 		componentMuster:        {hostNetworkPatch(componentMuster)},
 		componentBackstage:     {hostNetworkPatch(componentBackstage)},
@@ -246,8 +274,12 @@ func componentPostRenderers(cfg *config.Config) (map[string]string, error) {
 	}
 	images := map[string][]kustomizeImage{}
 	for _, component := range slices.Sorted(maps.Keys(cfg.Platform.DevImages)) {
-		target := devImageTargets[component]
-		images[component] = append(images[component], devImageOverride(target.image, cfg.Platform.DevImages[component]))
+		target, ok := devImageTargets[component]
+		name := imageNames[component]
+		if !ok || name == "" {
+			continue
+		}
+		images[component] = append(images[component], devImageOverride(name, cfg.Platform.DevImages[component]))
 		patches[component] = append(patches[component], pullPolicyPatch(target))
 	}
 	out := map[string]string{}
@@ -287,15 +319,30 @@ func devImageOverride(name, ref string) kustomizeImage {
 	return img
 }
 
-// devImageRefs lists the dev images to side-load, fully qualified.
+// devImageRefs lists the dev images to side-load into the node, fully
+// qualified: the Deployment targets. The `harness` image is not among them —
+// nothing on the node's containerd pulls it (pushDevImage).
 func devImageRefs(cfg *config.Config) []string {
 	var refs []string
-	for _, ref := range cfg.Platform.DevImages {
+	for component, ref := range cfg.Platform.DevImages {
+		if component == config.DevImageHarness {
+			continue
+		}
 		refs = append(refs, fullImageRef(ref))
 	}
 	slices.Sort(refs)
 	return refs
 }
+
+// harnessDevImage is the configured `harness` dev image ref, "" when none.
+func harnessDevImage(cfg *config.Config) string {
+	return cfg.Platform.DevImages[config.DevImageHarness]
+}
+
+// localhostName is the host docker, containerd and atelet treat as a local
+// registry without TLS: the lab registry's spelling on the host and in the
+// Harness ref, and one of the lab Dex's names (certs.go).
+const localhostName = "localhost"
 
 // fullImageRef spells a ref the way containerd (and `crictl images`) does:
 // docker's implicit registry and library namespace made explicit, so
@@ -307,7 +354,7 @@ func fullImageRef(ref string) string {
 	if !hasPath {
 		return "docker.io/library/" + ref
 	}
-	if strings.ContainsAny(first, ".:") || first == "localhost" {
+	if strings.ContainsAny(first, ".:") || first == localhostName {
 		return ref
 	}
 	return "docker.io/" + ref

--- a/internal/lab/postrenderers_test.go
+++ b/internal/lab/postrenderers_test.go
@@ -23,6 +23,13 @@ const (
 	devBackstageFull    = "docker.io/library/" + devBackstageRef
 	chartMusterImage    = "gsoci.azurecr.io/giantswarm/muster"
 	chartBackstageImage = "gsoci.azurecr.io/giantswarm/backstage"
+	devControllerRef    = "kagent-controller:dev-139"
+	devHarnessRepo      = "golang-adk"
+	devHarnessRef       = devHarnessRepo + ":dev-139"
+	devTag              = "dev"
+	// lineControllerImage is the controller's name on the kagent line, as its
+	// chart renders it (the table's fallback is the 3.x wrapper's).
+	lineControllerImage = "ghcr.io/giantswarm/kagent/controller"
 )
 
 // The dev-image swap spells the ref the way containerd lists a side-loaded
@@ -33,8 +40,8 @@ func TestDevImageOverride(t *testing.T) {
 		want kustomizeImage
 	}{
 		{devMusterRef, kustomizeImage{Name: chartMusterImage, NewName: devMusterName, NewTag: "dev-1a2b"}},
-		{"giantswarm/muster:dev", kustomizeImage{Name: chartMusterImage, NewName: "docker.io/giantswarm/muster", NewTag: "dev"}},
-		{"localhost:5000/muster:dev", kustomizeImage{Name: chartMusterImage, NewName: "localhost:5000/muster", NewTag: "dev"}},
+		{"giantswarm/muster:dev", kustomizeImage{Name: chartMusterImage, NewName: "docker.io/giantswarm/muster", NewTag: devTag}},
+		{"localhost:5000/muster:dev", kustomizeImage{Name: chartMusterImage, NewName: "localhost:5000/muster", NewTag: devTag}},
 		{"gsoci.azurecr.io/giantswarm/muster:5.14.1", kustomizeImage{Name: chartMusterImage, NewName: chartMusterImage, NewTag: "5.14.1"}},
 		{"muster@sha256:" + strings.Repeat("a", 64), kustomizeImage{Name: chartMusterImage, NewName: devMusterName, Digest: "sha256:" + strings.Repeat("a", 64)}},
 	}
@@ -66,17 +73,31 @@ func TestFullImageRef(t *testing.T) {
 // componentPostRenderers is the lab's whole patch set as the chart forwards
 // it: Flux's postRenderers shape per component, the hostNetwork patches on
 // muster and Backstage, the sidecar on every MCP server, the UI NodePort on
-// kagent — and, for a dev image, the kustomize image override plus the pull
-// policy patch on its container, nothing on the others.
+// kagent — and, for a dev image, the kustomize image override on the name the
+// render resolved plus the pull policy patch on its container, nothing on the
+// others. The `harness` target is no post-renderer: it pins the platform
+// Harness through the values.
 func TestComponentPostRenderers(t *testing.T) {
 	cfg := config.Default()
 	cfg.Platform.Agents = true
 	cfg.Platform.Observability = true
 	cfg.Platform.ModelManager = config.ModelManager{Enabled: true, Backends: []string{ollama}}
-	cfg.Platform.DevImages = map[string]string{componentMuster: devMusterRef, componentBackstage: devBackstageRef}
-	rendered, err := componentPostRenderers(cfg)
+	cfg.Platform.DevImages = map[string]string{
+		componentMuster:        devMusterRef,
+		componentBackstage:     devBackstageRef,
+		componentKagent:        devControllerRef,
+		config.DevImageHarness: devHarnessRef,
+	}
+	names := defaultDevImageNames(cfg)
+	// The controller's name as the kagent line's render says it (devimages.go).
+	names[componentKagent] = lineControllerImage
+	rendered, err := componentPostRenderers(cfg, names)
 	if err != nil {
 		t.Fatal(err)
+	}
+	// The harness is not a component: nothing renders under its key.
+	if raw, ok := rendered[config.DevImageHarness]; ok {
+		t.Errorf("harness: the Harness pins its image through the values, got postRenderers:\n%s", raw)
 	}
 	// The connectivity chart is not patched: its kagent controller metrics
 	// Service selects kagent's own release since agent-platform 3.20.2.
@@ -142,13 +163,39 @@ func TestComponentPostRenderers(t *testing.T) {
 	if len(backstage.Kustomize.Images) != 1 || backstage.Kustomize.Images[0].Name != chartBackstageImage || backstage.Kustomize.Images[0].NewTag != "tools-84e5" {
 		t.Errorf("backstage dev image: got %+v", backstage.Kustomize.Images)
 	}
-	if refs := devImageRefs(cfg); len(refs) != 2 || refs[0] != devBackstageFull || refs[1] != devMusterFull {
+	// The controller override replaces the name the line renders, not the
+	// table's wrapper name, and relaxes the pull policy on container
+	// `controller` of Deployment kagent-controller.
+	kagent := parse(componentKagent)
+	if want := (kustomizeImage{Name: lineControllerImage, NewName: "docker.io/library/kagent-controller", NewTag: "dev-139"}); len(kagent.Kustomize.Images) != 1 || kagent.Kustomize.Images[0] != want {
+		t.Errorf("kagent dev image: got %+v, want %+v", kagent.Kustomize.Images, want)
+	}
+	if got := patchOn(componentKagent, kindDeployment, "kagent-controller"); len(got) != 1 || !strings.Contains(got[0], "name: controller\n          imagePullPolicy: IfNotPresent") {
+		t.Errorf("kagent: want the pull-policy patch on container controller, got %q", got)
+	}
+	// The side-load list is the Deployment targets: the harness image goes to
+	// the registry instead.
+	if refs := devImageRefs(cfg); len(refs) != 3 || refs[0] != devBackstageFull || refs[1] != "docker.io/library/kagent-controller:dev-139" || refs[2] != devMusterFull {
 		t.Errorf("devImageRefs = %v", refs)
+	}
+	if got := harnessDevImage(cfg); got != devHarnessRef {
+		t.Errorf("harnessDevImage = %q", got)
+	}
+	// A configured target whose name did not resolve renders no override
+	// (resolveDevImageNames refuses that case before the render; here the
+	// table simply has no entry).
+	delete(names, componentMuster)
+	rendered, err = componentPostRenderers(cfg, names)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if imgs := parse(componentMuster).Kustomize.Images; len(imgs) != 0 {
+		t.Errorf("muster without a resolved name: want no override, got %+v", imgs)
 	}
 
 	// Without agents and managed models the optional servers render nothing.
 	cfg.Platform.Agents, cfg.Platform.ModelManager.Enabled, cfg.Platform.DevImages = false, false, nil
-	rendered, err = componentPostRenderers(cfg)
+	rendered, err = componentPostRenderers(cfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,12 +204,16 @@ func TestComponentPostRenderers(t *testing.T) {
 			t.Errorf("%s: off, want no postRenderers", c)
 		}
 	}
-	// Every dev-image component has a render target — the config's list and
-	// the lab's table cannot drift apart.
+	// Every Deployment target of the config's list has a render target — the
+	// list and the lab's table cannot drift apart; the harness is the one
+	// key that is no Deployment.
 	for _, c := range config.DevImageComponents {
-		if _, ok := devImageTargets[c]; !ok {
+		if _, ok := devImageTargets[c]; !ok && c != config.DevImageHarness {
 			t.Errorf("config.DevImageComponents names %s, but devImageTargets has no render target for it", c)
 		}
+	}
+	if _, ok := devImageTargets[config.DevImageHarness]; ok {
+		t.Errorf("the harness target is no Deployment; devImageTargets must not list it")
 	}
 }
 

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -83,6 +83,15 @@ type tmplData struct {
 	PostRenderers              map[string]string
 	MCPPrometheusPostRenderers string
 	MCPPrometheusChartVersion  string
+	// HarnessDevImage is the `harness` dev image as the platform Harness pins
+	// it — the lab registry's ref by digest (devimages.go), forwarded as
+	// kagent.harness.image; empty without the target, or in a render that
+	// cannot ask the registry. LocalRegistryEndpoint is the lab registry as
+	// Substrate's atelet reaches it on the kind docker network
+	// (--localhost-registry-replacement): a fixed name per cluster, rendered
+	// whenever the agents are, so the flag is in place before any swap.
+	HarnessDevImage       string
+	LocalRegistryEndpoint string
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -97,7 +106,9 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 			endpoints = map[string]string{}
 		}
 	}
-	postRenderers, err := componentPostRenderers(cfg)
+	// The dev-image overrides with the table's names: `agentlab platform`
+	// re-renders with the names the component renders say (devimages.go).
+	postRenderers, err := componentPostRenderers(cfg, defaultDevImageNames(cfg))
 	if err != nil {
 		return nil, err
 	}
@@ -110,6 +121,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		PostRenderers:              postRenderers,
 		MCPPrometheusPostRenderers: strings.TrimRight(string(mcpPrometheus), "\n"),
 		MCPPrometheusChartVersion:  mcpPrometheusChartVersion,
+		LocalRegistryEndpoint:      devRegistryEndpoint(cfg),
 		ModelManagerEnabled:        cfg.ModelManagerEnabled(),
 		ModelManagerBackends:       cfg.Platform.ModelManager.Backends,
 		ModelManagerEndpoints:      endpoints,
@@ -165,6 +177,10 @@ var tmplFuncs = template.FuncMap{
 	},
 }
 
+// platformValuesTemplate renders the meta chart's lab values (the lab
+// shape, platform.go).
+const platformValuesTemplate = "agent-platform-values.yaml.tmpl"
+
 // renderTemplate renders one embedded template with the config; mutate, when
 // given, adjusts the template data first (the platform run hands
 // extra-models.yaml.tmpl the statically wired host models this way).
@@ -199,7 +215,7 @@ var manifests = map[string]struct {
 }{
 	"kind-config.yaml.tmpl":                  {out: "kind-config.yaml"},
 	"rbac.yaml.tmpl":                         {out: "rbac.yaml"},
-	"agent-platform-values.yaml.tmpl":        {out: "agent-platform-values.yaml"},
+	platformValuesTemplate:                   {out: "agent-platform-values.yaml"},
 	"kube-prometheus-stack-values.yaml.tmpl": {out: "kube-prometheus-stack-values.yaml"},
 	mcpPrometheusTemplate:                    {out: "mcp-prometheus.yaml"},
 	"observability-route.yaml.tmpl":          {out: "observability-route.yaml"},

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -334,6 +334,15 @@ func TestPlatformValuesFourXTopology(t *testing.T) {
 	if at("kagent", "harness", "snapshotLocation") != "s3://ate-snapshots/kagent" || at("substrate", "rustfs", "enabled") != true {
 		t.Errorf("snapshot store: kagent.harness.snapshotLocation=%v substrate.rustfs.enabled=%v", at("kagent", "harness", "snapshotLocation"), at("substrate", "rustfs", "enabled"))
 	}
+	// The lab registry rewrite rides in the same substrate block (a second
+	// `substrate:` key would replace the first in the values merge) and the
+	// Harness keeps the chart's digest until a `harness` dev image pins it.
+	if args, _ := at("substrate", "atelet", "extraArgs").([]any); len(args) != 1 || args[0] != "--localhost-registry-replacement=agentlab-registry:5000" {
+		t.Errorf("substrate.atelet.extraArgs = %v, want only the lab registry rewrite", args)
+	}
+	if at("kagent", "harness", "image") != nil {
+		t.Errorf("kagent.harness.image = %v, want the chart's pin without a harness dev image", at("kagent", "harness", "image"))
+	}
 	if at("kagent", "controller", "auth", "mode") != "trusted-proxy" {
 		t.Errorf("kagent.controller.auth.mode = %v, want trusted-proxy (the JWT policy is the first layer)", at("kagent", "controller", "auth", "mode"))
 	}

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -326,6 +326,23 @@ postgres:
 substrate:
   rustfs:
     enabled: true
+  # The lab registry a `harness` dev image is served from
+  # (platform.devImages.harness, devimages.go). The Harness's workload image
+  # is pulled by Substrate's atelet into its own layer cache, never through
+  # the node's containerd, so a side-load cannot reach it; the kind
+  # local-registry pattern can: the Harness names the image as
+  # localhost:<port>/…@sha256:…, and atelet rewrites that registry to the
+  # container's endpoint on the kind docker network (plain HTTP). The chart
+  # forwards the flag verbatim to its substrate component. Always on with the
+  # agents, not only while a dev image is configured: the flag is inert for
+  # every other image ref, and having it in place before a swap means the
+  # Harness's new digest can never race ahead of the atelet roll that would
+  # carry it — the connectivity release (the Harness) and the substrate
+  # release (atelet) reconcile independently. The registry container itself
+  # is created on the first swap.
+  atelet:
+    extraArgs:
+      - --localhost-registry-replacement={{ .LocalRegistryEndpoint }}
 
 kagent:
   # The kagent controller's gRPC API through the edge — the Dev Portal, the
@@ -356,6 +373,18 @@ kagent:
   # Required by the chart with kagent on; an installation names its bucket.
   harness:
     snapshotLocation: s3://ate-snapshots/kagent
+{{- if .HarnessDevImage }}
+    # The `harness` dev image (platform.devImages.harness, devimages.go): the
+    # build on this host, pushed to the lab registry and pinned by the digest
+    # the registry computed for it. The meta chart forwards this to the
+    # connectivity chart, which renders it as the platform Harness's workload
+    # image — the CRD accepts nothing but a digest — and a changed image
+    # recompiles every template the Harness admits (a new golden snapshot per
+    # revision). Substrate's atelet pulls it from the registry, rewriting the
+    # localhost host to the registry container (substrate.atelet.extraArgs
+    # above).
+    image: {{ .HarnessDevImage }}
+{{- end }}
   # The controller's database is the platform Postgres (postgres.enabled
   # below, the fleet shape): kagent's `kagent_v2` database on the CNPG
   # Cluster, its connection Secret <clusterName>-kagent-v2-app derived by


### PR DESCRIPTION
Fixes giantswarm/agentlab#139

## What

`platform.devImages` gains the **`harness`** target — the platform Harness's workload image, the Go ADK every agent runs on under kagent API v2 — and the **`kagent`** controller target now follows the line the lab runs instead of a fixed image name.

### The `harness` target

Under kagent API v2 the agent runtime is no Deployment the lab could patch: the connectivity chart renders the image **by digest** into the `Harness` object (the CRD rejects a tag), and Substrate's **atelet pulls it from a registry into its own layer cache** (`/var/lib/ateom-gvisor`, the actors' overlay lowerdirs) — never through the node's containerd. A kind side-load is therefore invisible to it; the path atelet implements for local development is the kind local-registry pattern (`--localhost-registry-replacement`, exposed by the substrate chart as `atelet.extraArgs`). So `agentlab platform`:

1. runs a registry container `<clusterName>-registry` (`registry:3.0.0`) on the kind docker network, published on `127.0.0.1:<platform.devRegistryPort>` (default 5001; created on demand, removed by `agentlab down`);
2. tags and pushes the local build there and reads the **manifest digest the registry computed**;
3. renders `kagent.harness.image: localhost:<port>/<path>@sha256:<digest>` (forwarded by the meta chart to the connectivity chart's Harness) and `substrate.atelet.extraArgs: [--localhost-registry-replacement=<clusterName>-registry:5000]` (forwarded to the substrate component; the lab's own Substrate values template carries the same flag) — both part of the release, so one plain `helm upgrade` applies them and removing the entry restores the chart's digest and drops the flag;
4. after the install asserts the Harness pins the dev digest and waits for **every template the Harness admits to recompile** (desired revision moved, latest successful revision caught up, Ready), reporting them in the boot log; a `platform.valuesFiles` overlay that pins `kagent.harness.image` itself is refused while the target is configured.

### The Deployment targets

The image name a kustomize override replaces is now **read off the component chart's render** — the render the boot already produces to side-load the platform images — so the `kagent` target replaces `ghcr.io/giantswarm/kagent/controller` under the kagent line's chart (4.x) and `gsoci.azurecr.io/giantswarm/kagent-controller` under the 3.x wrapper, whatever Deployment `kagent-controller`'s `controller` container names. A target whose chart rendered **without** that Deployment/container is refused before the install (kustomize would drop the override silently); a chart that did not render at all falls back to the table's name with a note.

### Also

- `docs/platform.md` "Dev images": both targets, the digest constraint (a digest-pinned Harness recompiles every admitted template; the swap is part of the release), the 3.x/4.x controller name rule, the refusal behaviour, `platform.devRegistryPort`.
- `internal/config`: `DevImageComponents` + `DevImageHarness`, `Platform.DevRegistryPort`, validation (`harness` needs `platform.agents`).
- Unit tests: name resolution on both lines and the unmatched-target refusal, the render parser, the registry naming/digest read (httptest), the values templates with and without the target, config validation.

## Lab verification

On the shared lab `agentlab-dev2` at the released **agent-platform 4.7.11** (kagent line 0.11.0-gs.3, Substrate 0.0.27-gs.5 chart-owned, connectivity 4.7.11; agentlab.yaml + a values overlay for the 4.x keys the v0.33.0 template does not render yet), two swap cycles under the lab lock, 2026-09-11 16:58–17:13Z, each restored exactly to the baseline afterwards with the released agentlab v0.33.0 (`agentlab.yaml` byte-identical, controller back on `ghcr.io/giantswarm/kagent/controller:0.11.0-gs.3` with the same imageID, Harness back on the chart's `golang-adk@sha256:a2d23f5e…`, atelet args back, `platform-test` PASS 6/6).

Dev images: real local builds of the kagent line's consumed head `fdfd405d` (`giantswarm/kagent-upstream`, branch `giantswarm`) from `go/Dockerfile` — `golang-adk:dev-139-fdfd405` (`BUILD_PACKAGE=adk/cmd/main.go`, 133 MB) and `kagent-controller:dev-139-fdfd405` (`core/cmd/controller/main.go`, 208 MB), linux/amd64.

```yaml
platform:
  devImages:
    harness: golang-adk:dev-139-fdfd405
    kagent: kagent-controller:dev-139-fdfd405
```

Cycle 1 (branch head `529dce4`) and cycle 2 (head `fca38b2`, this PR's head, registry created by the run itself), each `agentlab platform` exit 0 in 2:03 / 2:17:

- boot log: `platform.devImages.kagent replaces ghcr.io/giantswarm/kagent/controller (Deployment kagent-controller, container controller in the kagent chart's render)` (cycle 2), `side-loaded 1 dev images`, `created the lab registry agentlab-dev2-registry (registry:3.0.0 on the kind network, published on localhost:5001)`, `the platform Harness kagent pins localhost:5001/golang-adk@sha256:792306296292dff65e226707b2265948377bc8e34ba7bac7ef661ed74d472ce8`, then `Harness kagent runs localhost:5001/golang-adk@sha256:7923…; 1 admitted templates recompiled on it: agentlab-agents-test 88c11e38… -> ebfce698…` (cycle 2: `da820540… -> 904c86c2…`);
- objects: Deployment `kagent-controller` → `docker.io/library/kagent-controller:dev-139-fdfd405` (pod Running on it, `imagePullPolicy: IfNotPresent`); `Harness kagent` gen 8→9 (→11) `spec.workload.image: localhost:5001/golang-adk@sha256:7923…`; atelet DaemonSet args gained `--localhost-registry-replacement=agentlab-dev2-registry:5000`; the admitted `AgentTemplate agentlab-agents-test`'s `status.harnesses[kagent]` moved desiredRevision and caught up `latestSuccessfulRevision`, Ready=True;
- atelet log: `Image cache miss ref=localhost:5001/golang-adk@sha256:7923…` → `Image pulled into layer cache layers=3 took=0.63s` → `/atelet.AteomHerder/Run` + `Checkpoint` of the golden actor `agentlab-agents-test-kagent-ebfce698…` — the pull went through the lab registry, rewritten by atelet;
- proofs with both swaps in place: `platform-test` PASS 6/6, `test` 10/10, `skills-test` PASS 3/3 — its throwaway AgentTemplate booted **on the dev Harness image** (`Harness kagent: image localhost:5001/golang-adk@sha256:7923…`, Ready after 20 s, golden snapshot written), one turn through the edge answered from the skill, nothing left behind;
- restore: removing the two entries and re-running `platform` moved the Harness back to the chart's digest and the template recompiled onto it (`ebfce698… -> da820540…`, Ready), the controller back to the line's image.

Not exercised in the lab: the refusal paths (an override matching nothing in the render, an overlay overriding the pin or the atelet list) — unit-tested; `agentlab down` removing the registry — the shared lab is not torn down.

Rebased onto `main` after #156/#155 on 2026-09-11 19:01Z (the Substrate template and the lab's own Substrate install are gone with #156: the Harness pin now sits inside the chart's `kagent.harness` block, the atelet flag inside its `substrate` block; `platformImages` takes #156's roster and returns the component renders). Verified by render: without `devImages` the rebased binary's `agentlab render` output is identical to `main`'s except the documented `substrate.atelet.extraArgs` default; with `harness` + `kagent` dev images it carries the controller's kustomize override and the atelet flag (the line's image name and the Harness digest are `agentlab platform`-time, unit-tested); an unknown `devImages` key is refused with the documented error. Unit tests green (`go build`, `go vet`, `go test ./...`).

## Not verified

- podman: the push path adds `--tls-verify=false`, untested here (docker host).
- `agents-test` / `toolsets-test` / `backstage-test` are red on the 4.7.11 lab independent of this change (the proofs assert the POC composer shape / label — agentlab#140, #142); the agent proof that runs on the Harness today, `skills-test`, is the one exercised with the swaps in place.

