### PR TITLE
feat: a GitHub token from $GITHUB_TOKEN for the portal and agent-manager; the proofs print the GitHub API window before resolving skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ it touches anything (see [Docker resources](docs/getting-started.md#docker-resou
 go install github.com/giantswarm/agentlab@latest   # or a release binary, or `go build -o agentlab .`
 
 export ANTHROPIC_API_KEY=sk-ant-...   # optional: powers the agents and Backstage's AI chat
+export GITHUB_TOKEN=github_pat_...    # optional: skill discovery/resolution call GitHub authenticated (5000/h, not 60/h)
 agentlab configure --defaults         # drop --defaults for the interactive form
 agentlab up                           # certs, kind cluster, Dex, RBAC, the platform — verified
 agentlab open portal                  # the portal in your browser (the URL is printed too)

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -96,6 +96,41 @@ The same key powers Backstage's AI chat via a second Secret,
 Further models — the host model servers through model-manager,
 `platform.extraModels` — are their own ModelConfigs; see [Models](models.md).
 
+## The GitHub token
+
+Two consumers of the lab resolve skills through GitHub's REST API: the
+portal's skill discovery (`GET /api/gs/agent-skills?repoUrl=…`, the create
+wizard's skills step) and agent-manager (`list_skills`, the commit
+`create_agent` pins a branch to, `refreshSkills`, the migrate Job of the
+cut-over). Without a token GitHub allows 60 requests an hour **per egress
+address**, and the kind cluster shares this machine's — a handful of
+`backstage-test` runs within an hour exhaust it, after which discovery comes
+back truncated (the proof refuses that by name) until the window resets.
+
+`$GITHUB_TOKEN` on the host lifts that: `agentlab up`/`platform` create **or
+update** the Secret `agentlab-github-token` (key `GITHUB_TOKEN`) in
+`agent-platform` — the portal takes it through `extraEnvVarsSecrets` and the
+lab's app-config overlay (`integrations.github[].token: ${GITHUB_TOKEN}`),
+agent-manager through the chart's `skills.github.tokenSecret` — and in
+`kagent` for the migrate Job (`agentManager.migration.githubToken`), which then
+call GitHub authenticated (5000 requests an hour; the rate-limit headers say
+so). A fine-grained token with public read access is enough; a token that
+reads a private skill repository lets agent-manager resolve skills from it.
+As with the Anthropic key, the token is a real credential: it travels host
+environment -> Secret and never enters `agentlab.yaml`, `state/` (the
+rendered values carry the Secret's *name*), a log line or a process's argv.
+Re-running with a new token rotates the Secret.
+
+Without the variable the lab is as before: the values name no Secret, the
+consumers call GitHub unauthenticated, and a Secret an earlier run created
+stays — unreferenced — until `agentlab down` (a run that merely lacks the
+export never deletes a credential; `kubectl -n agent-platform delete secret
+agentlab-github-token` does). `backstage-test`, `agents-test` and the
+rehearsal print the window before their first skill-resolving step
+(`GitHub API window (unauthenticated: this machine's shared window): 12 of 60
+requests remaining, resets 14:32:10 CEST`) and, when it is exhausted, wait once
+until the reset instead of failing on a truncated listing.
+
 ## The UI and the controller's route
 
 The kagent UI is host-published like the other components:

--- a/docs/backstage.md
+++ b/docs/backstage.md
@@ -153,7 +153,12 @@ what the proof checks is what the portal shows.
 **The create path** (as the first `platform-admins` user):
 
 - skill discovery for `https://github.com/giantswarm/agent-skills` — every
-  entry carries the listing's head commit as a full id;
+  entry carries the listing's head commit as a full id. The portal reads
+  GitHub for this, so the proof first prints the GitHub API window it shares
+  with this machine (authenticated when `$GITHUB_TOKEN` is set — see
+  [The GitHub token](agents.md#the-github-token)) and, when the window is
+  exhausted, waits once for its reset; a listing GitHub truncated is refused
+  by name, never asserted on;
 - `get_info` and `list_model_configs` through the portal;
 - the dry run (`validate_agent`): valid, mode `create`, the `OCIRepository` at
   `1.x`, the `HelmRelease` as `kagent-flux`, `values.agent.harness` = the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -106,13 +106,13 @@ The flags pin a value regardless of the discovery, with or without
 | Variable | Read by | Effect |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | `up`, `platform` | Becomes the Secrets `kagent/kagent-anthropic` and `backstage/backstage-anthropic` at deploy time; never written to `agentlab.yaml` or `state/`. See [Agents](agents.md). |
+| `GITHUB_TOKEN` | `up`, `platform`, `backstage-test`, `agents-test`, the rehearsal, the update check | Becomes the Secret `agentlab-github-token` (key `GITHUB_TOKEN`) in `agent-platform` and `kagent` at deploy time — created or updated, so a re-run rotates it — and the values name that Secret for the portal's skill discovery, agent-manager's skill resolution and the migrate Job, which then call GitHub authenticated (5000 requests an hour instead of the 60 this machine's address shares). Never written to `agentlab.yaml` or `state/`. Unset: the lab is as before, the Secret of an earlier run stays unreferenced, and the proofs print the remaining unauthenticated window before resolving skills. See [Agents](agents.md#the-github-token). |
 | `<name>` per `extraModels[].apiKeyEnv` | `up`, `platform` | The key for that model config, same handling. See [Models](models.md). |
 | `NODE_USE_SYSTEM_CA=1` | Node >= 22.15, Claude Code | Makes Node honor the system trust store after `agentlab trust`. Older Node: `NODE_EXTRA_CA_CERTS=$PWD/certs/ca.crt`. See [TLS](tls.md). |
 | `KUBECONFIG` | your shell | Ignored by the lab: its embedded Helm and Kubernetes client are built from `state/kubeconfig` alone. `KUBECONFIG=state/kubeconfig kubectl ...` is the lab's view from a shell. |
 | `AGENTLAB_TELEMETRY_OPTOUT`, `DO_NOT_TRACK=1` | every command | Disable the anonymous usage signal. See [Usage data](telemetry.md). |
 | `AGENTLAB_TELEMETRY_TESTMODE=1` | every command | File the signals as test data and log delivery errors, for work on the lab itself. |
 | `AGENTLAB_NO_UPDATE_CHECK=1` | every command | Silence the newer-release hint (below). |
-| `GITHUB_TOKEN` | the update check | Lifts GitHub's anonymous rate limit; nothing else. |
 
 ## Keeping agentlab current
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -137,6 +137,7 @@ Then bring the lab up:
 
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...   # optional: powers the agents + Backstage AI chat
+export GITHUB_TOKEN=github_pat_...    # optional: skill discovery/resolution call GitHub authenticated (5000/h, not 60/h)
 ./agentlab configure       # interactive form: cluster, users, components
 ./agentlab up              # certs, kind cluster, Dex, RBAC, the agent platform — verified
 ./agentlab open portal     # the portal (Backstage) in the browser; `open agents` the kagent UI
@@ -192,6 +193,7 @@ Discovering this machine:
   Lemonade Server   11.9.0 on :13305 — answers on 172.21.0.1 (the address pods dial): yes; 4 downloaded, 3 tool-calling
   LM Studio         api v1 on :1234 — answers on 172.21.0.1 (the address pods dial): yes; 6 downloaded, 4 tool-calling
   Anthropic key     $ANTHROPIC_API_KEY is set — the agents' default ModelConfig and Backstage's AI chat get the real key at deploy time
+  GitHub token      $GITHUB_TOKEN is set — the portal's skill discovery and agent-manager's skill resolution call GitHub authenticated (5000 requests an hour) from deploy time
 
 Applied to the configuration:
   platform.modelManager.backends: [ollama] -> [ollama, lemonade, lmstudio]
@@ -239,6 +241,10 @@ Applied to the configuration:
   that trusted the code would find an Ollama on every LM Studio port.
 - **`$ANTHROPIC_API_KEY`**: whether it is exported, since the agents'
   default ModelConfig and Backstage's AI chat take it at deploy time.
+- **`$GITHUB_TOKEN`**: whether it is exported, since the portal's skill
+  discovery and agent-manager's skill resolution take it at deploy time and
+  otherwise share this machine's unauthenticated GitHub window (60 requests
+  an hour). See [Agents](agents.md#the-github-token).
 
 Pins override the discovery for that run: `--model-manager[=false]` decides
 the flag regardless of what answers, `--model-manager-backends ollama,lmstudio`

--- a/docs/migration-rehearsal.md
+++ b/docs/migration-rehearsal.md
@@ -44,7 +44,14 @@ The recipe needs **agentlab v0.39.1 or newer** — the release that renders the
 carries `agentlab turn` (the one this page ships with). A mikefarah `yq` v4,
 `kubectl`, `helm`, `jq` and `kind` on the machine; the Anthropic key is read
 from the Secret `kagent/kagent-anthropic` of the running lab unless
-`ANTHROPIC_API_KEY` is set, and never printed.
+`ANTHROPIC_API_KEY` is set, and never printed. The migrate Job resolves every
+seeded skill through GitHub: with `GITHUB_TOKEN` exported when `upgrade.sh`
+runs `agentlab platform`, the Job (and agent-manager) call GitHub
+authenticated through the Secret the lab creates (see
+[The GitHub token](agents.md#the-github-token)); either way `upgrade.sh` and
+`contract.sh` print the GitHub API window before the Job runs and wait once
+for its reset when it is exhausted (`lib.sh github_window`; the token is never
+logged).
 
 ```sh
 cd <lab dir>                      # agentlab.yaml, state/, certs/

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -209,6 +209,7 @@ registry.
 ```bash
 agentlab configure --defaults --chart-branch my-feature
 export ANTHROPIC_API_KEY=sk-ant-...
+export GITHUB_TOKEN=github_pat_...   # optional: the proofs' skill discovery/resolution off the 60/h window (agents.md)
 agentlab up
 agentlab platform-test && agentlab test && agentlab backstage-test
 ```

--- a/hack/migration-rehearsal/contract.sh
+++ b/hack/migration-rehearsal/contract.sh
@@ -328,6 +328,7 @@ main() {
     # the AgentTemplate in the Agent's place) is what the contract phase sweeps.
     kubectl -n "$NS" get agents.kagent.dev -o name 2>/dev/null | sed 's#.*/##' | sort >|"$EVIDENCE/before-run2-v1alpha2-agents.txt" || true
     log "  v1alpha2 Agents left for the contract phase: [$(paste -sd, "$EVIDENCE/before-run2-v1alpha2-agents.txt")]"
+    github_window "the contract phase's migrate Job (it resolves every skill through GitHub)"
     run_migrate agent-manager-migrate-2
     report=$EVIDENCE/agent-manager-migrate-2-report.json
     if [[ $(jq -r .phase "$report") == wait ]]; then

--- a/hack/migration-rehearsal/lib.sh
+++ b/hack/migration-rehearsal/lib.sh
@@ -91,6 +91,47 @@ scrub_key() {
   fi
 }
 
+# ----------------------------------------------------------------- github ---
+
+# github_window <what>: print GitHub's core API window before a step that
+# resolves skills through GitHub (the migrate Job, agent-manager), the way
+# `agentlab backstage-test` and `agents-test` do. Authenticated with
+# GITHUB_TOKEN from the environment, else with the lab's own Secret
+# agent-platform/agentlab-github-token when `agentlab platform` created one;
+# the token reaches curl through a header file, never argv, and is never
+# logged. An exhausted window is waited out once (bounded to an hour and a
+# bit) rather than failing later on a truncated resolution; an endpoint that
+# cannot be read is a log line, never a failure.
+github_window() {
+  local what="$1" token="${GITHUB_TOKEN:-}" who json limit remaining reset wait
+  if [ -z "$token" ]; then
+    token=$(kubectl -n agent-platform get secret agentlab-github-token -o jsonpath='{.data.GITHUB_TOKEN}' 2>/dev/null | base64 -d 2>/dev/null || true)
+  fi
+  who="unauthenticated: this machine's shared window"
+  if [ -n "$token" ]; then
+    who="authenticated with GITHUB_TOKEN"
+    json=$(curl -sS --max-time 15 -H 'Accept: application/vnd.github+json' \
+      -H @<(printf 'Authorization: Bearer %s\n' "$token") https://api.github.com/rate_limit 2>/dev/null) || json=''
+  else
+    json=$(curl -sS --max-time 15 -H 'Accept: application/vnd.github+json' https://api.github.com/rate_limit 2>/dev/null) || json=''
+  fi
+  limit=$(jq -r '.resources.core.limit // empty' <<<"$json" 2>/dev/null || true)
+  remaining=$(jq -r '.resources.core.remaining // empty' <<<"$json" 2>/dev/null || true)
+  reset=$(jq -r '.resources.core.reset // empty' <<<"$json" 2>/dev/null || true)
+  if ! [[ $remaining =~ ^[0-9]+$ && $reset =~ ^[0-9]+$ ]]; then
+    log "GitHub API window not read; $what proceeds without it"
+    return 0
+  fi
+  log "GitHub API window ($who): $remaining of $limit requests remaining, resets $(date -d "@$reset" +%H:%M:%S)"
+  if (( remaining == 0 )); then
+    wait=$(( reset - $(now) + 5 ))
+    (( wait < 0 )) && wait=0
+    (( wait > 3900 )) && wait=3900
+    log "the window is exhausted — waiting ${wait}s for it to reset at $(date -d "@$reset" +%H:%M:%S) before $what (one bounded wait; export GITHUB_TOKEN to lift it to 5000 an hour)"
+    sleep "$wait"
+  fi
+}
+
 # ------------------------------------------------------------------ tools ---
 
 pick_yq() { # prints the first mikefarah yq v4 found (YQ, yq, ~/.go/bin/yq, go-yq)

--- a/hack/migration-rehearsal/upgrade.sh
+++ b/hack/migration-rehearsal/upgrade.sh
@@ -250,6 +250,9 @@ step_upgrade() {
   status "LAB UPGRADING in place $BEFORE_VERSION → $TARGET (agentlab platform, lock held)"
   rm -f "$EVIDENCE/TRAP"
   local t0 pid rc=0 trap_seen='' waited=0
+  # The connectivity release's migrate Job resolves every seeded skill
+  # through GitHub as part of this upgrade.
+  github_window "the upgrade's migrate Job"
   t0=$(now)
   timeout 1500 "$AGENTLAB" platform --trust=false --open=false >"$EVIDENCE/platform.log" 2>&1 &
   pid=$!

--- a/internal/lab/agentstest.go
+++ b/internal/lab/agentstest.go
@@ -159,6 +159,12 @@ func AgentsTest(cfg *config.Config, email string) error {
 	defer cleanup()
 
 	step("%slist_skills — the head commit of %s (the commit refreshSkills re-pins to)", agentManagerToolPrefix, fixture.Repo)
+	// agent-manager reads GitHub for this and for the create_agent pin
+	// below; its window is this machine's (githubwindow.go) — printed, and
+	// waited for once when exhausted.
+	if err := awaitGitHubWindow("agent-manager's skill resolution"); err != nil {
+		return err
+	}
 	head, err := agentManagerSkillHead(session, fixture)
 	if err != nil {
 		return err

--- a/internal/lab/backstagetest_create.go
+++ b/internal/lab/backstagetest_create.go
@@ -337,6 +337,12 @@ func proveCreatePath(primary, viewer *portalSession) (agentSpec, *agentTemplate,
 	}
 
 	step("Skill discovery through the portal: GET %s for %s, every skill pinned to the head commit", portalSkillsPath, skillsTestRepo)
+	// The portal reads GitHub for this; its window is this machine's
+	// (githubwindow.go) — printed, and waited for once when exhausted, rather
+	// than failing on the truncated listing below.
+	if err := awaitGitHubWindow("the portal's skill discovery"); err != nil {
+		return fail(err)
+	}
 	discovery, err := discoverSkills(primary, skillsTestRepo)
 	if err != nil {
 		return fail(err)

--- a/internal/lab/discover.go
+++ b/internal/lab/discover.go
@@ -29,6 +29,7 @@ import (
 type Discovery struct {
 	Tools         []ToolVersion
 	AnthropicKey  bool
+	GitHubToken   bool
 	ClusterExists bool
 	ClusterPorts  map[int]bool
 	KindGateway   string
@@ -92,7 +93,7 @@ const flmOwner = "FastFlowLM"
 // Discover probes this machine. Nothing here needs the cluster; every probe
 // is loopback or a local CLI and degrades to "not found".
 func Discover(cfg *config.Config) *Discovery {
-	d := &Discovery{AnthropicKey: os.Getenv(AnthropicKeyEnv) != ""}
+	d := &Discovery{AnthropicKey: os.Getenv(AnthropicKeyEnv) != "", GitHubToken: gitHubTokenSet()}
 	d.Tools = toolVersions(dockerVersion())
 	d.ClusterExists, d.ClusterPorts = kindNodePublishedPorts(cfg.ControlPlaneNode())
 	if gw, err := kindGatewayIP(cfg.ControlPlaneNode()); err == nil {
@@ -273,6 +274,11 @@ func (d *Discovery) Report(cfg *config.Config) string {
 		line("Anthropic key", "$%s is set — the agents' default ModelConfig and Backstage's AI chat get the real key at deploy time", AnthropicKeyEnv)
 	} else {
 		line("Anthropic key", "$%s is not set — the default ModelConfig and Backstage's AI chat get a placeholder until it is exported and `agentlab platform` re-runs", AnthropicKeyEnv)
+	}
+	if d.GitHubToken {
+		line("GitHub token", "$%s is set — the portal's skill discovery and agent-manager's skill resolution call GitHub authenticated (5000 requests an hour) from deploy time", GitHubTokenEnv)
+	} else {
+		line("GitHub token", "$%s is not set — skill discovery and resolution share this machine's unauthenticated GitHub window (60 requests an hour) until it is exported and `agentlab platform` re-runs", GitHubTokenEnv)
 	}
 	return b.String()
 }

--- a/internal/lab/githubtoken.go
+++ b/internal/lab/githubtoken.go
@@ -15,7 +15,7 @@ import (
 // environment -> Kubernetes Secret only and never enters agentlab.yaml, the
 // rendered state/ files, a log line or a process's argv. The same variable
 // lifts the anonymous rate limit of the self-update check (internal/update).
-const GitHubTokenEnv = "GITHUB_TOKEN"
+const GitHubTokenEnv = "GITHUB_TOKEN" // #nosec G101 -- env var NAME, not a credential
 
 // gitHubTokenSecret is the Secret the consumers read — one key, named after
 // the env var so Backstage's envFrom yields $GITHUB_TOKEN as it is:
@@ -29,7 +29,7 @@ const GitHubTokenEnv = "GITHUB_TOKEN"
 // name the Secret only when the variable is set at render time, so a render
 // and the Secret always agree on one environment.
 const (
-	gitHubTokenSecret    = "agentlab-github-token"
+	gitHubTokenSecret    = "agentlab-github-token" // #nosec G101 -- Secret NAME, not a credential
 	gitHubTokenSecretKey = GitHubTokenEnv
 )
 

--- a/internal/lab/githubtoken.go
+++ b/internal/lab/githubtoken.go
@@ -1,0 +1,95 @@
+package lab
+
+import (
+	"context"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// GitHubTokenEnv is where the lab reads a GitHub token from at deploy time
+// (`agentlab up`/`platform`) and before the proofs that resolve skills. Like
+// the Anthropic key (anthropic.go) it is a real credential: it travels host
+// environment -> Kubernetes Secret only and never enters agentlab.yaml, the
+// rendered state/ files, a log line or a process's argv. The same variable
+// lifts the anonymous rate limit of the self-update check (internal/update).
+const GitHubTokenEnv = "GITHUB_TOKEN"
+
+// gitHubTokenSecret is the Secret the consumers read — one key, named after
+// the env var so Backstage's envFrom yields $GITHUB_TOKEN as it is:
+//   - agent-platform/: the portal (backstage.backstage.extraEnvVarsSecrets,
+//     read by the overlay's integrations.github[].token: ${GITHUB_TOKEN})
+//     and agent-manager (agent-manager.skills.github.tokenSecret);
+//   - kagent/: the connectivity chart's agent-manager migrate Job
+//     (agentManager.migration.githubToken).
+//
+// The values (agent-platform-values.yaml.tmpl, backstage-catalog.yaml.tmpl)
+// name the Secret only when the variable is set at render time, so a render
+// and the Secret always agree on one environment.
+const (
+	gitHubTokenSecret    = "agentlab-github-token"
+	gitHubTokenSecretKey = GitHubTokenEnv
+)
+
+// gitHubTokenSet reports whether the host environment carries a GitHub token
+// — the one input the render and the Secret creation decide on.
+func gitHubTokenSet() bool { return os.Getenv(GitHubTokenEnv) != "" }
+
+// gitHubTokenWired is the render's answer: the token is set and the chart
+// line takes the keys (the 4.x agent-manager chart's skills.github.tokenSecret
+// and the connectivity chart's agentManager.migration.githubToken; the 3.x
+// line the rehearsal seeds has neither, and its portal has no discovery to
+// authenticate).
+func gitHubTokenWired(cfg *config.Config) bool { return gitHubTokenSet() && !cfg.LegacyChart() }
+
+// ensureGitHubTokenSecrets is the deploy-time half, run before the install:
+// agent-platform/ always (the portal's envFrom and agent-manager's env
+// reference the Secret without `optional`, so it must exist before the pods
+// do), kagent/ when that namespace already exists — a re-run, or the
+// rehearsal's upgrade of a seeded lab; a first install gets it after the
+// chart created the namespace (platform.go, next to kagent-anthropic).
+//
+// Without the variable nothing is written: the values rendered from the same
+// environment reference no Secret, so the consumers call GitHub
+// unauthenticated — the lab's behaviour before the token — and a Secret an
+// earlier run created stays, unreferenced, until `agentlab down`: a run that
+// merely lacks an export never destroys a credential. The proofs' window
+// print (githubwindow.go) is where the difference shows.
+func ensureGitHubTokenSecrets(ctx context.Context, cfg *config.Config) error {
+	if !gitHubTokenSet() {
+		if exists, err := objectExists(ctx, gvrSecrets, platformNamespace, gitHubTokenSecret); err == nil && exists {
+			note("$%s is not set — secret %s/%s from an earlier run stays, but nothing references it: GitHub is called unauthenticated (60 requests an hour, shared by this machine)", GitHubTokenEnv, platformNamespace, gitHubTokenSecret)
+		}
+		return nil
+	}
+	if err := ensureGitHubTokenSecret(ctx, platformNamespace); err != nil {
+		return err
+	}
+	if !cfg.Platform.Agents {
+		return nil
+	}
+	exists, err := objectExists(ctx, gvrNamespaces, "", kagentNamespace)
+	if err != nil || !exists {
+		return err
+	}
+	return ensureGitHubTokenSecret(ctx, kagentNamespace)
+}
+
+// ensureGitHubTokenSecret creates or updates ns/gitHubTokenSecret from the
+// host environment — an update, unlike the Anthropic Secret, so a re-run with
+// a new token rotates it; a no-op without the variable.
+func ensureGitHubTokenSecret(_ context.Context, ns string) error {
+	token := os.Getenv(GitHubTokenEnv)
+	if token == "" {
+		return nil
+	}
+	// Applied in-process, so the token never appears in a process's argv or
+	// in a file; server-side apply creates or updates.
+	if err := ensureSecret(ns, gitHubTokenSecret, corev1.SecretTypeOpaque, map[string][]byte{gitHubTokenSecretKey: []byte(token)}); err != nil {
+		return err
+	}
+	note("secret %s/%s from $%s — skill discovery and resolution call GitHub authenticated", ns, gitHubTokenSecret, GitHubTokenEnv)
+	return nil
+}

--- a/internal/lab/githubtoken_test.go
+++ b/internal/lab/githubtoken_test.go
@@ -1,0 +1,204 @@
+package lab
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/giantswarm/agentlab/internal/config"
+)
+
+// gitHubTestToken is a sentinel no real token looks like; the assertions
+// below hunt for it in everything the render writes to state/.
+const gitHubTestToken = "ghp_agentlab_unit_test_sentinel_0000000000"
+
+// renderGitHubTokenSurfaces renders the two files that name the Secret: the
+// meta chart's values and the Backstage overlay, raw and parsed.
+func renderGitHubTokenSurfaces(t *testing.T, cfg *config.Config) (valuesRaw string, values map[string]any, overlayRaw string, overlay map[string]any) {
+	t.Helper()
+	out, err := renderTemplate(cfg, platformValuesTemplate, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := yaml.Unmarshal(out, &values); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	raw, err := renderTemplate(cfg, "backstage-catalog.yaml.tmpl", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out), values, string(raw), backstageOverlayAppConfig(t, cfg)
+}
+
+func gitHubTokenTestConfig() *config.Config {
+	cfg := config.Default()
+	cfg.Platform.Enabled, cfg.Platform.Agents, cfg.Backstage.Enabled = true, true, true
+	return cfg
+}
+
+// TestGitHubTokenWiresBothConsumers: with $GITHUB_TOKEN set the values name
+// the Secret for the portal (extraEnvVarsSecrets, read by the overlay's
+// integrations.github reference), agent-manager (skills.github.tokenSecret)
+// and the migrate Job (agentManager.migration.githubToken) — the Secret's
+// NAME only: the token itself appears in nothing the render writes.
+func TestGitHubTokenWiresBothConsumers(t *testing.T) {
+	t.Setenv(GitHubTokenEnv, gitHubTestToken)
+	valuesRaw, values, overlayRaw, overlay := renderGitHubTokenSurfaces(t, gitHubTokenTestConfig())
+
+	if got := dig(values, "backstage", "backstage", "extraEnvVarsSecrets"); !reflect.DeepEqual(got, []any{gitHubTokenSecret}) {
+		t.Errorf("backstage.backstage.extraEnvVarsSecrets = %v, want [%s]", got, gitHubTokenSecret)
+	}
+	for _, tc := range []struct {
+		path []string
+		want any
+	}{
+		{[]string{"agent-manager", "skills", "github", "tokenSecret", "name"}, gitHubTokenSecret},
+		{[]string{"agent-manager", "skills", "github", "tokenSecret", "key"}, gitHubTokenSecretKey},
+		{[]string{"agentManager", "migration", "githubToken", "secretName"}, gitHubTokenSecret},
+		{[]string{"agentManager", "migration", "githubToken", "key"}, gitHubTokenSecretKey},
+	} {
+		if got := dig(values, tc.path...); got != tc.want {
+			t.Errorf("%s = %v, want %v", strings.Join(tc.path, "."), got, tc.want)
+		}
+	}
+	// The lab's other agent-manager values survive next to the new key.
+	if got := dig(values, "agent-manager", "muster", "mcpServer", "auth", "requiredAudiences"); got == nil {
+		t.Errorf("agent-manager.muster.mcpServer.auth.requiredAudiences went missing:\n%s", valuesRaw)
+	}
+
+	github, _ := dig(overlay, "integrations", "github").([]any)
+	if len(github) != 1 {
+		t.Fatalf("overlay integrations.github = %v, want one github.com entry", dig(overlay, "integrations", "github"))
+	}
+	entry, _ := github[0].(map[string]any)
+	if entry["host"] != "github.com" || entry["token"] != "${"+GitHubTokenEnv+"}" {
+		t.Errorf("overlay integrations.github[0] = %v, want host github.com and token ${%s}", entry, GitHubTokenEnv)
+	}
+
+	for name, text := range map[string]string{platformValuesTemplate: valuesRaw, "backstage-catalog.yaml.tmpl": overlayRaw} {
+		if strings.Contains(text, gitHubTestToken) {
+			t.Errorf("%s carries the token itself:\n%s", name, text)
+		}
+	}
+}
+
+// TestGitHubTokenUnsetLeavesTheLabAsItWas: without the variable none of the
+// keys render — the consumers call GitHub unauthenticated, as before.
+func TestGitHubTokenUnsetLeavesTheLabAsItWas(t *testing.T) {
+	t.Setenv(GitHubTokenEnv, "")
+	valuesRaw, values, overlayRaw, overlay := renderGitHubTokenSurfaces(t, gitHubTokenTestConfig())
+	for _, path := range [][]string{
+		{"backstage", "backstage", "extraEnvVarsSecrets"},
+		{"agent-manager", "skills"},
+		{"agentManager"},
+	} {
+		if got := dig(values, path...); got != nil {
+			t.Errorf("%s = %v without $%s, want nothing", strings.Join(path, "."), got, GitHubTokenEnv)
+		}
+	}
+	if got := dig(overlay, "integrations"); got != nil {
+		t.Errorf("overlay integrations = %v without $%s, want nothing", got, GitHubTokenEnv)
+	}
+	for name, text := range map[string]string{platformValuesTemplate: valuesRaw, "backstage-catalog.yaml.tmpl": overlayRaw} {
+		if strings.Contains(text, gitHubTokenSecret) {
+			t.Errorf("%s names %s without $%s:\n%s", name, gitHubTokenSecret, GitHubTokenEnv, text)
+		}
+	}
+}
+
+// TestGitHubTokenLegacyChartTakesNoKeys: the 3.x line the rehearsal seeds
+// has neither agent-manager's tokenSecret nor the migrate Job, so a seed run
+// with the variable exported renders none of the keys.
+func TestGitHubTokenLegacyChartTakesNoKeys(t *testing.T) {
+	t.Setenv(GitHubTokenEnv, gitHubTestToken)
+	cfg := gitHubTokenTestConfig()
+	cfg.Platform.ChartVersion = "3.23.1"
+	if !cfg.LegacyChart() {
+		t.Fatal("3.23.1 is not the legacy line?")
+	}
+	valuesRaw, _, overlayRaw, _ := renderGitHubTokenSurfaces(t, cfg)
+	for name, text := range map[string]string{platformValuesTemplate: valuesRaw, "backstage-catalog.yaml.tmpl": overlayRaw} {
+		if strings.Contains(text, gitHubTokenSecret) || strings.Contains(text, gitHubTestToken) {
+			t.Errorf("%s wires the GitHub token on the 3.x line:\n%s", name, text)
+		}
+	}
+}
+
+// TestEnsureGitHubTokenSecrets: nothing without the variable; with it the
+// agent-platform Secret, the kagent copy once that namespace exists, an
+// update (not "left alone") on a new token, and no deletion when a later run
+// lacks the variable.
+func TestEnsureGitHubTokenSecrets(t *testing.T) {
+	newFakeLab(t)
+	ctx := context.Background()
+	cfg := gitHubTokenTestConfig()
+	tokenIn := func(ns string) string {
+		t.Helper()
+		got, err := secretDataKey(ctx, ns, gitHubTokenSecret, gitHubTokenSecretKey)
+		if err != nil {
+			t.Fatalf("%s/%s: %v", ns, gitHubTokenSecret, err)
+		}
+		return string(got)
+	}
+	exists := func(ns string) bool {
+		t.Helper()
+		ok, err := objectExists(ctx, gvrSecrets, ns, gitHubTokenSecret)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ok
+	}
+
+	t.Setenv(GitHubTokenEnv, "")
+	if err := ensureGitHubTokenSecrets(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if exists(platformNamespace) {
+		t.Fatalf("a Secret was written without $%s", GitHubTokenEnv)
+	}
+
+	t.Setenv(GitHubTokenEnv, gitHubTestToken)
+	if err := ensureGitHubTokenSecrets(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := tokenIn(platformNamespace); got != gitHubTestToken {
+		t.Errorf("%s/%s carries %q, want the token from $%s", platformNamespace, gitHubTokenSecret, got, GitHubTokenEnv)
+	}
+	if exists(kagentNamespace) {
+		t.Errorf("the kagent copy landed before the namespace exists (the chart creates it)")
+	}
+
+	if err := ensureNamespace(kagentNamespace); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureGitHubTokenSecrets(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := tokenIn(kagentNamespace); got != gitHubTestToken {
+		t.Errorf("%s/%s carries %q after the namespace exists, want the token", kagentNamespace, gitHubTokenSecret, got)
+	}
+
+	rotated := gitHubTestToken + "-rotated"
+	t.Setenv(GitHubTokenEnv, rotated)
+	if err := ensureGitHubTokenSecrets(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	for _, ns := range []string{platformNamespace, kagentNamespace} {
+		if got := tokenIn(ns); got != rotated {
+			t.Errorf("%s/%s carries %q after a re-run with a new token, want the rotation", ns, gitHubTokenSecret, got)
+		}
+	}
+
+	t.Setenv(GitHubTokenEnv, "")
+	if err := ensureGitHubTokenSecrets(ctx, cfg); err != nil {
+		t.Fatal(err)
+	}
+	for _, ns := range []string{platformNamespace, kagentNamespace} {
+		if !exists(ns) {
+			t.Errorf("a run without $%s removed %s/%s", GitHubTokenEnv, ns, gitHubTokenSecret)
+		}
+	}
+}

--- a/internal/lab/githubtoken_test.go
+++ b/internal/lab/githubtoken_test.go
@@ -13,24 +13,44 @@ import (
 
 // gitHubTestToken is a sentinel no real token looks like; the assertions
 // below hunt for it in everything the render writes to state/.
-const gitHubTestToken = "ghp_agentlab_unit_test_sentinel_0000000000"
+const gitHubTestToken = "ghp_agentlab_unit_test_sentinel_0000000000" // #nosec G101 -- test sentinel, not a credential
 
-// renderGitHubTokenSurfaces renders the two files that name the Secret: the
-// meta chart's values and the Backstage overlay, raw and parsed.
-func renderGitHubTokenSurfaces(t *testing.T, cfg *config.Config) (valuesRaw string, values map[string]any, overlayRaw string, overlay map[string]any) {
+// The values blocks the token lands in: the agent-manager chart's own and
+// the connectivity chart's wiring for it; the chart version of the 3.x line.
+const (
+	agentManagerValuesKey = "agent-manager"
+	agentManagerWiringKey = "agentManager"
+	legacyChartVersion    = "3.23.1"
+)
+
+// gitHubTokenSurfaces is what the render writes that could name the Secret
+// (or leak the token): the meta chart's values and the Backstage overlay,
+// raw and parsed.
+type gitHubTokenSurfaces struct {
+	valuesRaw, overlayRaw string
+	values, overlay       map[string]any
+}
+
+// raw is the rendered text by template name, for the token hunt.
+func (s gitHubTokenSurfaces) raw() map[string]string {
+	return map[string]string{platformValuesTemplate: s.valuesRaw, backstageOverlayTemplate: s.overlayRaw}
+}
+
+func renderGitHubTokenSurfaces(t *testing.T, cfg *config.Config) gitHubTokenSurfaces {
 	t.Helper()
 	out, err := renderTemplate(cfg, platformValuesTemplate, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	var values map[string]any
 	if err := yaml.Unmarshal(out, &values); err != nil {
 		t.Fatalf("%v\n%s", err, out)
 	}
-	raw, err := renderTemplate(cfg, "backstage-catalog.yaml.tmpl", nil)
+	overlayRaw, err := renderTemplate(cfg, backstageOverlayTemplate, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return string(out), values, string(raw), backstageOverlayAppConfig(t, cfg)
+	return gitHubTokenSurfaces{valuesRaw: string(out), overlayRaw: string(overlayRaw), values: values, overlay: backstageOverlayAppConfig(t, cfg)}
 }
 
 func gitHubTokenTestConfig() *config.Config {
@@ -46,39 +66,42 @@ func gitHubTokenTestConfig() *config.Config {
 // NAME only: the token itself appears in nothing the render writes.
 func TestGitHubTokenWiresBothConsumers(t *testing.T) {
 	t.Setenv(GitHubTokenEnv, gitHubTestToken)
-	valuesRaw, values, overlayRaw, overlay := renderGitHubTokenSurfaces(t, gitHubTokenTestConfig())
+	s := renderGitHubTokenSurfaces(t, gitHubTokenTestConfig())
 
-	if got := dig(values, "backstage", "backstage", "extraEnvVarsSecrets"); !reflect.DeepEqual(got, []any{gitHubTokenSecret}) {
+	if got := dig(s.values, componentBackstage, componentBackstage, "extraEnvVarsSecrets"); !reflect.DeepEqual(got, []any{gitHubTokenSecret}) {
 		t.Errorf("backstage.backstage.extraEnvVarsSecrets = %v, want [%s]", got, gitHubTokenSecret)
 	}
+	tokenSecret := []string{agentManagerValuesKey, "skills", "github", "tokenSecret"}
+	githubToken := []string{agentManagerWiringKey, "migration", "githubToken"}
 	for _, tc := range []struct {
 		path []string
 		want any
 	}{
-		{[]string{"agent-manager", "skills", "github", "tokenSecret", "name"}, gitHubTokenSecret},
-		{[]string{"agent-manager", "skills", "github", "tokenSecret", "key"}, gitHubTokenSecretKey},
-		{[]string{"agentManager", "migration", "githubToken", "secretName"}, gitHubTokenSecret},
-		{[]string{"agentManager", "migration", "githubToken", "key"}, gitHubTokenSecretKey},
+		{append(tokenSecret, nameKey), gitHubTokenSecret},
+		{append(tokenSecret, fieldKey), gitHubTokenSecretKey},
+		{append(githubToken, "secretName"), gitHubTokenSecret},
+		{append(githubToken, fieldKey), gitHubTokenSecretKey},
 	} {
-		if got := dig(values, tc.path...); got != tc.want {
+		if got := dig(s.values, tc.path...); got != tc.want {
 			t.Errorf("%s = %v, want %v", strings.Join(tc.path, "."), got, tc.want)
 		}
 	}
 	// The lab's other agent-manager values survive next to the new key.
-	if got := dig(values, "agent-manager", "muster", "mcpServer", "auth", "requiredAudiences"); got == nil {
-		t.Errorf("agent-manager.muster.mcpServer.auth.requiredAudiences went missing:\n%s", valuesRaw)
+	if got := dig(s.values, agentManagerValuesKey, "muster", "mcpServer", "auth", "requiredAudiences"); got == nil {
+		t.Errorf("agent-manager.muster.mcpServer.auth.requiredAudiences went missing:\n%s", s.valuesRaw)
 	}
 
-	github, _ := dig(overlay, "integrations", "github").([]any)
+	integrations := dig(s.overlay, "integrations", "github")
+	github, _ := integrations.([]any)
 	if len(github) != 1 {
-		t.Fatalf("overlay integrations.github = %v, want one github.com entry", dig(overlay, "integrations", "github"))
+		t.Fatalf("overlay integrations.github = %v, want one github.com entry", integrations)
 	}
 	entry, _ := github[0].(map[string]any)
 	if entry["host"] != "github.com" || entry["token"] != "${"+GitHubTokenEnv+"}" {
 		t.Errorf("overlay integrations.github[0] = %v, want host github.com and token ${%s}", entry, GitHubTokenEnv)
 	}
 
-	for name, text := range map[string]string{platformValuesTemplate: valuesRaw, "backstage-catalog.yaml.tmpl": overlayRaw} {
+	for name, text := range s.raw() {
 		if strings.Contains(text, gitHubTestToken) {
 			t.Errorf("%s carries the token itself:\n%s", name, text)
 		}
@@ -89,20 +112,20 @@ func TestGitHubTokenWiresBothConsumers(t *testing.T) {
 // keys render — the consumers call GitHub unauthenticated, as before.
 func TestGitHubTokenUnsetLeavesTheLabAsItWas(t *testing.T) {
 	t.Setenv(GitHubTokenEnv, "")
-	valuesRaw, values, overlayRaw, overlay := renderGitHubTokenSurfaces(t, gitHubTokenTestConfig())
+	s := renderGitHubTokenSurfaces(t, gitHubTokenTestConfig())
 	for _, path := range [][]string{
-		{"backstage", "backstage", "extraEnvVarsSecrets"},
-		{"agent-manager", "skills"},
-		{"agentManager"},
+		{componentBackstage, componentBackstage, "extraEnvVarsSecrets"},
+		{agentManagerValuesKey, "skills"},
+		{agentManagerWiringKey},
 	} {
-		if got := dig(values, path...); got != nil {
+		if got := dig(s.values, path...); got != nil {
 			t.Errorf("%s = %v without $%s, want nothing", strings.Join(path, "."), got, GitHubTokenEnv)
 		}
 	}
-	if got := dig(overlay, "integrations"); got != nil {
+	if got := dig(s.overlay, "integrations"); got != nil {
 		t.Errorf("overlay integrations = %v without $%s, want nothing", got, GitHubTokenEnv)
 	}
-	for name, text := range map[string]string{platformValuesTemplate: valuesRaw, "backstage-catalog.yaml.tmpl": overlayRaw} {
+	for name, text := range s.raw() {
 		if strings.Contains(text, gitHubTokenSecret) {
 			t.Errorf("%s names %s without $%s:\n%s", name, gitHubTokenSecret, GitHubTokenEnv, text)
 		}
@@ -115,12 +138,11 @@ func TestGitHubTokenUnsetLeavesTheLabAsItWas(t *testing.T) {
 func TestGitHubTokenLegacyChartTakesNoKeys(t *testing.T) {
 	t.Setenv(GitHubTokenEnv, gitHubTestToken)
 	cfg := gitHubTokenTestConfig()
-	cfg.Platform.ChartVersion = "3.23.1"
+	cfg.Platform.ChartVersion = legacyChartVersion
 	if !cfg.LegacyChart() {
-		t.Fatal("3.23.1 is not the legacy line?")
+		t.Fatalf("%s is not the legacy line?", legacyChartVersion)
 	}
-	valuesRaw, _, overlayRaw, _ := renderGitHubTokenSurfaces(t, cfg)
-	for name, text := range map[string]string{platformValuesTemplate: valuesRaw, "backstage-catalog.yaml.tmpl": overlayRaw} {
+	for name, text := range renderGitHubTokenSurfaces(t, cfg).raw() {
 		if strings.Contains(text, gitHubTokenSecret) || strings.Contains(text, gitHubTestToken) {
 			t.Errorf("%s wires the GitHub token on the 3.x line:\n%s", name, text)
 		}

--- a/internal/lab/githubwindow.go
+++ b/internal/lab/githubwindow.go
@@ -1,0 +1,122 @@
+package lab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/giantswarm/agentlab/pkg/project"
+)
+
+// gitHubRateLimitURL is GitHub's window endpoint; a call to it does not count
+// against the window it reports.
+const gitHubRateLimitURL = "https://api.github.com/rate_limit"
+
+// gitHubWindowMaxWait bounds the one wait on an exhausted window: GitHub's
+// windows are an hour, so a reset further out than this is a clock problem,
+// not something to sleep through.
+const gitHubWindowMaxWait = 65 * time.Minute
+
+// Seams the tests replace: the endpoint, the clock and the wait.
+var (
+	gitHubRateLimitEndpoint = gitHubRateLimitURL
+	gitHubNow               = time.Now
+	gitHubSleep             = time.Sleep
+)
+
+// gitHubWindow is the core REST API window as /rate_limit reports it.
+type gitHubWindow struct {
+	Limit, Remaining int
+	Reset            time.Time
+	Authenticated    bool
+}
+
+// String is the window print — never the token.
+func (w gitHubWindow) String() string {
+	who := "unauthenticated: this machine's shared window"
+	if w.Authenticated {
+		who = "authenticated with $" + GitHubTokenEnv
+	}
+	return fmt.Sprintf("GitHub API window (%s): %d of %d requests remaining, resets %s", who, w.Remaining, w.Limit, w.Reset.Local().Format("15:04:05 MST"))
+}
+
+// readGitHubWindow asks /rate_limit once, with the host's token when set;
+// its own deadline, since the caller may sleep an hour between two reads.
+func readGitHubWindow() (gitHubWindow, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gitHubRateLimitEndpoint, nil)
+	if err != nil {
+		return gitHubWindow{}, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "agentlab/"+project.Version())
+	token := os.Getenv(GitHubTokenEnv)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return gitHubWindow{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return gitHubWindow{}, fmt.Errorf("GET %s answered %d", gitHubRateLimitEndpoint, resp.StatusCode)
+	}
+	var body struct {
+		Resources struct {
+			Core struct {
+				Limit     int   `json:"limit"`
+				Remaining int   `json:"remaining"`
+				Reset     int64 `json:"reset"`
+			} `json:"core"`
+		} `json:"resources"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return gitHubWindow{}, fmt.Errorf("GET %s: not the expected JSON: %w", gitHubRateLimitEndpoint, err)
+	}
+	core := body.Resources.Core
+	return gitHubWindow{Limit: core.Limit, Remaining: core.Remaining, Reset: time.Unix(core.Reset, 0), Authenticated: token != ""}, nil
+}
+
+// awaitGitHubWindow prints the GitHub API window before a proof step that
+// resolves skills through GitHub (the portal's discovery, agent-manager's
+// list_skills and create_agent) and, when the window is exhausted, waits once
+// — bounded — until it resets rather than letting the step fail on a
+// truncated listing. The consumers in the cluster share this machine's egress
+// address, so an unauthenticated read here is their window; with
+// $GITHUB_TOKEN set on the host the lab handed them the same token
+// (githubtoken.go), so the read is authenticated as theirs are. An endpoint
+// that cannot be read is a note, never a failure; a window still exhausted
+// after the wait is.
+func awaitGitHubWindow(what string) error {
+	w, err := readGitHubWindow()
+	if err != nil {
+		note("GitHub API window not read (%v); %s proceeds without it", err, what)
+		return nil
+	}
+	note("%s", w)
+	if w.Remaining > 0 {
+		return nil
+	}
+	wait := max(w.Reset.Sub(gitHubNow())+5*time.Second, 0)
+	if wait > gitHubWindowMaxWait {
+		wait = gitHubWindowMaxWait
+	}
+	note("the window is exhausted — waiting %s for it to reset at %s before %s (one bounded wait; export $%s to lift it to 5000 an hour)", wait.Round(time.Second), w.Reset.Local().Format("15:04:05 MST"), what, GitHubTokenEnv)
+	gitHubSleep(wait)
+	if w, err = readGitHubWindow(); err != nil {
+		note("GitHub API window not re-read after the wait (%v); %s proceeds", err, what)
+		return nil
+	}
+	note("%s", w)
+	if w.Remaining == 0 {
+		return fmt.Errorf("GitHub API window still exhausted after waiting for its reset (%s): %s cannot resolve skills — export $%s or try again after %s", w.Reset.Local().Format("15:04:05 MST"), what, GitHubTokenEnv, w.Reset.Local().Format("15:04:05 MST"))
+	}
+	return nil
+}

--- a/internal/lab/githubwindow_test.go
+++ b/internal/lab/githubwindow_test.go
@@ -1,0 +1,159 @@
+package lab
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeGitHubRateLimit is /rate_limit on a test server: the window it answers
+// with, the Authorization headers it saw, and the seams pointed at it.
+type fakeGitHubRateLimit struct {
+	mu        sync.Mutex
+	remaining int
+	reset     time.Time
+	auth      []string
+	slept     []time.Duration
+}
+
+func newFakeGitHubRateLimit(t *testing.T, reset time.Time) *fakeGitHubRateLimit {
+	t.Helper()
+	f := &fakeGitHubRateLimit{reset: reset}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.auth = append(f.auth, r.Header.Get("Authorization"))
+		_, _ = fmt.Fprintf(w, `{"resources":{"core":{"limit":60,"remaining":%d,"reset":%d}}}`, f.remaining, f.reset.Unix())
+	}))
+	prevEndpoint, prevNow, prevSleep := gitHubRateLimitEndpoint, gitHubNow, gitHubSleep
+	gitHubRateLimitEndpoint = srv.URL
+	gitHubNow = func() time.Time { return reset.Add(-30 * time.Minute) }
+	// The reset refills the window, as GitHub's does.
+	gitHubSleep = func(d time.Duration) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.slept = append(f.slept, d)
+		f.remaining = 60
+	}
+	t.Cleanup(func() {
+		srv.Close()
+		gitHubRateLimitEndpoint, gitHubNow, gitHubSleep = prevEndpoint, prevNow, prevSleep
+	})
+	return f
+}
+
+func (f *fakeGitHubRateLimit) set(remaining int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.remaining, f.auth, f.slept = remaining, nil, nil
+}
+
+func (f *fakeGitHubRateLimit) seen() (auth []string, slept []time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.auth...), append([]time.Duration(nil), f.slept...)
+}
+
+// TestAwaitGitHubWindow: one read, authenticated exactly when the host has a
+// token; no wait while the window has budget; one bounded wait until the
+// reset when it is exhausted, then a re-read; an error only when the window
+// is still empty after the wait. The print never carries the token.
+func TestAwaitGitHubWindow(t *testing.T) {
+	reset := time.Unix(time.Now().Add(30*time.Minute).Unix(), 0)
+	f := newFakeGitHubRateLimit(t, reset)
+
+	t.Run("unauthenticated with budget", func(t *testing.T) {
+		t.Setenv(GitHubTokenEnv, "")
+		f.set(42)
+		if err := awaitGitHubWindow("the proof"); err != nil {
+			t.Fatal(err)
+		}
+		auth, slept := f.seen()
+		if len(auth) != 1 || auth[0] != "" {
+			t.Errorf("Authorization headers = %q without a token, want one empty", auth)
+		}
+		if len(slept) != 0 {
+			t.Errorf("waited %v on a window with budget", slept)
+		}
+	})
+
+	t.Run("authenticated", func(t *testing.T) {
+		t.Setenv(GitHubTokenEnv, gitHubTestToken)
+		f.set(4999)
+		if err := awaitGitHubWindow("the proof"); err != nil {
+			t.Fatal(err)
+		}
+		auth, _ := f.seen()
+		if len(auth) != 1 || auth[0] != "Bearer "+gitHubTestToken {
+			t.Errorf("Authorization headers = %q, want the bearer token once", auth)
+		}
+	})
+
+	t.Run("exhausted waits once until the reset", func(t *testing.T) {
+		t.Setenv(GitHubTokenEnv, "")
+		f.set(0)
+		if err := awaitGitHubWindow("the proof"); err != nil {
+			t.Fatal(err)
+		}
+		auth, slept := f.seen()
+		if len(slept) != 1 || slept[0] != 30*time.Minute+5*time.Second {
+			t.Errorf("slept %v, want one wait of 30m5s (until the reset plus a margin)", slept)
+		}
+		if len(auth) != 2 {
+			t.Errorf("%d reads, want the read and the re-read after the wait", len(auth))
+		}
+	})
+
+	t.Run("a reset beyond an hour is capped", func(t *testing.T) {
+		prev := gitHubNow
+		gitHubNow = func() time.Time { return reset.Add(-3 * time.Hour) }
+		t.Cleanup(func() { gitHubNow = prev })
+		f.set(0)
+		if err := awaitGitHubWindow("the proof"); err != nil {
+			t.Fatal(err)
+		}
+		if _, slept := f.seen(); len(slept) != 1 || slept[0] != gitHubWindowMaxWait {
+			t.Errorf("slept %v, want the %s cap", slept, gitHubWindowMaxWait)
+		}
+	})
+
+	t.Run("still exhausted after the wait", func(t *testing.T) {
+		prev := gitHubSleep
+		gitHubSleep = func(time.Duration) {} // no refill
+		t.Cleanup(func() { gitHubSleep = prev })
+		f.set(0)
+		err := awaitGitHubWindow("the proof")
+		if err == nil || !strings.Contains(err.Error(), "still exhausted") {
+			t.Errorf("err = %v, want the still-exhausted verdict", err)
+		}
+	})
+}
+
+// TestAwaitGitHubWindowUnreachableIsANote: an endpoint that cannot be read
+// never fails the proof.
+func TestAwaitGitHubWindowUnreachableIsANote(t *testing.T) {
+	prev := gitHubRateLimitEndpoint
+	gitHubRateLimitEndpoint = "http://127.0.0.1:1/rate_limit"
+	t.Cleanup(func() { gitHubRateLimitEndpoint = prev })
+	if err := awaitGitHubWindow("the proof"); err != nil {
+		t.Errorf("an unreachable /rate_limit failed the proof: %v", err)
+	}
+}
+
+// TestGitHubWindowPrintNamesTheVariableNotTheToken pins the print's shape.
+func TestGitHubWindowPrintNamesTheVariableNotTheToken(t *testing.T) {
+	w := gitHubWindow{Limit: 5000, Remaining: 4321, Reset: time.Unix(1_800_000_000, 0), Authenticated: true}
+	got := w.String()
+	for _, want := range []string{"4321 of 5000", "$" + GitHubTokenEnv, "resets "} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q lacks %q", got, want)
+		}
+	}
+	if !strings.Contains(gitHubWindow{Limit: 60, Remaining: 0}.String(), "unauthenticated") {
+		t.Errorf("an unauthenticated window must say so: %q", gitHubWindow{Limit: 60}.String())
+	}
+}

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -251,6 +251,13 @@ func platformUp(cfg *config.Config, header string, offers Offers) error {
 	if err := ensurePlatformSecrets(ctx); err != nil {
 		return err
 	}
+	// The GitHub token (githubtoken.go) — before the install: the portal's
+	// envFrom and agent-manager's env reference the Secret without
+	// `optional`, and the values just rendered name it whenever $GITHUB_TOKEN
+	// is set.
+	if err := ensureGitHubTokenSecrets(ctx, cfg); err != nil {
+		return err
+	}
 
 	// Inside pods, *.<domain> must resolve to the edge Gateway (outside, the
 	// nip.io wildcard already answers 127.0.0.1) — without this Backstage
@@ -507,6 +514,12 @@ func platformUp(cfg *config.Config, header string, offers Offers) error {
 	if cfg.Platform.Agents {
 		step("Wiring the agents to Anthropic (ModelConfig model: %s)", cfg.AIModel)
 		if _, err := ensureAnthropicSecret(kagentNamespace, "kagent-anthropic"); err != nil {
+			return err
+		}
+		// The migrate Job's copy of the GitHub token (githubtoken.go) — the
+		// chart created the kagent namespace by now; a no-op when the
+		// pre-install pass already found the namespace, or without the token.
+		if err := ensureGitHubTokenSecret(ctx, kagentNamespace); err != nil {
 			return err
 		}
 		// The extra ModelConfigs from platform.extraModels (self-hosted

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -101,6 +101,12 @@ type tmplData struct {
 	// (ateletImageCacheArgs, substrate.go), rendered after the registry flag
 	// in the same substrate.atelet.extraArgs list.
 	AteletImageCacheArgs []string
+	// GitHubToken mirrors gitHubTokenWired(cfg): $GITHUB_TOKEN is set on the
+	// host (githubtoken.go), so the values name the Secret the lab creates
+	// from it — the portal's extraEnvVarsSecrets and the overlay's
+	// integrations.github, agent-manager's skills.github.tokenSecret, the
+	// migrate Job's githubToken. Only ever the Secret's name, never the token.
+	GitHubToken bool
 }
 
 func newTmplData(cfg *config.Config) (*tmplData, error) {
@@ -132,6 +138,7 @@ func newTmplData(cfg *config.Config) (*tmplData, error) {
 		MCPPrometheusChartVersion:  mcpPrometheusChartVersion,
 		LocalRegistryEndpoint:      devRegistryEndpoint(cfg),
 		AteletImageCacheArgs:       ateletImageCacheArgs,
+		GitHubToken:                gitHubTokenWired(cfg),
 		ModelManagerEnabled:        cfg.ModelManagerEnabled(),
 		LegacyChart:                cfg.LegacyChart(),
 		ModelManagerBackends:       cfg.Platform.ModelManager.Backends,

--- a/internal/lab/render.go
+++ b/internal/lab/render.go
@@ -188,8 +188,12 @@ var tmplFuncs = template.FuncMap{
 }
 
 // platformValuesTemplate renders the meta chart's lab values (the lab
-// shape, platform.go).
-const platformValuesTemplate = "agent-platform-values.yaml.tmpl"
+// shape, platform.go); backstageOverlayTemplate the lab's Backstage catalog
+// and app-config overlay.
+const (
+	platformValuesTemplate   = "agent-platform-values.yaml.tmpl"
+	backstageOverlayTemplate = "backstage-catalog.yaml.tmpl"
+)
 
 // renderTemplate renders one embedded template with the config; mutate, when
 // given, adjusts the template data first (the platform run hands

--- a/internal/lab/templates/agent-platform-values.yaml.tmpl
+++ b/internal/lab/templates/agent-platform-values.yaml.tmpl
@@ -508,11 +508,36 @@ kagent:
 # carry the `kubernetes` audience to pass the kind apiserver — the lab Dex
 # lists agent-platform as a trusted peer of that client.
 agent-manager:
+{{- if .GitHubToken }}
+  # The token agent-manager resolves skills with (list_skills, the
+  # create_agent pin, refreshSkills): the Secret the lab creates from
+  # $GITHUB_TOKEN (githubtoken.go), lifting the unauthenticated 60-an-hour
+  # window this machine's egress address shares. The chart renders it as the
+  # Deployment's GITHUB_TOKEN; the repositories list stays the chart's.
+  skills:
+    github:
+      tokenSecret:
+        name: agentlab-github-token
+        key: GITHUB_TOKEN
+{{- end }}
   muster:
     mcpServer:
       auth:
         requiredAudiences:
           - kubernetes
+{{- if .GitHubToken }}
+
+# The connectivity chart's wiring for agent-manager: its migrate Job (the
+# cut-over the rehearsal drives) resolves skills through GitHub too, from the
+# kagent namespace — the same token, the lab's copy of the Secret there
+# (githubtoken.go). The Job's env is optional, so a first install, where the
+# copy lands after the chart created the namespace, still runs.
+agentManager:
+  migration:
+    githubToken:
+      secretName: agentlab-github-token
+      key: GITHUB_TOKEN
+{{- end }}
 {{- end }}
 
 {{- if .ModelManagerEnabled }}
@@ -607,6 +632,16 @@ backstage:
         configMapRef: agent-platform-backstage-app-config
       - filename: app-config.agentlab.yaml
         configMapRef: agentlab-backstage-app-config
+{{- if .GitHubToken }}
+    # $GITHUB_TOKEN into the portal's environment from the Secret the lab
+    # creates (githubtoken.go); the overlay's integrations.github reads it
+    # (backstage-catalog.yaml.tmpl), so the gs backend's skill discovery calls
+    # GitHub authenticated — 5000 requests an hour instead of the 60 this
+    # machine's egress address shares. A separate list from the umbrella's
+    # extraEnvVars, so nothing of the umbrella's is overridden.
+    extraEnvVarsSecrets:
+      - agentlab-github-token
+{{- end }}
     extraVolumes:
       # Restated from the chart (global.identity.ca): the lab CA Backstage
       # trusts via NODE_EXTRA_CA_CERTS.

--- a/internal/lab/templates/backstage-catalog.yaml.tmpl
+++ b/internal/lab/templates/backstage-catalog.yaml.tmpl
@@ -74,6 +74,17 @@ data:
           target: /lab-catalog/users.yaml
           rules:
             - allow: [User, Group]
+{{- if .GitHubToken }}
+    # The portal's skill discovery (the gs backend's GET /api/gs/agent-skills
+    # reads GitHub through Backstage's integrations) authenticates with the
+    # token the lab put into the pod's environment (extraEnvVarsSecrets in
+    # agent-platform-values.yaml, from the Secret githubtoken.go creates). A
+    # reference Backstage resolves at start-up, never the value.
+    integrations:
+      github:
+        - host: github.com
+          token: ${GITHUB_TOKEN}
+{{- end }}
 {{- if .Platform.Observability }}
     # The umbrella hardcodes mimirEnabled: false — standalone installations
     # have no GS observability stack at observability.<baseDomain>. With


### PR DESCRIPTION
Fixes giantswarm/agentlab#160

## Problem

The portal's skill discovery (`GET /api/gs/agent-skills?repoUrl=…`) and agent-manager's skill resolution (`list_skills`, the commit `create_agent` pins, `refreshSkills`, the migrate Job of the cut-over) call GitHub's REST API unauthenticated: 60 requests an hour per egress address, shared with every other unauthenticated GitHub call from the machine. Five `backstage-test` runs within an hour exhausted it on 2026-09-11; the sixth run's discovery came back truncated.

## Change

- **`$GITHUB_TOKEN`** on the host, read at `agentlab up`/`platform` the way `$ANTHROPIC_API_KEY` is, becomes the Secret **`agentlab-github-token`** (key `GITHUB_TOKEN`) in `agent-platform` (portal + agent-manager) and `kagent` (the migrate Job) — applied in-process through client-go (server-side apply: created **or updated**, so a re-run rotates it); never in `agentlab.yaml`, `state/`, argv or a log line.
- The values name that Secret **only when the variable is set at render time**, so a render and the Secret always agree:
  - portal: `backstage.backstage.extraEnvVarsSecrets: [agentlab-github-token]` + the lab's app-config overlay gains `integrations.github: [{host: github.com, token: ${GITHUB_TOKEN}}]` (the gs backend's discovery reads Backstage's integrations through `DefaultGithubCredentialsProvider`);
  - agent-manager: `agent-manager.skills.github.tokenSecret: {name: agentlab-github-token, key: GITHUB_TOKEN}` (chart 1.1.x renders it as the Deployment's `GITHUB_TOKEN`);
  - migrate Job: `agentManager.migration.githubToken: {secretName: agentlab-github-token, key: GITHUB_TOKEN}` (connectivity chart; `optional: true`).
  - Both halves are forwarded verbatim by the released meta chart from **4.7.15** (the lab's version today) — no chart change needed. The 3.x line the rehearsal seeds gets none of the keys.
- Ordering: the `agent-platform` Secret lands in "Creating namespace and secrets" before the install (both Deployment references are non-optional); the `kagent` copy before the install when that namespace already exists (re-run, the rehearsal's upgrade) and after it otherwise (the chart creates the namespace).
- Unset: the lab behaves as before; a Secret of an earlier run stays, unreferenced (a run that merely lacks an export never deletes a credential), and a note names it.
- **The window print**: `backstage-test` (before the portal discovery), `agents-test` (before `list_skills`) and the rehearsal (`lib.sh github_window`, before `upgrade.sh`'s `agentlab platform` and `contract.sh`'s first `run_migrate`) read `https://api.github.com/rate_limit` once — authenticated when the token is set, the token itself never printed or passed through argv — print `limit`/`remaining`/`reset` and, at `remaining: 0`, wait once (bounded to 65 min) for the reset and re-read rather than failing on a truncated listing. An unreachable endpoint is a note, never a failure.
- Discovery (`agentlab configure`) reports whether `$GITHUB_TOKEN` is set, next to the Anthropic key.
- Docs: `docs/cli.md` env table (the row replaces the update-check-only one), `docs/agents.md` "The GitHub token", `docs/getting-started.md`, `docs/backstage.md`, `docs/migration-rehearsal.md`, `docs/platform.md`, `README.md`.

## Unit tests

`TestGitHubTokenWiresBothConsumers` (the keys, the overlay reference, and the token sentinel absent from everything rendered), `TestGitHubTokenUnsetLeavesTheLabAsItWas`, `TestGitHubTokenLegacyChartTakesNoKeys`, `TestEnsureGitHubTokenSecrets` (create; kagent copy once the namespace exists; rotate; kept without the variable), `TestAwaitGitHubWindow` (+ unreachable, print shape). `go test ./...`, `go vet`, `golangci-lint`, `shellcheck lib.sh` green locally.

## How this is verified on the lab (not run here — this PR is code only)

With `GITHUB_TOKEN` exported, `agentlab platform`, then, using each pod's **own** env (the token never leaves the cluster):

```sh
K=state/kubeconfig
# agent-manager: the chart's env from the Secret
kubectl --kubeconfig $K -n agent-platform exec deploy/agent-manager -- sh -c 'wget -qS -O /dev/null --header="Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/rate_limit 2>&1 | grep -i x-ratelimit-limit'
# the portal: envFrom the Secret, read by the overlay's integrations.github
kubectl --kubeconfig $K -n agent-platform exec deploy/backstage -- sh -c 'node -e "fetch(\"https://api.github.com/rate_limit\",{headers:{Authorization:\"Bearer \"+process.env.GITHUB_TOKEN}}).then(r=>console.log(r.headers.get(\"x-ratelimit-limit\")))"'
```

both print `5000`; `agentlab backstage-test` and `agentlab agents-test` print `GitHub API window (authenticated with $GITHUB_TOKEN): … of 5000 requests remaining`. Without the variable, the same runs print the unauthenticated `… of 60` window and behave as before; `grep -c ghp_\|github_pat_ state/*.yaml` is 0 either way.
