### PR TITLE
fix(models): platform.extraModels render at the kagent.dev version the chart line serves — v1alpha3 on the 4.x line, v1alpha2 on a legacy 3.x chart

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -42,7 +42,10 @@ platform:
 
 `agentlab configure` asks for these interactively (the "extra model configs"
 confirm in the platform group); `agentlab platform` (or `agentlab up`)
-applies them and waits for the kagent controller to accept each one. Entries
+applies them and waits for the kagent controller to accept each one. The CRs
+are rendered at the kagent API version the chart line serves —
+`kagent.dev/v1alpha3` on the 4.x line, `kagent.dev/v1alpha2` on a released
+3.x chart (kagent 0.10); the ModelConfig spec is the same in both. Entries
 removed from `agentlab.yaml` are **pruned** on the next run — the managed-by
 label scopes the pruning to lab-created ModelConfigs, so the chart's default
 one is never touched.

--- a/internal/lab/models_test.go
+++ b/internal/lab/models_test.go
@@ -1,10 +1,12 @@
 package lab
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +72,70 @@ func TestExtraModelsTemplate(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "kind:") {
 		t.Errorf("empty extraModels rendered objects:\n%s", raw)
+	}
+}
+
+// The extra ModelConfigs render at the kagent.dev version the chart line
+// serves: v1alpha3 on the kagent line (meta chart >= 4.0), v1alpha2 on a
+// released 3.x chart (kagent 0.10) — the ModelConfig spec is the same in
+// both, so nothing but the apiVersion moves between the two renders.
+func TestExtraModelsAPIVersionFollowsChartLine(t *testing.T) {
+	render := func(cfg *config.Config) map[string]any {
+		out, err := renderTemplate(cfg, extraModelsTemplate, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var docs []map[string]any
+		dec := yaml.NewDecoder(strings.NewReader(string(out)))
+		for {
+			var doc map[string]any
+			if err := dec.Decode(&doc); err != nil {
+				break
+			}
+			if doc != nil {
+				docs = append(docs, doc)
+			}
+		}
+		if len(docs) != 1 {
+			t.Fatalf("rendered %d ModelConfigs, want 1:\n%s", len(docs), out)
+		}
+		return docs[0]
+	}
+	model := config.ExtraModel{Name: "local-vllm", Provider: config.ProviderOpenAI, Model: "mistral-small-3.2", BaseURL: "https://vllm.example.internal/v1"}
+	current := config.Default()
+	current.Platform.ChartVersion = "4.7.15"
+	current.Platform.ExtraModels = []config.ExtraModel{model}
+	legacy := config.Default()
+	legacy.Platform.ChartVersion = "3.24.0"
+	legacy.Platform.ExtraModels = []config.ExtraModel{model}
+	if !legacy.LegacyChart() || current.LegacyChart() {
+		t.Fatalf("LegacyChart(): 3.24.0=%v 4.7.15=%v", legacy.LegacyChart(), current.LegacyChart())
+	}
+	currentMC, legacyMC := render(current), render(legacy)
+
+	if got := currentMC["apiVersion"]; got != "kagent.dev/v1alpha3" {
+		t.Errorf("4.7.15: apiVersion = %v, want kagent.dev/v1alpha3", got)
+	}
+	if got := legacyMC["apiVersion"]; got != "kagent.dev/v1alpha2" {
+		t.Errorf("3.24.0: apiVersion = %v, want kagent.dev/v1alpha2", got)
+	}
+	if got := currentMC["kind"]; got != "ModelConfig" {
+		t.Errorf("kind = %v, want ModelConfig", got)
+	}
+	metadata := currentMC["metadata"].(map[string]any)
+	if metadata["name"] != model.Name || metadata["namespace"] != kagentNamespace {
+		t.Errorf("metadata = %v, want %s/%s", metadata, kagentNamespace, model.Name)
+	}
+	spec := currentMC["spec"].(map[string]any)
+	if spec["provider"] != model.Provider || spec["model"] != model.Model || spec["openAI"].(map[string]any)["baseUrl"] != model.BaseURL {
+		t.Errorf("spec = %v, want provider %s, model %s, openAI.baseUrl %s", spec, model.Provider, model.Model, model.BaseURL)
+	}
+
+	// Nothing but the apiVersion differs between the two lines.
+	delete(currentMC, "apiVersion")
+	delete(legacyMC, "apiVersion")
+	if !reflect.DeepEqual(currentMC, legacyMC) {
+		t.Errorf("the 3.x ModelConfig differs from the 4.x one beyond the apiVersion:\n--- 4.x\n%s\n--- 3.x\n%s", mustYAML(t, currentMC), mustYAML(t, legacyMC))
 	}
 }
 

--- a/internal/lab/templates/extra-models.yaml.tmpl
+++ b/internal/lab/templates/extra-models.yaml.tmpl
@@ -8,9 +8,12 @@
 # The managed-by label scopes pruning: entries removed from agentlab.yaml
 # are deleted on the next run; the chart's default ModelConfig is never
 # touched.
+# The apiVersion is the kagent.dev version the chart line serves: v1alpha3
+# on the kagent line (meta chart >= 4.0), v1alpha2 on a released 3.x chart
+# (kagent 0.10) — the ModelConfig spec is the same in both.
 {{- range .ExtraModels }}
 ---
-apiVersion: kagent.dev/v1alpha2
+apiVersion: {{ if $.LegacyChart }}kagent.dev/v1alpha2{{ else }}kagent.dev/v1alpha3{{ end }}
 kind: ModelConfig
 metadata:
   name: {{ .Name }}


### PR DESCRIPTION
## Problem

`agentlab up` (and `platform`) fail at "Adding extra model configs" on the 4.x line for any lab with `platform.extraModels`:

```
ModelConfig qwen3-8-27b: no matches for kind "ModelConfig" in version "kagent.dev/v1alpha2"
```

`internal/lab/templates/extra-models.yaml.tmpl` hardcoded `apiVersion: kagent.dev/v1alpha2` (the kagent 0.10 version); the kagent line's `kagent-crds` chart (meta chart >= 4.0) serves `v1alpha3` only. The platform itself comes up (every HelmRelease Ready, the chart-rendered default ModelConfig Accepted), but the lab's extra ModelConfigs are never created and `up` exits 1 before its edge/Backstage verification. A lab without `extraModels` never hits it, which is why every proof passed.

## Change

- The template renders the apiVersion the chart line serves: `kagent.dev/v1alpha3` by default, `kagent.dev/v1alpha2` on a legacy 3.x chart (`LegacyChart`, already in the template data). The ModelConfig `spec` is identical between the two versions; nothing else in the object moves. No new config key.
- `ensureExtraModels` / `pruneExtraModels` stay version-agnostic (they resolve `modelconfigs.kagent.dev` through discovery and list by label).
- `docs/models.md`: one sentence on the version the extra ModelConfigs follow.

## Verification

- New unit test `TestExtraModelsAPIVersionFollowsChartLine` (`internal/lab/models_test.go`, next to `TestExtraModelsTemplate`): one `extraModels` entry rendered with `chartVersion: 4.7.15` -> `kagent.dev/v1alpha3`, with `3.24.0` -> `kagent.dev/v1alpha2`, and the two objects are `DeepEqual` once the apiVersion is removed. The test fails against the previous template (`apiVersion = kagent.dev/v1alpha2, want kagent.dev/v1alpha3`).
- `go build ./... && go vet ./... && go test ./...` green; `golangci-lint run -E gosec -E goconst -E govet ./...` 0 issues.
- The live check (`agentlab platform` on a 4.7.15 lab with `extraModels`, each Accepted) is the follow-up on a real lab after this releases.

Fixes giantswarm/agentlab#163
