### PR TITLE
fix(platform): a released 3.x meta chart renders the 3.x lab shape again (kagent 0.10, no Substrate) — the seed of the migration rehearsal

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -43,6 +43,18 @@ The lab installs it in its **lab shape**:
   The one exception is deliberate too: the [dev channel](#dev-channel),
   where `platform.chartBranch` follows a branch's newest dev build — and
   still installs an exact version, written into `chartVersion`.
+- A **released 3.x meta chart** (`chartVersion` below `4.0.0`, no
+  `chartBranch`, no `chartPath`) renders the **3.x lab shape**: that line's
+  root schema is closed and the kagent 0.10 wrapper it resolves refuses the
+  current line's keys, so the lab values carry no platform Postgres
+  (`postgres`, `components.cloudnative-pg`), no `substrate`, and a `kagent`
+  block without `harness`, `database`, the JWT policy on the controller route
+  or the CNPG DSN mount — kagent 0.10 on its bundled Postgres, the controller
+  in its local-dev auth mode, the controller ServiceMonitor following
+  observability. This is what a migration rehearsal seeds before upgrading
+  in place to the 4.x line; the switch is `config.LegacyChart`. The dev
+  channel and a chart directory always render the current line's shape,
+  whatever version they carry.
 
 The platform installs as part of `agentlab up` (it is enabled in the default
 configuration); on an already-running cluster the steps are also standalone:

--- a/internal/config/chart_test.go
+++ b/internal/config/chart_test.go
@@ -22,6 +22,37 @@ func TestValidateChartVersion(t *testing.T) {
 	}
 }
 
+// A released 3.x meta chart is the legacy shape; the current line is every
+// 4.x release, and the dev channel and a chart directory whatever their
+// version says.
+func TestLegacyChart(t *testing.T) {
+	for _, tc := range []struct {
+		name                      string
+		version, branch, chartDir string
+		major                     uint64
+		legacy                    bool
+	}{
+		{"3.x release", "3.23.1", "", "", 3, true},
+		{"3.x release with a v", "v3.20.0", "", "", 3, true},
+		{"4.x release", "4.7.11", "", "", 4, false},
+		{"the default", DefaultChartVersion, "", "", 4, false},
+		{"4.0 prerelease", "4.0.0-rc.1", "", "", 4, false},
+		{"5.x release", "5.0.0", "", "", 5, false},
+		{"dev channel resolved to a 3.x-numbered build", "3.24.0-dev.main.2026-09-11.08-12-33.h7f841be", "main", "", 3, false},
+		{"chart directory with a 3.x pin left over", "3.23.1", "", "/tmp/agent-platform", 3, false},
+		{"unset (rejected by ValidateChartVersion first)", "", "", "", 0, false},
+	} {
+		cfg := Default()
+		cfg.Platform.ChartVersion, cfg.Platform.ChartBranch, cfg.Platform.ChartPath = tc.version, tc.branch, tc.chartDir
+		if got := cfg.ChartMajor(); got != tc.major {
+			t.Errorf("%s: ChartMajor() = %d, want %d", tc.name, got, tc.major)
+		}
+		if got := cfg.LegacyChart(); got != tc.legacy {
+			t.Errorf("%s: LegacyChart() = %v, want %v", tc.name, got, tc.legacy)
+		}
+	}
+}
+
 // A dev image names its tag or digest; a bare name would resolve to latest
 // and hide which build the lab runs.
 func TestValidateImageRef(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v3"
 )
