### PR TITLE
fix(preload): stream the side-load into the node and snapshot only what pods run

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -380,12 +380,12 @@ real installation runs its edge on 443, so the umbrella has no reason to
 carry a ported public URL; the overlay is the lab's permanent answer, not an
 interim.
 
-### U16. Podman: the side-load is one archive per image — OPEN, FIXABLE IN THE LAB
+### U16. Podman: the side-load is one save per image — OPEN, FIXABLE IN THE LAB
 A multi-image `docker save -o <tar> a b c` under Podman's docker-compatible
 CLI writes ONE image carrying every name as a tag unless
 `--multi-image-archive` is passed, so a batched archive lands one image under
 all the tags (the Flux controllers crashlooped running flux-cli). Under podman
-(`runtime.go`) the lab therefore saves and imports one archive per image
+(`runtime.go`) the lab therefore saves and imports one image at a time
 (`kindLoadImages`); under docker the batch is saved per platform (U21). The
 save is the lab's own `docker save` now (the import is the embedded kind's
 `nodeutils.LoadImageArchive`), so the lab could pass podman's
@@ -483,12 +483,17 @@ open since 2024-11; the maintainers point consumers to `docker save --platform
 | kind load image-archive` and will not lock the platform inside `kind load`).
 The lab does exactly that, with kind embedded (`kind.go`): the load path of
 kind's `load docker-image` command is not used at all — `dockerLoadImages`
-asks `docker image inspect` which platform the host holds each ref in, writes
-one `docker save --platform <p> -o <tmp.tar>` per platform and imports each
-archive with `nodeutils.LoadImageArchive`, the library call behind `kind load
-image-archive`. Needs Docker 28 (API 1.48) for `docker save --platform`; an
-older client/daemon gets one plain archive of the batch, which is right under
-the classic graph driver. Podman keeps its one-archive-per-image load (U16).
+asks `docker image inspect` which platform the host holds each ref in, runs
+one `docker save --platform <p>` per platform and streams its stdout into
+`nodeutils.LoadImageArchive`, the library call behind `kind load
+image-archive`. Streamed, not staged: `kind load docker-image` writes the
+archive to the temp dir first, and the archive of everything a lab ran is
+tens of GiB — on `/tmp`, a tmpfs on many Linux hosts, that is RAM for the
+length of the import, and for good when the boot is interrupted (a 20 GiB
+leftover was found filling a host's swap). Needs Docker 28 (API 1.48) for
+`docker save --platform`; an older client/daemon gets one plain save of the
+batch, which is right under the classic graph driver. Podman keeps its
+one-save-per-image load (U16).
 Unblocks when kind's `load docker-image` logic (the re-tag of an image ID the
 node already has, the per-image save) survives the containerd image store and
 is worth reusing over the plain archive import.

