### PR TITLE
fix(platform): the lab renders an atelet image-cache policy the host disk cannot trigger — watermark 100/99 with a 4 GiB cap; platform-test asserts it on the rolled DaemonSet

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -828,6 +828,31 @@ data the page reads — see [The muster plugin](backstage.md#the-muster-plugin).
   pod -l ate.dev/worker-pool=kagent-default`; the `WorkerPool` recreates
   them, the pending golden actor gets a worker within seconds. A fresh
   install and `platform-down` → `platform` recreate the pods anyway.
+- **The first turn after idling hangs on a full laptop disk — the lab
+  renders an atelet image-cache policy against it.** Substrate's atelet
+  evicts cached images on every GC pass (`--image-cache-gc-period`, 5 min)
+  while its cache volume is at or above `--image-cache-high-percent` (85 %),
+  sparing only records younger than `--image-cache-min-age` (2 min). In the
+  lab that volume is the kind node's root overlay, i.e. the host's disk: on a
+  laptop above 85 % the Harness image is gone five minutes after every turn
+  (atelet log `Image cache evicting image record`), the next turn pulls and
+  unpacks it cold (`Restore timing breakdown` with `oci_unpack` ≈ 5 s), the
+  atenet router's 5 s parked-request budget cancels the restore (ate-api-server
+  `CallAteletRestore … context canceled`) and the agent stays "Working…" —
+  while every turn within five minutes of the previous one works. The lab
+  takes the host disk out of the policy through the chart's
+  `substrate.atelet.extraArgs`: `--image-cache-high-percent=100` and
+  `--image-cache-low-percent=99` (eviction only below 1 % free, where nothing
+  runs anyway) with `--image-cache-max-bytes=4294967296` as the bound instead
+  (4 GiB, some twenty Harness digests, evicted oldest-first past that);
+  period and min-age keep the chart's defaults. `agentlab platform` rolls the
+  atelet DaemonSet to it on an existing lab and `agentlab platform-test`
+  asserts the flags on the rolled DaemonSet. A `platform.valuesFiles` overlay
+  that sets `substrate.atelet.extraArgs` replaces the whole list (Helm merges
+  maps, not lists) — keep the policy and the registry flag in it, or drop the
+  key. The Substrate line's fix (eviction that spares live images, a restore
+  budget that covers a cold start) retires the policy once the meta chart
+  pins that release.
 - **`allowPublicClientRegistration` must be on for Claude Code's login.**
   Claude Code registers over DCR as a public client on a random loopback port,
   so none of the other registration gates can be opened for it: it cannot send

--- a/internal/lab/platformtest.go
+++ b/internal/lab/platformtest.go
@@ -169,6 +169,20 @@ func PlatformTest(cfg *config.Config, email string) error {
 			return err
 		}
 		verdict += "\nPASS: agent-manager writes as the caller — a viewer's create_agent with a forged x-user-id is the apiserver's Forbidden for the viewer"
+		// The lab's atelet image-cache policy, live on the node agents
+		// (ateletImageCacheArgs): without it a laptop above the chart's 85 %
+		// watermark loses the Harness image five minutes after every turn.
+		if version, _ := helmReleaseVersion(substrateNamespace, substrateRelease); version != "" {
+			step("Verifying the atelet DaemonSet carries the lab's image-cache policy %s", strings.Join(ateletImageCacheArgs, " "))
+			ctx, cancel := context.WithTimeout(context.Background(), kubeReadTimeout)
+			ready, err := proveAteletImageCachePolicy(ctx)
+			cancel()
+			if err != nil {
+				return err
+			}
+			note("atelet %s/%s: the policy flags on all %d ready pods", substrateNamespace, ateletDaemonSet, ready)
+			verdict += "\nPASS: atelet carries the lab's image-cache policy (the host disk cannot evict the Harness image; a 4 GiB cap bounds the cache)"
+		}
 	}
 
 	// The per-server sign-in path: muster as OAuth client, challenged by the

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -97,6 +97,10 @@ type tmplData struct {
 	// whenever the agents are, so the flag is in place before any swap.
 	HarnessDevImage       string
 	LocalRegistryEndpoint string
+	// AteletImageCacheArgs is the lab's atelet image-cache policy
+	// (ateletImageCacheArgs, substrate.go), rendered after the registry flag
+	// in the same substrate.atelet.extraArgs list.
+	AteletImageCacheArgs []string
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -127,6 +131,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		MCPPrometheusPostRenderers: strings.TrimRight(string(mcpPrometheus), "\n"),
 		MCPPrometheusChartVersion:  mcpPrometheusChartVersion,
 		LocalRegistryEndpoint:      devRegistryEndpoint(cfg),
+		AteletImageCacheArgs:       ateletImageCacheArgs,
 		ModelManagerEnabled:        cfg.ModelManagerEnabled(),
 		LegacyChart:                cfg.LegacyChart(),
 		ModelManagerBackends:       cfg.Platform.ModelManager.Backends,

--- a/internal/lab/render_test.go
+++ b/internal/lab/render_test.go
@@ -452,8 +452,11 @@ func TestPlatformValuesFourXTopology(t *testing.T) {
 	// The lab registry rewrite rides in the same substrate block (a second
 	// `substrate:` key would replace the first in the values merge) and the
 	// Harness keeps the chart's digest until a `harness` dev image pins it.
-	if args, _ := at("substrate", "atelet", "extraArgs").([]any); len(args) != 1 || args[0] != "--localhost-registry-replacement=agentlab-registry:5000" {
-		t.Errorf("substrate.atelet.extraArgs = %v, want only the lab registry rewrite", args)
+	// The image-cache policy (ateletImageCacheArgs) follows it in the same
+	// list — the host disk must not evict the Harness image.
+	wantArgs := append([]any{testRegistryFlag}, anySlice(ateletImageCacheArgs)...)
+	if args, _ := at("substrate", "atelet", "extraArgs").([]any); !reflect.DeepEqual(args, wantArgs) {
+		t.Errorf("substrate.atelet.extraArgs = %v, want the lab registry rewrite then the image-cache policy %v", args, wantArgs)
 	}
 	if at("kagent", "harness", "image") != nil {
 		t.Errorf("kagent.harness.image = %v, want the chart's pin without a harness dev image", at("kagent", "harness", "image"))

--- a/internal/lab/substrate.go
+++ b/internal/lab/substrate.go
@@ -3,6 +3,9 @@ package lab
 import (
 	"context"
 	"fmt"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Agent Substrate is kagent API v2's actor runtime: WorkerPools of sandboxed
@@ -46,4 +49,81 @@ func preflightPodCertificateAPI(ctx context.Context) error {
 			"cluster predates them — feature gates are fixed at kind create, so run `agentlab down && agentlab up`", err)
 	}
 	return nil
+}
+
+// ateletImageCacheArgs is the lab's atelet image-cache policy, rendered into
+// substrate.atelet.extraArgs (agent-platform-values.yaml.tmpl) and asserted
+// on the DaemonSet by `agentlab platform-test` (proveAteletImageCachePolicy).
+//
+// atelet evicts cached images on every GC pass (--image-cache-gc-period, 5
+// min) while the cache volume is at or above --image-cache-high-percent (85
+// by default) and spares only records younger than --image-cache-min-age. In
+// the lab the cache dir (/var/lib/ateom-gvisor/image-cache) sits on the kind
+// node's root overlay, which is the host's disk — on a laptop above 85 % the
+// Harness image is gone five minutes after every turn, the next turn pays a
+// cold pull and unpack that overruns the atenet router's parked-request
+// budget, and the agent stays "Working…" forever (agentlab#169). The lab
+// therefore takes the host disk out of the policy: the watermark moves to
+// 100 (eviction only when the host has < 1 % free, where nothing runs
+// anyway; low must stay below high) and an absolute cap bounds the cache
+// instead — 4 GiB holds some twenty Harness digests (~50 MiB compressed, 3
+// layers), evicted oldest-first past that. The period and min-age keep the
+// chart's defaults so the cap is enforced. The Substrate line's fix
+// (eviction sparing live images, a budget that covers a cold start) retires
+// this policy once the meta chart pins it.
+var ateletImageCacheArgs = []string{
+	"--image-cache-high-percent=100",
+	"--image-cache-low-percent=99",
+	"--image-cache-max-bytes=4294967296",
+}
+
+// ateletDaemonSet is the substrate chart's per-node agent (templates/atelet.yaml).
+const ateletDaemonSet = "atelet"
+
+// proveAteletImageCachePolicy asserts the atelet DaemonSet carries every flag
+// of ateletImageCacheArgs and that its pods have rolled to that spec — the
+// live half of the policy: values that render but never reach the node
+// would leave the eviction in place. Returns the number of ready pods.
+func proveAteletImageCachePolicy(ctx context.Context) (int64, error) {
+	gvr, err := gvrFor("daemonsets.apps")
+	if err != nil {
+		return 0, err
+	}
+	ds, err := getObject(ctx, gvr, substrateNamespace, ateletDaemonSet)
+	if err != nil {
+		return 0, fmt.Errorf("reading the %s DaemonSet in %s: %w", ateletDaemonSet, substrateNamespace, err)
+	}
+	if missing := ateletArgsMissing(ds); len(missing) > 0 {
+		return 0, fmt.Errorf("the %s DaemonSet lacks the lab's image-cache policy %v — a platform.valuesFiles overlay that sets substrate.atelet.extraArgs replaces the list (Helm merges maps, not lists); add the flags to the overlay's list or drop the key, then `agentlab platform`",
+			ateletDaemonSet, missing)
+	}
+	desired, _, _ := unstructured.NestedInt64(ds.Object, "status", "desiredNumberScheduled")
+	updated, _, _ := unstructured.NestedInt64(ds.Object, "status", "updatedNumberScheduled")
+	ready, _, _ := unstructured.NestedInt64(ds.Object, "status", "numberReady")
+	if desired == 0 || updated < desired || ready < desired {
+		return 0, fmt.Errorf("the %s DaemonSet carries the policy but has not rolled to it (desired %d, updated %d, ready %d) — `kubectl -n %s rollout status ds/%s`",
+			ateletDaemonSet, desired, updated, ready, substrateNamespace, ateletDaemonSet)
+	}
+	return ready, nil
+}
+
+// ateletArgsMissing is the policy flags the DaemonSet's atelet container does
+// not carry, in policy order; empty when it carries them all.
+func ateletArgsMissing(ds *unstructured.Unstructured) []string {
+	var args []any
+	containers, _, _ := unstructured.NestedSlice(ds.Object, "spec", "template", "spec", "containers")
+	for _, c := range containers {
+		container, _ := c.(map[string]any)
+		if container["name"] == ateletDaemonSet {
+			args, _ = container["args"].([]any)
+			break
+		}
+	}
+	var missing []string
+	for _, want := range ateletImageCacheArgs {
+		if !slices.Contains(args, any(want)) {
+			missing = append(missing, want)
+		}
+	}
+	return missing
 }

--- a/internal/lab/substrate_test.go
+++ b/internal/lab/substrate_test.go
@@ -2,8 +2,11 @@ package lab
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // A cluster without the certificates.k8s.io/v1beta1 API is refused before
@@ -13,5 +16,45 @@ func TestSubstratePreflightWithoutTheAPI(t *testing.T) {
 	err := preflightPodCertificateAPI(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "agentlab down && agentlab up") {
 		t.Errorf("want the recreate hint, got %v", err)
+	}
+}
+
+// testRegistryFlag is the lab registry rewrite the values render ahead of
+// the image-cache policy (registryFlag on the default config).
+const testRegistryFlag = "--localhost-registry-replacement=agentlab-registry:5000"
+
+// anySlice is a []string as the YAML decoder hands a list back.
+func anySlice(s []string) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
+
+func TestAteletArgsMissing(t *testing.T) {
+	ds := func(args ...string) *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			fieldSpec: map[string]any{"template": map[string]any{fieldSpec: map[string]any{
+				"containers": []any{
+					map[string]any{nameKey: "sidecar", argsKey: anySlice(ateletImageCacheArgs)},
+					map[string]any{nameKey: ateletDaemonSet, argsKey: anySlice(args)},
+				},
+			}}},
+		}}
+	}
+	registry := testRegistryFlag
+	// The rendered list: the registry flag, then the policy.
+	if got := ateletArgsMissing(ds(append([]string{registry}, ateletImageCacheArgs...)...)); len(got) != 0 {
+		t.Errorf("a DaemonSet carrying the policy: missing = %v, want none", got)
+	}
+	// A platform.valuesFiles overlay that replaced the list: every policy flag
+	// is reported (another container's args do not count), in policy order.
+	if got := ateletArgsMissing(ds(registry)); !reflect.DeepEqual(got, ateletImageCacheArgs) {
+		t.Errorf("a DaemonSet without the policy: missing = %v, want %v", got, ateletImageCacheArgs)
+	}
+	// A partial list names what is left.
+	if got := ateletArgsMissing(ds(registry, ateletImageCacheArgs[0])); !reflect.DeepEqual(got, ateletImageCacheArgs[1:]) {
+		t.Errorf("a DaemonSet with one policy flag: missing = %v, want %v", got, ateletImageCacheArgs[1:])
 	}
 }

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -343,9 +343,19 @@ substrate:
   # carry it — the connectivity release (the Harness) and the substrate
   # release (atelet) reconcile independently. The registry container itself
   # is created on the first swap.
+  #
+  # The image-cache policy that follows takes the host disk out of atelet's
+  # eviction: the cache dir is the kind node's root overlay, i.e. the host's
+  # disk, and above the chart's 85 % watermark every GC pass (5 min) would
+  # evict the Harness image and the next turn's cold restore overruns the
+  # router's budget (ateletImageCacheArgs, substrate.go; docs/platform.md
+  # "Platform gotchas"). platform-test asserts the flags on the DaemonSet.
   atelet:
     extraArgs:
       - --localhost-registry-replacement={{ .LocalRegistryEndpoint }}
+{{- range .AteletImageCacheArgs }}
+      - {{ . }}
+{{- end }}
 {{- end }}
 
 kagent:


### PR DESCRIPTION
## Problem

Substrate's atelet evicts cached images on every GC pass (`--image-cache-gc-period`, 5 min) while its cache volume is at or above `--image-cache-high-percent` (85), sparing only records younger than `--image-cache-min-age` (2 min). In the lab the cache dir (`/var/lib/ateom-gvisor/image-cache`) sits on the kind node's root overlay — the host's disk. On a laptop above 85 % (a 1.9 TB disk with 270 GB free, this one) every Harness image is gone five minutes after a turn (`Image cache evicting image record`), the next turn pulls and unpacks it cold (`Restore timing breakdown` with `oci_unpack` 4.99 s of `total` 4.99 s), the atenet router's 5 s parked-request budget cancels the restore (`CallAteletRestore … context canceled`) and the person sees the agent "Working…" forever. Every turn within five minutes of the previous one works, which is why the proofs pass and the manual test fails. The platform fix is the Substrate line's; the lab must not depend on a person's disk usage in the meantime.

## Change

- `internal/lab/substrate.go`: `ateletImageCacheArgs`, the lab's policy, defined once: `--image-cache-high-percent=100 --image-cache-low-percent=99 --image-cache-max-bytes=4294967296`. The watermark check is `usedPct >= highPct` on the cache volume, so 100 fires only below 1 % free (19 GB on this disk — nothing runs there anyway; `low` must stay below `high`, so 99). The 4 GiB cap is the bound instead: the Harness image is 3 layers, ~52 MiB compressed, so the cap holds some twenty digests, evicted oldest-first past that. `--image-cache-gc-period` and `--image-cache-min-age` keep the chart's defaults so the cap is enforced (`0` would switch the pass — and the cap — off). `proveAteletImageCachePolicy` reads the `atelet` DaemonSet in `ate-system`, requires every flag on the atelet container and the pods rolled to the spec (`updatedNumberScheduled` and `numberReady` at `desiredNumberScheduled`).
- `internal/lab/templates/agent-platform-values.yaml.tmpl` / `render.go`: the flags render after `--localhost-registry-replacement` in the same `substrate.atelet.extraArgs` list (the meta chart forwards the `substrate:` block verbatim — `components.substrate.valuesFrom: substrate`, no `omitKeys`, checked at 4.7.15 — and the substrate chart appends `atelet.extraArgs` to the DaemonSet's args).
- `internal/lab/platformtest.go`: with the agents on and a `substrate` release present, a step asserts the policy on the rolled DaemonSet, with the `platform.valuesFiles` remedy in the failure (an overlay that sets `substrate.atelet.extraArgs` replaces the list — Helm merges maps, not lists).
- `docs/platform.md` "Platform gotchas": symptom → cause → what the lab sets, and the note that the Substrate line's fix retires the policy once the meta chart pins it.
- Tests: `TestPlatformValuesLabShape` expects the registry flag then the policy; `TestAteletArgsMissing` covers the DaemonSet check (all present, list replaced, partial).

Closes #169

## Test plan

- [x] `go test ./...`, `pre-commit run --all-files` green
- [x] Lab proof on an existing lab (chart 4.7.15, Substrate v0.0.27-gs.5, host disk at 86 % throughout, `agentlab.yaml` unchanged), 2026-09-12:
  - `agentlab platform` with this branch's binary (exit 0, 09:41:56Z) rolled atelet: pod `atelet-g8jfs` from 09:41:46Z, DaemonSet `desired=updated=ready=1`, args end in `--localhost-registry-replacement=agentlab-registry:5000 --image-cache-high-percent=100 --image-cache-low-percent=99 --image-cache-max-bytes=4294967296`
  - `agentlab platform-test` exit 0 with the new step: `atelet ate-system/atelet: the policy flags on all 1 ready pods` → `PASS: atelet carries the lab's image-cache policy …` (all nine PASS lines)
  - 09:42:55Z first turn after the atelet restart, cache empty: `Image cache miss`, `Restore timing breakdown oci_unpack=4.988 total=4.991`, `request timed out` — the cold start the policy guards against (the Substrate line's fix); the pull landed (`Image pulled into layer cache took 5.44s`)
  - 09:43:24Z warm turn: `Image cache hit`, `oci_unpack=0.000648 total=0.2547`, `pong` in 3.9 s
  - ten idle minutes (`sleep 610`, two GC passes): **no** `Image cache evicting image record` in the atelet log
  - 09:54:08Z turn: `Image cache hit`, `Restore timing breakdown oci_unpack=0.003822 download=0.065488 ateom_restore=0.356512 total=0.434319`, `state: completed`, `elapsed: 2.741s`, `answer: pong`, instance deleted — before this change the same lab evicted the image on every pass and the next turn was cancelled at 4.99 s