@@ -915,6 +916,33 @@ func (m ModelManager) Validate(agents bool) error {
 // ModelManagerEnabled reports whether the platform installs model-manager.
 func (c *Config) ModelManagerEnabled() bool {
 	return c.Platform.Enabled && c.Platform.Agents && c.Platform.ModelManager.Enabled
+}
+
+// ChartMajor is the major version of the meta chart release platform.
+// chartVersion pins (a leading v tolerated); 0 when it is not an exact
+// version — ValidateChartVersion rejects that before anything renders.
+func (c *Config) ChartMajor() uint64 {
+	v, err := semver.NewVersion(c.Platform.ChartVersion)
+	if err != nil {
+		return 0
+	}
+	return v.Major()
+}
+
+// LegacyChart reports whether the lab installs a released meta chart of the
+// 3.x line: an exact platform.chartVersion below 4.0.0 on the stable
+// channel. The 3.x line's values are a different shape (kagent 0.10 with
+// its bundled Postgres, no Agent Substrate, no platform Postgres, a closed
+// root schema that refuses the 4.x keys), so the lab values render in that
+// shape for it; a dev channel (platform.chartBranch) or a chart directory
+// (platform.chartPath) is always the current line, whatever version its
+// Chart.yaml or resolved tag carries.
+func (c *Config) LegacyChart() bool {
+	if c.Platform.ChartBranch != "" || c.Platform.ChartPath != "" {
+		return false
+	}
+	major := c.ChartMajor()
+	return major > 0 && major < 4
 }
 
 // AdminUser returns the first user in platform-admins: the identity the up

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -61,6 +61,11 @@ type tmplData struct {
 	ModelManagerEnabled   bool
 	ModelManagerBackends  []string
 	ModelManagerEndpoints map[string]string
+	// LegacyChart mirrors cfg.LegacyChart(): the lab installs a released
+	// 3.x meta chart, and agent-platform-values.yaml.tmpl renders the 3.x
+	// lab shape (kagent 0.10 with its bundled Postgres, no Substrate, no
+	// platform Postgres) instead of the current line's.
+	LegacyChart bool
 	// ExtraModels is what extra-models.yaml.tmpl renders: the
 	// platform.extraModels entries.
 	ExtraModels []config.ExtraModel
@@ -123,6 +128,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		MCPPrometheusChartVersion:  mcpPrometheusChartVersion,
 		LocalRegistryEndpoint:      devRegistryEndpoint(cfg),
 		ModelManagerEnabled:        cfg.ModelManagerEnabled(),
+		LegacyChart:                cfg.LegacyChart(),
 		ModelManagerBackends:       cfg.Platform.ModelManager.Backends,
 		ModelManagerEndpoints:      endpoints,
 		ExtraModels:                cfg.Platform.ExtraModels,

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -285,6 +286,120 @@ func TestKagentServiceMonitorStaysOff(t *testing.T) {
 	if got := kagentMonitor(render()); got != false {
 		t.Errorf("dev channel: kagent.serviceMonitor.enabled = %v, want false", got)
 	}
+}
+
+// A released 3.x meta chart (platform.chartVersion below 4.0.0 on the stable
+// channel) gets the 3.x lab shape: the chart's closed root schema and the
+// kagent 0.10 wrapper it resolves refuse every key of the current line, so
+// none of them render — no platform Postgres or CNPG operator, no Substrate,
+// and a kagent block with the plain controller route, the local-dev auth
+// mode and the monitor following observability (the 0.10 controller serves
+// /metrics). Everything else is the current line's render, byte for byte:
+// the legacy values are exactly the 4.x values minus those keys.
+func TestPlatformValuesLegacyChartShape(t *testing.T) {
+	render := func(cfg *config.Config) (map[string]any, string) {
+		out, err := renderTemplate(cfg, "agent-platform-values.yaml.tmpl", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var values map[string]any
+		if err := yaml.Unmarshal(out, &values); err != nil {
+			t.Fatalf("%v\n%s", err, out)
+		}
+		return values, string(out)
+	}
+	current := config.Default()
+	legacy := config.Default()
+	legacy.Platform.ChartVersion = "3.23.1"
+	if !legacy.LegacyChart() || current.LegacyChart() {
+		t.Fatalf("LegacyChart(): 3.23.1=%v %s=%v", legacy.LegacyChart(), current.Platform.ChartVersion, current.LegacyChart())
+	}
+	currentValues, currentOut := render(current)
+	legacyValues, legacyOut := render(legacy)
+
+	kagent := legacyValues["kagent"].(map[string]any)
+	for _, key := range []string{"postgres", "substrate"} {
+		if _, ok := legacyValues[key]; ok {
+			t.Errorf("3.x shape: root %s rendered (the 3.x root schema is closed)", key)
+		}
+	}
+	if _, ok := legacyValues["components"].(map[string]any)["cloudnative-pg"]; ok {
+		t.Error("3.x shape: components.cloudnative-pg rendered (kagent 0.10 runs its bundled Postgres)")
+	}
+	for _, key := range []string{fieldHarness, "database", "substrateWorkerPool"} {
+		if _, ok := kagent[key]; ok {
+			t.Errorf("3.x shape: kagent.%s rendered (the 0.10 wrapper's schema is closed)", key)
+		}
+	}
+	if _, ok := kagent["controllerRoute"].(map[string]any)["jwtAuthentication"]; ok || kagent["controllerRoute"].(map[string]any)["enabled"] != true {
+		t.Errorf("3.x shape: kagent.controllerRoute = %v, want enabled without jwtAuthentication", kagent["controllerRoute"])
+	}
+	controller := kagent["controller"].(map[string]any)
+	for _, key := range []string{"volumes", "volumeMounts"} {
+		if _, ok := controller[key]; ok {
+			t.Errorf("3.x shape: kagent.controller.%s rendered (no platform Postgres to mount)", key)
+		}
+	}
+	if got := controller["auth"].(map[string]any)["mode"]; got != "unsecure" {
+		t.Errorf("3.x shape: kagent.controller.auth.mode = %v, want unsecure (no JWT policy in front)", got)
+	}
+	if got := kagent["serviceMonitor"].(map[string]any)["enabled"]; got != true {
+		t.Errorf("3.x shape: kagent.serviceMonitor.enabled = %v, want observability (%v)", got, legacy.Platform.Observability)
+	}
+	if got := kagent["providers"].(map[string]any)["default"]; got != "anthropic" {
+		t.Errorf("3.x shape: kagent.providers.default = %v, want anthropic", got)
+	}
+	if got := kagent["ui"].(map[string]any)["service"].(map[string]any)["type"]; got != "NodePort" {
+		t.Errorf("3.x shape: kagent.ui.service.type = %v, want NodePort", got)
+	}
+
+	// The legacy render is the current one minus the 4.x keys — nothing else
+	// moves between the shapes.
+	expected := currentValues
+	delete(expected, "postgres")
+	delete(expected, "substrate")
+	delete(expected["components"].(map[string]any), "cloudnative-pg")
+	expectedKagent := expected["kagent"].(map[string]any)
+	delete(expectedKagent, fieldHarness)
+	delete(expectedKagent, "database")
+	delete(expectedKagent["controllerRoute"].(map[string]any), "jwtAuthentication")
+	delete(expectedKagent["controller"].(map[string]any), "volumes")
+	delete(expectedKagent["controller"].(map[string]any), "volumeMounts")
+	expectedKagent["controller"].(map[string]any)["auth"].(map[string]any)["mode"] = "unsecure"
+	expectedKagent["serviceMonitor"].(map[string]any)["enabled"] = legacy.Platform.Observability
+	if !reflect.DeepEqual(expected, legacyValues) {
+		t.Errorf("the 3.x values differ from the 4.x values in more than the 4.x keys:\n--- 4.x minus the keys\n%s\n--- 3.x\n%s", mustYAML(t, expected), mustYAML(t, legacyValues))
+	}
+
+	// The current line is unchanged by the switch: a 4.x release, a 5.x one,
+	// the dev channel and a chart directory render the same bytes, and a
+	// 3.x-numbered dev build is still the current line.
+	for name, mutate := range map[string]func(*config.Config){
+		"4.x release": func(c *config.Config) { c.Platform.ChartVersion = "4.7.11" },
+		"5.x release": func(c *config.Config) { c.Platform.ChartVersion = "5.0.0" },
+		"dev channel on a 3.x-numbered": func(c *config.Config) {
+			c.Platform.ChartVersion, c.Platform.ChartBranch = "3.24.0-dev.main.2026-09-11.08-12-33.h7f841be", testRefMain
+		},
+		"chart directory": func(c *config.Config) { c.Platform.ChartVersion, c.Platform.ChartPath = "3.23.1", t.TempDir() },
+	} {
+		cfg := config.Default()
+		mutate(cfg)
+		if _, out := render(cfg); out != currentOut {
+			t.Errorf("%s: the render differs from the current line's", name)
+		}
+	}
+	if legacyOut == currentOut {
+		t.Error("the 3.x render must differ from the current line's")
+	}
+}
+
+func mustYAML(t *testing.T, v any) string {
+	t.Helper()
+	out, err := yaml.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
 }
 
 // The 4.x line's topology is the lab's shape: Agent Substrate and the

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -157,6 +157,7 @@ components:
 {{- if .Platform.Agents }}
     postRenderers:
 {{ index .PostRenderers "kagent" | indent 6 }}
+{{- if not .LegacyChart }}
   # The platform Postgres: the CloudNativePG operator (the chart's optional
   # component; a management cluster runs it as its own app) and, under
   # postgres.enabled below, the CNPG Cluster the connectivity chart renders
@@ -165,6 +166,7 @@ components:
   # here for real. Rides with the agents: nothing else in the lab needs it.
   cloudnative-pg:
     enabled: true
+{{- end }}
   # The agent write surface (agents as HelmReleases of the agent chart, as
   # the caller), on whenever kagent is — the standalone umbrella's contract.
   agent-manager:
@@ -297,6 +299,7 @@ muster:
             url: muster-valkey:6379
 
 {{- if .Platform.Agents }}
+{{- if not .LegacyChart }}
 # The platform Postgres — one CNPG Cluster in the kagent namespace holding
 # kagent's `kagent_v2` database (postgres.databases.kagent-v2, the vector
 # extension for the memory API) and Substrate's control-plane database
@@ -343,8 +346,21 @@ substrate:
   atelet:
     extraArgs:
       - --localhost-registry-replacement={{ .LocalRegistryEndpoint }}
+{{- end }}
 
 kagent:
+{{- if .LegacyChart }}
+  # THE 3.x LINE (a released meta chart below 4.0.0, config.LegacyChart):
+  # kagent 0.10 on its bundled Postgres, no platform Harness, no platform
+  # Postgres, no Agent Substrate — that chart's root schema is closed and the
+  # kagent 0.10 wrapper refuses the keys of the current line, so none of
+  # them render here. The controller API through the edge for the Dev
+  # Portal's kagent page (the connectivity chart derives the app-config's
+  # apiBaseUrl from this route); JWT validation stays off like in that
+  # chart's kind example — the edge only listens on the host's loopback.
+  controllerRoute:
+    enabled: true
+{{- else }}
   # The kagent controller's gRPC API through the edge — the Dev Portal, the
   # proofs and klaus-gateway dial it there — with the chart's JWT policy in
   # front (jwtAuthentication.enabled, mode Strict: the fleet shape). The
@@ -397,6 +413,7 @@ kagent:
       vectorEnabled: true
       bundled:
         enabled: false
+{{- end }}
   # The default ModelConfig every agent starts from (the kagent chart renders
   # it from providers.<default>). The chart would only create the referenced
   # Secret if the raw key were inlined in these values — which would put a
@@ -412,6 +429,14 @@ kagent:
       apiKeySecretKey: ANTHROPIC_API_KEY
   controller:
     auth:
+{{- if .LegacyChart }}
+      # The 3.x line runs no JWT-validating policy in front of the controller
+      # (controllerRoute.jwtAuthentication is off above), so trusted-proxy —
+      # bearer claims decoded WITHOUT verification — would trust anyone, and
+      # the kagent UI's direct NodePort path sends no bearer at all:
+      # upstream's local-dev mode is the honest setting here.
+      mode: unsecure
+{{- else }}
       # The chart's default: the controller decodes the bearer's claims
       # WITHOUT verifying the signature and trusts the JWT-validating
       # agentgateway policy in front of it (controllerRoute.jwtAuthentication
@@ -429,6 +454,7 @@ kagent:
       - name: cnpg-dsn
         mountPath: /etc/cnpg
         readOnly: true
+{{- end }}
   # Publish the UI on the host through the kind port mapping. NodePort is a
   # chart value, but the chart's ui-service template renders no `nodePort`
   # field (a random one would be useless to kind's fixed mappings), so the
@@ -436,6 +462,16 @@ kagent:
   ui:
     service:
       type: NodePort
+{{- if .LegacyChart }}
+  # The connectivity chart's per-object toggle for the kagent controller
+  # ServiceMonitor it renders (the kagent chart itself ships none); the
+  # chart-level gate is global.observability.metrics.serviceMonitor.enabled
+  # above, and the 3.x line's kagent 0.10 controller serves plain-HTTP
+  # /metrics on :8080 via the chart's default METRICS_BIND_ADDRESS/
+  # METRICS_SECURE env, so the monitor follows observability.
+  serviceMonitor:
+    enabled: {{ .Platform.Observability }}
+{{- else }}
   # The connectivity chart's per-object toggle for the kagent controller
   # ServiceMonitor (the chart-level gate is
   # global.observability.metrics.serviceMonitor.enabled above). Off, the
@@ -445,6 +481,7 @@ kagent:
   # serves them.
   serviceMonitor:
     enabled: false
+{{- end }}
   # No OTLP gateway in kind; the exporters would only log dial errors.
   otel:
     tracing:


### PR DESCRIPTION
## Problem

`agentlab render` writes `state/agent-platform-values.yaml` in the 4.x lab shape unconditionally (#156). A lab pinned to a released 3.x meta chart cannot install it: `helm template` of agent-platform **3.23.1** with that file fails

```
values don't meet the specifications of the schema(s): agent-platform: - at '': additional properties 'substrate' not allowed
```

(the 3.x root schema is closed), and beyond `substrate:` the file carries keys a 3.x install must not get — root `postgres:`, `components.cloudnative-pg`, `kagent.controllerRoute.jwtAuthentication`, `kagent.harness`, `kagent.database`, `kagent.controller.auth.mode: trusted-proxy`, the `cnpg-dsn` volume and mount, `kagent.serviceMonitor.enabled: false` — which the kagent 0.10 wrapper (0.3.3, what 3.23.1's `components.kagent` range resolves) validates against its own closed schema. The migration rehearsal (#143) seeds a lab on the released 3.23.1 and upgrades it in place to the 4.x line, so the lab has to render the 3.x shape for a 3.x pin.

## Change

- `config.Config.ChartMajor()` (the major of `platform.chartVersion`) and the predicate `config.Config.LegacyChart()`: true for an exact `chartVersion` with major `< 4` on the stable channel — `chartBranch` (the dev channel) and `chartPath` (a chart directory) are always the current line, whatever version they carry.
- `tmplData.LegacyChart` mirrors it, and `agent-platform-values.yaml.tmpl` gates the 4.x-only blocks on it: no root `postgres`/`substrate`, no `components.cloudnative-pg`, and the `kagent` block as the 3.x line takes it — `controllerRoute.enabled: true` without the JWT policy, no `harness`/`database`/DSN mount, `controller.auth.mode: unsecure` (no JWT-validating policy in front), `serviceMonitor.enabled` following `platform.observability` (the 0.10 controller serves `/metrics`). No second template, no new config key.
- Every other case (a 4.x or later release, `chartBranch`, `chartPath`) renders byte-identically to `main`.
- One paragraph in `docs/platform.md` next to `platform.chartVersion`.

## Verification

- `go build ./... && go vet ./... && go test ./...` green; `golangci-lint run -E=gosec -E=goconst -E=govet` (the pre-commit args) 0 issues.
- New tests: `TestLegacyChart` (3.23.1 and v3.20.0 → legacy; 4.7.11, 4.0.0-rc.1, 5.0.0, a 3.x-numbered dev build with `chartBranch`, `chartPath` with a 3.x pin → current) and `TestPlatformValuesLegacyChartShape` (the 3.x render has none of the 4.x keys and is exactly the 4.x values minus those keys; 4.x, 5.x, dev channel and chart directory render the same bytes as the current line).
- Rendered from a copy of a running lab's `agentlab.yaml` (agents, model-manager, observability on):
  - `chartVersion: 4.7.11` → `state/agent-platform-values.yaml` byte-identical to the render of a `main` (d6a8d5a) build (`diff` empty).
  - `chartVersion: 3.23.1` → `helm template agent-platform <agent-platform-3.23.1> -n agent-platform -f state/agent-platform-values.yaml --kube-version 1.33.0` exits 0 (37 rendered objects; before the change: the schema error above).
  - The forwarded `kagent` block minus the keys 3.23.1 strips (`controllerRoute fluxServiceAccountName modelConfigs oauth2ProxyIngress remoteMcpServers serviceMonitor uiRoute`) against the kagent wrapper 0.3.3: `helm template kagent <kagent-0.3.3> -f kagent.yaml` exits 0 (52 rendered objects). The block:
    ```yaml
    kagent:
      controllerRoute:
        enabled: true
      providers:
        default: anthropic
        anthropic:
          provider: Anthropic
          model: claude-sonnet-4-6
          apiKeySecretRef: kagent-anthropic
          apiKeySecretKey: ANTHROPIC_API_KEY
      controller:
        auth:
          mode: unsecure
      ui:
        service:
          type: NodePort
      serviceMonitor:
        enabled: true
      otel:
        tracing:
          enabled: false
        logging:
          enabled: false
    ```

Refs giantswarm/agentlab#143