--- a/internal/lab/kind.go
+++ b/internal/lab/kind.go
@@ -1,8 +1,9 @@
 package lab
 
 import (
+	"errors"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -109,30 +110,61 @@ var kindKubeconfigRaw = func(name string) ([]byte, error) {
 	return []byte(raw), nil
 }
 
-// kindLoadArchive imports an image archive into every node of the cluster:
+// kindLoadArchive streams an image archive into every node of the cluster:
 // `ctr images import` over the engine's exec, what `kind load image-archive`
-// runs (preload.go says why the archive, HACKS.md U21). A variable so tests
-// can stand in for the node.
-var kindLoadArchive = func(clusterName, archive string) error {
+// runs (preload.go says why the archive, HACKS.md U21), reading the stream as
+// it comes — never a file. The lab is a single-node cluster
+// (config.ControlPlaneNode); a cluster with more nodes gets the one stream
+// fanned out to each of them, a node whose import stopped dropping out
+// without stalling the rest. A variable so tests can stand in for the node.
+var kindLoadArchive = func(clusterName string, archive io.Reader) error {
 	nodes, err := kindProvider().ListInternalNodes(clusterName)
 	if err != nil {
 		return kindError("listing the nodes of cluster "+clusterName, err)
 	}
 	if len(nodes) == 0 {
-		return fmt.Errorf("kind: cluster %q has no nodes to load %s into", clusterName, archive)
+		return fmt.Errorf("kind: cluster %q has no nodes to load images into", clusterName)
 	}
-	for _, node := range nodes {
-		f, err := os.Open(archive) // #nosec G304 -- the temporary archive this process wrote
-		if err != nil {
-			return err
-		}
-		err = nodeutils.LoadImageArchive(node, f)
-		_ = f.Close()
-		if err != nil {
-			return kindError("loading "+archive+" into "+node.String(), err)
+	if len(nodes) == 1 {
+		return kindError("loading images into "+nodes[0].String(), nodeutils.LoadImageArchive(nodes[0], archive))
+	}
+	sinks := make([]*nodeSink, len(nodes))
+	writers := make([]io.Writer, len(nodes))
+	errs := make([]error, len(nodes))
+	var wg sync.WaitGroup
+	for i, node := range nodes {
+		r, w := io.Pipe()
+		sinks[i] = &nodeSink{w: w}
+		writers[i] = sinks[i]
+		wg.Go(func() {
+			errs[i] = kindError("loading images into "+node.String(), nodeutils.LoadImageArchive(node, r))
+			_ = r.Close() // the sink's next write fails and it goes quiet
+		})
+	}
+	_, copyErr := io.Copy(io.MultiWriter(writers...), archive)
+	for _, s := range sinks {
+		_ = s.w.CloseWithError(copyErr)
+	}
+	wg.Wait()
+	return errors.Join(errs...)
+}
+
+// nodeSink is one node's end of a fanned-out archive stream: a write the
+// node's import no longer takes (its pipe closed) is dropped and reported
+// complete, so io.MultiWriter keeps feeding the other nodes — the failed
+// import speaks for itself through kindLoadArchive's error.
+type nodeSink struct {
+	w    *io.PipeWriter
+	dead bool
+}
+
+func (s *nodeSink) Write(p []byte) (int, error) {
+	if !s.dead {
+		if _, err := s.w.Write(p); err != nil {
+			s.dead = true
 		}
 	}
-	return nil
+	return len(p), nil
 }
 
 // kindError is the error a failed kind operation reports: kind's own message

--- a/internal/lab/platform.go
+++ b/internal/lab/platform.go
@@ -626,7 +626,7 @@ func platformUp(cfg *config.Config, header string, offers Offers) error {
 %s%s`, header, reach, usersBlock(cfg), backstageHint, claudeCodeHint(cfg), agentsHint, modelManagerHint(cfg, backendEndpoints), obsHint, devImagesHint(cfg, dev), tryItBlock(cfg))
 	// Everything the platform runs is in the node now — record it so the next
 	// boot side-loads instead of pulling.
-	snapshotPreloadImages(cfg)
+	snapshotPreloadImages()
 	// The two steps the summary above only describes: on a terminal, ask
 	// instead of telling (prompt.go). Optional to the last: whatever the
 	// person answers, the platform is up and this returns nil.

--- a/internal/lab/preload.go
+++ b/internal/lab/preload.go
@@ -1,9 +1,12 @@
 package lab
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -13,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -109,14 +114,14 @@ func sideloadImages(cfg *config.Config, images []string) preloadResult {
 }
 
 // kindLoadImages side-loads images and reports how many landed. Every load is
-// a `docker save` into a temporary archive that the embedded kind imports
-// into the node (kindLoadArchive) — what `kind load image-archive` does, and
-// the recipe kind's maintainers give consumers (HACKS.md U21). Under docker
+// a `docker save` streamed into the node's `ctr images import` through the
+// embedded kind (kindLoadArchive): the archive `kind load image-archive`
+// reads, never written out (saveAndLoadArchive, HACKS.md U21). Under docker
 // the batch is saved per platform (dockerLoadImages). Under podman it is one
-// archive per image: podman's multi-image save folds the batch into one
-// image under every tag (runtime.go, HACKS.md U16), and a single-image save
-// is always right. A failed image does not stop the rest, so the count and
-// the error are both reported and a partial load reads as one.
+// save per image: podman's multi-image save folds the batch into one image
+// under every tag (runtime.go, HACKS.md U16), and a single-image save is
+// always right. A failed image does not stop the rest, so the count and the
+// error are both reported and a partial load reads as one.
 func kindLoadImages(cfg *config.Config, images []string) (int, error) {
 	if !dockerIsPodman() {
 		return dockerLoadImages(cfg, images)
@@ -134,7 +139,7 @@ func kindLoadImages(cfg *config.Config, images []string) (int, error) {
 }
 
 // dockerLoadImages is the docker side-load: `docker save --platform <what the
-// host holds>` into an archive per platform, imported into the node. A plain
+// host holds>`, one stream per platform, imported into the node. A plain
 // `docker save` — what `kind load docker-image` runs — breaks under Docker's
 // containerd image store (the default on Docker Desktop and on new Docker 29
 // installs): that archive carries the image's whole multi-platform index
@@ -197,30 +202,41 @@ func hostImagePlatforms(images []string) (map[string][]string, []error) {
 	return groups, failed
 }
 
-// saveAndLoadArchive writes the images — their <platform> variants when one
-// is named, else as `docker save` has them — to a temporary archive and loads
-// it into the cluster's nodes. The archive is removed either way; the kind
-// CLI stages its own the same way, so the footprint is the one `kind load
-// docker-image` always had. docker's one-line stderr (the ref and platform it
-// could not export) belongs in the error the caller reports, as does kind's
-// (kindError carries the node-side command's output).
+// saveAndLoadArchive streams the images — their <platform> variants when one
+// is named, else as `docker save` has them — from `docker save` straight into
+// the cluster's nodes (kindLoadArchive). Nothing is staged on the way: the
+// archive of everything a lab ran is tens of gigabytes, and a temporary file
+// (what `kind load docker-image` writes first) puts that much on /tmp — a
+// tmpfs on many Linux hosts, so in RAM — for as long as the import takes,
+// and for good when the boot is interrupted (HACKS.md U21). A save that fails
+// cuts the stream short and fails the import with it, so docker's one-line
+// stderr (the ref and platform it could not export) is the error the caller
+// gets; kind's (kindError carries the node-side command's output) only when
+// docker had nothing to say.
 func saveAndLoadArchive(cfg *config.Config, platform string, images []string) error {
-	f, err := os.CreateTemp("", "agentlab-images-*.tar")
-	if err != nil {
-		return err
-	}
-	tar := f.Name()
-	_ = f.Close()
-	defer func() { _ = os.Remove(tar) }()
 	args := []string{"save"}
 	if platform != "" {
 		args = append(args, "--platform", platform)
 	}
-	args = append(append(args, "-o", tar), images...)
-	if _, err := outputQuiet("docker", args...); err != nil {
+	args = append(args, images...)
+	save := command(dockerBin, args...)
+	var stderr bytes.Buffer
+	save.Stderr = &stderr
+	archive, err := save.StdoutPipe()
+	if err != nil {
 		return err
 	}
-	return kindLoadArchive(cfg.ClusterName, tar)
+	if err := save.Start(); err != nil {
+		return cmdError(dockerBin, args, err, nil)
+	}
+	loadErr := kindLoadArchive(cfg.ClusterName, archive)
+	// An import that stopped early would leave docker blocked on the full
+	// pipe; draining lets it finish and say why.
+	_, _ = io.Copy(io.Discard, archive)
+	if err := save.Wait(); err != nil {
+		return cmdError(dockerBin, args, err, stderr.Bytes())
+	}
+	return loadErr
 }
 
 // dockerSaveHasPlatform reports whether `docker save --platform` works here:
@@ -387,29 +403,21 @@ func scrapeImages(rendered string) []string {
 	return slices.Compact(imgs)
 }
 
-// snapshotPreloadImages records the node's current workload images into the
-// preload manifest for the next boot. Best-effort: a failed snapshot only
-// costs the next boot its cache.
-func snapshotPreloadImages(cfg *config.Config) {
-	tags, err := nodeImageTags(cfg.ControlPlaneNode())
+// snapshotPreloadImages records the images the cluster's pods run into the
+// preload manifest for the next boot. The pods, not the node's image store:
+// that store keeps every image the node ever ran — each dev-image swap,
+// reload and chart bump of a lab's lifetime adds a version and none leaves —
+// and a manifest read off it grew to 130 images and 21 GiB, most of them tags
+// no pod would ask for again, each pulled, saved and imported on the next
+// boot. Best-effort: a failed snapshot only costs the next boot its cache.
+func snapshotPreloadImages() {
+	images, err := podImages()
 	if err != nil {
 		return
 	}
-	var images []string
-	for _, tag := range tags {
-		infra := false
-		for _, p := range infraImagePrefixes {
-			if strings.HasPrefix(tag, p) {
-				infra = true
-				break
-			}
-		}
-		if !infra {
-			images = append(images, tag)
-		}
-	}
-	slices.Sort(images)
-	images = slices.Compact(images)
+	images = slices.DeleteFunc(images, func(img string) bool {
+		return slices.ContainsFunc(infraImagePrefixes, func(p string) bool { return strings.HasPrefix(img, p) })
+	})
 	// Images built here were side-loaded by whoever built them and have no
 	// registry to be pulled from on the next boot. They are remembered as
 	// such, so a later `docker image prune` on the host does not make them
@@ -445,6 +453,45 @@ func snapshotPreloadImages(cfg *config.Config) {
 		return
 	}
 	_ = os.WriteFile(preloadImagesFile, []byte(b.String()), 0o600)
+}
+
+// podImages lists the images the cluster's pods reference — every namespace,
+// init and ephemeral containers included, finished Job pods too (the hook
+// Jobs' images are the first the next boot needs) — spelled the way the node
+// spells them (fullImageRef), so the node-side skip in sideloadImages matches.
+// Tagged refs only: a digest-pinned reference is the kubelet's to pull
+// (splitDigestRefs), and a bare name is not a pullable ref (the rule
+// scrapeImages applies).
+func podImages() ([]string, error) {
+	k, err := labKube()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pods, err := k.clientset.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("listing pods: %w", err)
+	}
+	var images []string
+	for _, pod := range pods.Items {
+		for _, c := range pod.Spec.InitContainers {
+			images = append(images, c.Image)
+		}
+		for _, c := range pod.Spec.Containers {
+			images = append(images, c.Image)
+		}
+		for _, c := range pod.Spec.EphemeralContainers {
+			images = append(images, c.Image)
+		}
+	}
+	images = slices.DeleteFunc(images, func(ref string) bool { return !strings.ContainsAny(ref, ":@") })
+	for i, ref := range images {
+		images[i] = fullImageRef(ref)
+	}
+	slices.Sort(images)
+	tagged, _ := splitDigestRefs(slices.Compact(images))
+	return tagged, nil
 }
 
 // localOnlyMarker prefixes the manifest lines that remember local-only refs —

--- a/internal/lab/preload_test.go
+++ b/internal/lab/preload_test.go
@@ -2,12 +2,16 @@ package lab
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubefake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/agentlab/internal/config"
 )
@@ -151,20 +155,17 @@ func TestSnapshotPreloadImagesSkipsLocalBuilds(t *testing.T) {
 	t.Chdir(dir)
 	hostImages := filepath.Join(dir, "host-images")
 	t.Setenv("FAKE_HOST_IMAGES", hostImages)
-	installFakeTool(t, dir, "docker", `
-case "$1" in
-exec) cat <<'JSON'
-{"images":[
- {"repoTags":["docker.io/library/backstage-dev:multi-backend-022f5b7e"]},
- {"repoTags":["docker.io/library/postgres:18.3-alpine"]},
- {"repoTags":["gsoci.azurecr.io/giantswarm/golang-adk:0.10.0"]},
- {"repoTags":["gsoci.azurecr.io/giantswarm/muster:dev"]},
- {"repoTags":["registry.k8s.io/etcd:3.6.4-0","docker.io/kindest/kindnetd:v20250512-df8de77b"]}
-]}
-JSON
-;;
-images) cat "$FAKE_HOST_IMAGES" ;;
-esac`)
+	installFakeTool(t, dir, "docker", `[ "$1" = images ] || { echo "unexpected docker $*" >&2; exit 2; }
+cat "$FAKE_HOST_IMAGES"`)
+	// What the pods run, spelled as their manifests spell it; the node's
+	// own images (kindnet, etcd) are baked into the node image.
+	stubLabKube(t, &kubeClients{clientset: kubefake.NewClientset(
+		podOf("backstage", "backstage-dev:multi-backend-022f5b7e"),
+		podOf("kagent-pg", "postgres:18.3-alpine"),
+		podOf("harness", refGolangADK),
+		podOf("muster", refMusterDev),
+		podOf("kindnet", "docker.io/kindest/kindnetd:v20250512-df8de77b", "registry.k8s.io/etcd:3.6.4-0"),
+	)})
 	writeHost := func(rows string) {
 		if err := os.WriteFile(hostImages, []byte(rows), 0o600); err != nil {
 			t.Fatal(err)
@@ -172,7 +173,7 @@ esac`)
 	}
 	check := func(phase string, wantPull, wantLocal []string) {
 		t.Helper()
-		snapshotPreloadImages(config.Default())
+		snapshotPreloadImages()
 		if got := readPreloadManifest(); !slices.Equal(got, wantPull) {
 			t.Errorf("%s: pull set\n got  %v\n want %v", phase, got, wantPull)
 		}
@@ -227,10 +228,10 @@ func withSavePlatform(t *testing.T, has bool) {
 
 // The two side-loads without `docker save --platform`. Podman: its multi-image
 // save is single-image, so the batch would land one image under every tag —
-// one plain archive per image. Docker older than 28: no `--platform`, so one
-// plain archive of the whole batch (right under the classic graph driver such
-// an engine runs). Either way the archive goes into the node through the
-// embedded kind's import, never through a kind on PATH.
+// one plain save per image. Docker older than 28: no `--platform`, so one
+// plain save of the whole batch (right under the classic graph driver such an
+// engine runs). Either way the stream goes into the node through the embedded
+// kind's import — never through a kind on PATH, never through a file.
 func TestKindLoadImagesArchivesWithoutSavePlatform(t *testing.T) {
 	images := []string{refPostgres, refGolangADK, refMusterDev}
 	for name, tc := range map[string]struct {
@@ -238,19 +239,18 @@ func TestKindLoadImagesArchivesWithoutSavePlatform(t *testing.T) {
 		wantSaves []string
 	}{
 		"docker without save --platform batches": {false, []string{
-			"docker save -o <tar> " + refPostgres + " " + refGolangADK + " " + refMusterDev,
+			"docker save " + refPostgres + " " + refGolangADK + " " + refMusterDev,
 		}},
 		"podman saves one at a time": {true, []string{
-			"docker save -o <tar> " + refPostgres,
-			"docker save -o <tar> " + refGolangADK,
-			"docker save -o <tar> " + refMusterDev,
+			"docker save " + refPostgres,
+			"docker save " + refGolangADK,
+			"docker save " + refMusterDev,
 		}},
 	} {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
-			t.Setenv("TMPDIR", dir)
-			dockerCalls := installFakeTool(t, dir, "docker", `[ "$1 $2" = "save -o" ] || { echo "unexpected docker $*" >&2; exit 2; }
-: > "$3"`)
+			dockerCalls := installFakeTool(t, dir, "docker", `[ "$1" = save ] || { echo "unexpected docker $*" >&2; exit 2; }
+echo "$*"`)
 			kindCalls := stubKindLoadArchive(t, dir)
 			withPodman(t, tc.podman)
 			withSavePlatform(t, false)
@@ -264,67 +264,72 @@ func TestKindLoadImagesArchivesWithoutSavePlatform(t *testing.T) {
 			if got := callLines(t, dockerCalls); !slices.Equal(got, tc.wantSaves) {
 				t.Errorf("saves\n got  %v\n want %v", got, tc.wantSaves)
 			}
-			wantKind := slices.Repeat([]string{kindLoadArchiveCall}, len(tc.wantSaves))
-			if got := callLines(t, kindCalls); !slices.Equal(got, wantKind) {
-				t.Errorf("kind loads\n got  %v\n want %v", got, wantKind)
-			}
-			if left := leftoverArchives(t, dir); len(left) > 0 {
-				t.Errorf("temporary archives left behind: %v", left)
+			if got, want := callLines(t, kindCalls), kindLoads(tc.wantSaves...); !slices.Equal(got, want) {
+				t.Errorf("kind loads\n got  %v\n want %v", got, want)
 			}
 		})
 	}
 }
 
-// tarPathRe matches the temporary archive's path in a stand-in's call log.
-var tarPathRe = regexp.MustCompile(`\S+\.tar`)
-
-// kindLoadArchiveCall is the one kind import a side-loaded archive makes, as
-// the stand-in logs it with the archive path normalised.
-const kindLoadArchiveCall = "kindLoadArchive agentlab <tar>"
-
 // stubKindLoadArchive stands in for the embedded kind's archive import
-// (kindLoadArchive): it logs each call to a file under dir — returned, for
-// callLines — and insists the archive exists when it runs.
+// (kindLoadArchive): it drains the stream and logs each call — the cluster
+// and what came down the stream — to a file under dir, returned for
+// callLines. The stand-in docker echoes its argv as the archive, so the log
+// proves which save fed which import; an import fed nothing (its save
+// failed) logs the bare call.
 func stubKindLoadArchive(t *testing.T, dir string) string {
 	t.Helper()
 	calls := filepath.Join(dir, "kind-calls")
 	prev := kindLoadArchive
-	kindLoadArchive = func(clusterName, archive string) error {
+	kindLoadArchive = func(clusterName string, archive io.Reader) error {
+		got, err := io.ReadAll(archive)
+		if err != nil {
+			return err
+		}
 		f, err := os.OpenFile(calls, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 -- the call log under t.TempDir
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, _ = fmt.Fprintf(f, "kindLoadArchive %s %s\n", clusterName, archive)
+		_, _ = fmt.Fprintln(f, strings.TrimSpace("kindLoadArchive "+clusterName+" "+string(got)))
 		_ = f.Close()
-		if _, err := os.Stat(archive); err != nil {
-			return fmt.Errorf("archive %s is not there: %w", archive, err)
-		}
 		return nil
 	}
 	t.Cleanup(func() { kindLoadArchive = prev })
 	return calls
 }
 
-// callLines splits a stand-in's log into lines with the archive path
-// normalised to <tar>, so the argv can be compared exactly.
+// kindLoads is the import log the stand-ins write for the given saves: one
+// import per save, fed that save's argv ("docker save ..." as the docker
+// stand-in logs it, "save ..." as it echoes it into the stream).
+func kindLoads(saves ...string) []string {
+	var lines []string
+	for _, save := range saves {
+		lines = append(lines, "kindLoadArchive agentlab "+strings.TrimPrefix(save, "docker "))
+	}
+	return lines
+}
+
+// kindLoadFedNothing is the import log of a save that failed before it wrote
+// a byte: the import still ran, on an empty stream.
+const kindLoadFedNothing = "kindLoadArchive agentlab"
+
+// callLines splits a stand-in's log into lines, so the argv can be compared
+// exactly.
 func callLines(t *testing.T, path string) []string {
 	t.Helper()
 	raw := strings.TrimSpace(readCalls(t, path))
 	if raw == "" {
 		return nil
 	}
-	return strings.Split(tarPathRe.ReplaceAllString(raw, "<tar>"), "\n")
+	return strings.Split(raw, "\n")
 }
 
 // installSideloadFakes puts a docker on PATH and a stand-in behind kind's
 // archive import for the docker side-load: docker answers `image inspect`
-// with a platform per ref (muster amd64, everything else arm64) and creates
-// the archive `save` is asked for; the import insists the archive exists when
-// it runs. The archives land in dir (TMPDIR), where the test can see them
-// gone again.
+// with a platform per ref (muster amd64, everything else arm64) and runs
+// saveBody for `save --platform`; the import drains and logs what it is fed.
 func installSideloadFakes(t *testing.T, dir, saveBody string) (dockerCalls, kindCalls string) {
 	t.Helper()
-	t.Setenv("TMPDIR", dir)
 	dockerCalls = installFakeTool(t, dir, "docker", `case "$1 $2" in
 "image inspect") case "$5" in
   *muster*) echo linux/amd64 ;;
@@ -340,24 +345,14 @@ esac`)
 	return dockerCalls, kindCalls
 }
 
-// leftoverArchives lists the temporary archives still in dir.
-func leftoverArchives(t *testing.T, dir string) []string {
-	t.Helper()
-	left, err := filepath.Glob(filepath.Join(dir, "agentlab-images-*.tar"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	return left
-}
-
-// Under docker the side-load is `docker save --platform` + kind's archive
-// import, one archive per platform the host holds the images in, never a
-// plain `docker save`: that breaks under the containerd image store
-// (kind#3795). Every ref is inspected for its platform, the archives are
-// written where docker was told to and are gone afterwards.
+// Under docker the side-load is `docker save --platform` streamed into kind's
+// archive import, one stream per platform the host holds the images in,
+// never a plain `docker save`: that breaks under the containerd image store
+// (kind#3795). Every ref is inspected for its platform, and each import is
+// fed exactly its platform's save.
 func TestDockerLoadImagesSavesOneArchivePerPlatform(t *testing.T) {
 	dir := t.TempDir()
-	dockerCalls, kindCalls := installSideloadFakes(t, dir, `: > "$5"`)
+	dockerCalls, kindCalls := installSideloadFakes(t, dir, `echo "$*"`)
 	images := []string{refPostgres, refGolangADK, refMusterDev}
 	loaded, err := kindLoadImages(config.Default(), images)
 	if err != nil {
@@ -385,29 +380,25 @@ func TestDockerLoadImagesSavesOneArchivePerPlatform(t *testing.T) {
 		t.Errorf("inspects\n got  %v\n want %v", inspects, wantInspects)
 	}
 	wantSaves := []string{
-		"docker save --platform linux/amd64 -o <tar> " + refMusterDev,
-		"docker save --platform linux/arm64/v8 -o <tar> " + refPostgres + " " + refGolangADK,
+		"docker save --platform linux/amd64 " + refMusterDev,
+		"docker save --platform linux/arm64/v8 " + refPostgres + " " + refGolangADK,
 	}
 	if !slices.Equal(saves, wantSaves) {
 		t.Errorf("saves\n got  %v\n want %v", saves, wantSaves)
 	}
-	wantKind := []string{kindLoadArchiveCall, kindLoadArchiveCall}
-	if got := callLines(t, kindCalls); !slices.Equal(got, wantKind) {
-		t.Errorf("kind calls\n got  %v\n want %v", got, wantKind)
-	}
-	if left := leftoverArchives(t, dir); len(left) > 0 {
-		t.Errorf("temporary archives left behind: %v", left)
+	if got, want := callLines(t, kindCalls), kindLoads(wantSaves...); !slices.Equal(got, want) {
+		t.Errorf("kind loads\n got  %v\n want %v", got, want)
 	}
 }
 
 // A platform group whose save fails, and a ref the host cannot inspect, must
-// not stop the other groups: the count says how many landed, the error names
-// what did not, and no archive is left behind either way.
+// not stop the other groups: the count says how many landed, and the error
+// names what did not in docker's words — not the cut stream's import error.
 func TestDockerLoadImagesPartialFailure(t *testing.T) {
 	dir := t.TempDir()
 	dockerCalls, kindCalls := installSideloadFakes(t, dir, `case "$3" in
   linux/amd64) echo "Error response from daemon: no suitable export target found" >&2; exit 1 ;;
-  *) : > "$5" ;;
+  *) echo "$*" ;;
   esac`)
 	loaded, err := kindLoadImages(config.Default(), []string{refPostgres, refSocat, refGolangADK, refMusterDev})
 	if err == nil {
@@ -428,17 +419,15 @@ func TestDockerLoadImagesPartialFailure(t *testing.T) {
 		}
 	}
 	wantSaves := []string{
-		"docker save --platform linux/amd64 -o <tar> " + refMusterDev,
-		"docker save --platform linux/arm64/v8 -o <tar> " + refPostgres + " " + refGolangADK,
+		"docker save --platform linux/amd64 " + refMusterDev,
+		"docker save --platform linux/arm64/v8 " + refPostgres + " " + refGolangADK,
 	}
 	if !slices.Equal(saves, wantSaves) {
 		t.Errorf("saves\n got  %v\n want %v", saves, wantSaves)
 	}
-	if got, want := callLines(t, kindCalls), []string{kindLoadArchiveCall}; !slices.Equal(got, want) {
-		t.Errorf("kind calls\n got  %v\n want %v (only the group whose save succeeded)", got, want)
-	}
-	if left := leftoverArchives(t, dir); len(left) > 0 {
-		t.Errorf("temporary archives left behind: %v", left)
+	want := []string{kindLoadFedNothing, kindLoads(wantSaves[1])[0]}
+	if got := callLines(t, kindCalls); !slices.Equal(got, want) {
+		t.Errorf("kind loads\n got  %v\n want %v (the arm64 group's import fed its save, the amd64 group's nothing)", got, want)
 	}
 }
 
@@ -463,14 +452,13 @@ func TestSaveHasPlatform(t *testing.T) {
 }
 
 // Under podman a failed image must not stop the rest, the count must say how
-// many landed so the caller can report a partial load as one, the error must
-// carry docker's words, and no archive may be left behind.
+// many landed so the caller can report a partial load as one, and the error
+// must carry docker's words.
 func TestKindLoadImagesPartialFailureUnderPodman(t *testing.T) {
 	dir := t.TempDir()
-	t.Setenv("TMPDIR", dir)
-	installFakeTool(t, dir, "docker", `case "$4" in
-`+refGolangADK+`) echo "Error response from daemon: No such image: $4" >&2; exit 1 ;;
-*) : > "$3" ;;
+	installFakeTool(t, dir, "docker", `case "$2" in
+`+refGolangADK+`) echo "Error response from daemon: No such image: $2" >&2; exit 1 ;;
+*) echo "$*" ;;
 esac`)
 	kindCalls := stubKindLoadArchive(t, dir)
 	withPodman(t, true)
@@ -484,10 +472,45 @@ esac`)
 	if loaded != 2 {
 		t.Errorf("loaded = %d, want 2 (the failure must not stop the rest)", loaded)
 	}
-	if got, want := callLines(t, kindCalls), []string{kindLoadArchiveCall, kindLoadArchiveCall}; !slices.Equal(got, want) {
-		t.Errorf("kind loads\n got  %v\n want %v (only the images whose save succeeded)", got, want)
+	want := []string{
+		"kindLoadArchive agentlab save " + refPostgres,
+		kindLoadFedNothing,
+		"kindLoadArchive agentlab save " + refMusterDev,
 	}
-	if left := leftoverArchives(t, dir); len(left) > 0 {
-		t.Errorf("temporary archives left behind: %v", left)
+	if got := callLines(t, kindCalls); !slices.Equal(got, want) {
+		t.Errorf("kind loads\n got  %v\n want %v", got, want)
+	}
+}
+
+// podOf is a pod running the given images as its containers, in a namespace
+// of its own so a listing that finds it is provably cluster-wide.
+func podOf(name string, images ...string) *corev1.Pod {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: name}}
+	for i, img := range images {
+		pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: fmt.Sprintf("c%d", i), Image: img})
+	}
+	return pod
+}
+
+// podImages reads what the pods reference — init and ephemeral containers
+// included, across namespaces, each ref once — spelled as the node spells it;
+// a digest-pinned or bare ref is left to the kubelet.
+func TestPodImages(t *testing.T) {
+	app := podOf("app", "alpine/k8s:1.37.0", "busybox")
+	app.Spec.InitContainers = []corev1.Container{{Name: "init", Image: "postgres:18.3-alpine"}}
+	app.Spec.EphemeralContainers = []corev1.EphemeralContainer{{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debug", Image: refSocat},
+	}}
+	stubLabKube(t, &kubeClients{clientset: kubefake.NewClientset(app,
+		podOf("pinned", "gsoci.azurecr.io/giantswarm/rustfs@sha256:0123abcd", refMusterDev),
+		podOf("again", refMusterDev),
+	)})
+	got, err := podImages()
+	if err != nil {
+		t.Fatalf("podImages: %v", err)
+	}
+	want := []string{"docker.io/alpine/k8s:1.37.0", refSocat, refPostgres, refMusterDev}
+	if !slices.Equal(got, want) {
+		t.Errorf("pod images\n got  %v\n want %v", got, want)
 	}
 }

--- a/internal/lab/up.go
+++ b/internal/lab/up.go
@@ -69,10 +69,6 @@ func Up(cfg *config.Config, offers Offers) error {
 		return err
 	}
 
-	// Side-load the cached images while Dex and the OIDC verification run;
-	// joined before the platform install, which is what actually needs them.
-	loaded := loadLabImages(cfg, pulled)
-
 	step("Deploying Dex")
 	// Namespace and TLS secret land before the Deployment so the pod never
 	// waits on a missing volume on first boot.
@@ -86,6 +82,13 @@ func Up(cfg *config.Config, offers Offers) error {
 		return err
 	}
 	sideloadDexImage(cfg, dexReady)
+	// The bulk side-load starts only now, with the Dex image in the node: it
+	// runs while Dex rolls out and the OIDC chain is verified, and is joined
+	// before the platform install, which is what actually needs it. Started
+	// any earlier it is what the Dex image queues behind — an import of
+	// everything the last boot ran, minutes long — with the boot log stuck on
+	// "Deploying Dex" meanwhile.
+	loaded := loadLabImages(cfg, pulled)
 	if err := ApplyDex(cfg); err != nil {
 		return err
 	}
@@ -164,11 +167,11 @@ func Up(cfg *config.Config, offers Offers) error {
 		// SIGINT that ends the process (platformUp snapshots first for the
 		// same reason). No portal without the platform (config.Validate), so
 		// this path can only offer the trust step.
-		snapshotPreloadImages(cfg)
+		snapshotPreloadImages()
 		offerTrustAndOpen(cfg, offers, false)
 		return nil
 	}
-	snapshotPreloadImages(cfg)
+	snapshotPreloadImages()
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`agentlab up` sat silent on `==> Deploying Dex` for five minutes and was aborted; the host had a 20 GiB `/tmp/agentlab-images-*.tar` left behind on tmpfs and its swap full.

Two things had grown under the bulk side-load:

- **The snapshot manifest recorded the node's whole image store**, not what pods run. A lab's lifetime of dev-image swaps, reloads and chart bumps left 130 images / 21.5 GiB in `state/preload-images.txt` (20 muster tags, 13 backstage, 11 mcp-kubernetes, …), each pulled, saved and imported on every boot.
- **The archive was staged in `os.TempDir()`** — `/tmp`, a tmpfs on many Linux hosts, i.e. RAM for the length of the import; on Ctrl-C the `defer os.Remove` never ran, so the file stayed. The Dex image's own side-load queued behind that import, hence the silent boot log.

## Change

- `saveAndLoadArchive` streams `docker save` straight into the node's `ctr images import` (`kindLoadArchive` takes an `io.Reader`; a multi-node cluster gets the stream fanned out). Nothing is staged; docker's stderr stays the error the caller sees when a save fails.
- `snapshotPreloadImages` lists the pods' images (init and ephemeral containers included, spelled as the node spells them via `fullImageRef`, digest-pinned refs left to the kubelet as before) instead of `crictl images`.
- The bulk lane starts after the Dex image is in the node, so the boot log keeps moving while it runs.
- HACKS.md U16/U21 wording; tests follow (the kind stand-in now drains the stream and logs what fed it — an import fed by a failed save logs the bare call).

## Verification (this host, 24 cores, Docker 29.8 / overlay2)

- Fresh boot with the **old** 130-image manifest and this binary: Dex ready at 0:35, OIDC chain verified at 0:41, `preloaded 123 cached images into the node (7m57s)`, `Lab is up.` at 15:59. `/tmp` moved by at most 91 MB over the whole boot (sampled every 10 s); the node's disk took the 21 GiB directly.
- `agentlab platform-test`: 9/9 PASS (both JWT halves on the kagent route included).
- `agentlab backstage-test admin@lab.local`: sign-in, muster, skills, validate_agent dry run pass; the deploy step stopped at `secret kagent-anthropic not found` because the boot ran without `$ANTHROPIC_API_KEY` in the environment — unrelated to this change.
- The snapshot the new code wrote after that boot: **31 images / 4.0 GiB** (was 130 / 21.5 GiB).
- Second boot from that manifest: see the follow-up comment.
